### PR TITLE
run: add server-side candidate validation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,18 +2,23 @@
 
 This document is authoritative for the current clean-slate Kernel. It describes
 the local, non-durable product only. Docker, recovery, remote execution, and
-formal evaluation are not design inputs for this version.
+post-Run hidden assessment are not design inputs for this version.
 
 ## Domain language
 
 - A `Program` is one immutable, content-addressed Policy source snapshot.
 - An `Evaluation` runs one Program through a bounded set of Episodes.
 - A `Submission` commits one Program and its public Feedback.
+- A finished candidate set is an ordered, bounded tuple of published
+  Submissions handed from the Agent to the Host in one atomic request.
+- `Validation` is a Host-only, post-Agent Evaluation of every finished
+  candidate on identical Episodes. It selects the final Submission without
+  publishing evidence back to the Agent workspace.
 - `Feedback` has a Kernel-required scalar score, Benchmark-defined public
   content, and optional public Artifact files.
 - A `ProgramEvolutionRun` is one bounded outer loop in which a Coding Agent
-  edits Programs, submits candidates, reads Feedback, and selects a final
-  Submission.
+  edits Programs, submits candidates, reads Feedback, and hands candidates to
+  Host-side final selection.
 - A `RunEvent` is immutable, Host-side observation delivered only after its
   matching lifecycle event is persisted.
 - An `Experiment` is reserved for a future collection of comparable Runs.
@@ -42,10 +47,11 @@ evopolicygym/
 │   └── _service.py             Episode rules and narrow runtime contracts
 │
 ├── run/                        complete Program-Evolution use case
-│   ├── __init__.py             RunConfig and run()
+│   ├── __init__.py             RunConfig, ValidationConfig, and run()
 │   ├── progress.py             public Run events, observer, and console reporter
 │   ├── _service.py             Run coordination and process-setting assembly
-│   ├── _session.py             Submission budget and final-selection rules
+│   ├── _session.py             Submission budget and atomic finish admission
+│   ├── _validation.py          post-Agent candidate evaluation and selection
 │   ├── _directory.py           workspace, events, invocation, and run.json
 │   ├── _feedback.py            Feedback and Artifact publication
 │   ├── _json.py                retained public-value JSON projection
@@ -111,8 +117,12 @@ The rules are:
   runtime, process implementation, or protocol codec;
 - `evaluation/_service.py` declares the Policy-runtime capabilities it
   consumes and never selects an execution setting or Agent provider;
-- `run/_session.py` owns budgets, admission, publication ordering, and final
-  selection without depending on an execution setting or provider;
+- `run/_session.py` owns budgets, admission, publication ordering, and the
+  atomic transfer of an ordered candidate set without depending on an
+  execution setting or provider;
+- `run/_validation.py` owns deterministic final selection. It starts only
+  after the Agent runner has reaped the process tree and the Session gateway
+  has closed;
 - `run/` owns Run directories, Feedback publication, and Session transport;
   these responsibilities do not live under process execution;
 - `run/progress.py` owns non-authoritative observation and terminal
@@ -140,6 +150,42 @@ The rules are:
 Narrow `Protocol` contracts are colocated with the service that consumes them.
 There is no global `ports.py`, global adapter namespace, or global composition
 root.
+
+## Run phase and evidence boundaries
+
+```text
+Agent search
+  submit → public Feedback → edit → ... → finish(candidate IDs)
+                                             │
+                                             ▼
+                              close Session and reap Agent
+                                             │
+                                             ▼
+                                Host-only Validation
+                                             │
+                                             ▼
+                           final selection and Run commit
+```
+
+`finish` uses `agent-session/v2` and accepts a non-empty
+`submission_ids` list. The Host rejects malformed, duplicate, unknown, or
+over-limit candidates before changing Session state. A successful request
+closes Agent authority; it does not select a final Program inside the Session.
+Without Validation, exactly one candidate is allowed.
+
+Validation uses a Run-seed-derived domain-separated seed and one identical
+`EvaluationConfig` for every candidate. Selection compares primary score in
+the Benchmark's declared direction, then Policy-failure count, then finish
+argument order. A trusted fault terminates the Run as `validation_failed`
+without a partial final selection or automatic retry.
+
+The Agent-visible `workspace/` contains only editable `program/`, public
+`feedback/`, and an optional Benchmark skill. `validation/` is not created
+until after Agent cleanup. A successful validated Run retains only aggregate
+candidate scores and Policy-failure counts in
+`validation/report.json`; private Episodes, seeds, cases, traces, and
+execution evidence do not cross into Feedback. `run.json` uses
+`evopolicygym/run-record/v2` and references that aggregate report.
 
 ## Migration status
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added atomic ordered candidate handoff through `agent-session/v2` and
+  optional post-Agent server-side Validation with aggregate retained results.
+- Added `ValidationConfig`, candidate and Validation fields on `RunResult`,
+  the `validation_failed` terminal reason, and run-record schema v2.
 - Added persisted Episode progress events, the public `RunObserver` contract,
   and a standard-library `ConsoleProgress` reporter.
 - Made the per-Submission Episode cap optional; it now defaults to `None` so

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ with `use_benchmark_skill=True`; the skill is never passed to the Policy:
 ```python
 from cartpole import CartPoleBenchmark, baseline_program
 
-from evopolicygym import RunConfig, run
+from evopolicygym import RunConfig, ValidationConfig, run
 from evopolicygym.agents import Codex
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import ConsoleProgress
@@ -138,23 +138,38 @@ result = run(
         episode_budget=48,
         max_episodes_per_submission=3,
         use_benchmark_skill=True,
+        validation=ValidationConfig(
+            split="validation",
+            episodes_per_candidate=10,
+            max_candidates=3,
+        ),
     ),
     observer=ConsoleProgress(),
 )
 ```
 
-During the Run, the agent evaluates and selects immutable submissions with:
+During the Run, the agent evaluates immutable submissions and hands candidates
+to the Host with:
 
 ```console
 evopolicygym submit program --episodes 3
-evopolicygym finish submission-000002
+evopolicygym finish submission-000002 submission-000007
 ```
 
+`finish` atomically hands an ordered candidate set to the Host and closes Agent
+authority. With `ValidationConfig`, the Host waits for the Agent process to be
+reaped, evaluates every candidate on the same private Validation Episodes, and
+selects by the Benchmark score direction, fewer Policy failures, then argument
+order. Validation has a separate Episode allocation and is never published
+back into workspace Feedback. Without `ValidationConfig`, `finish` accepts
+exactly one candidate and the Host selects it after Agent cleanup.
+
 The Host retains submitted Programs, public Feedback and Artifacts,
-`events.jsonl`, the final `run.json`, and separate Agent logs. Benchmark
-authors control the public Feedback content and may publish bounded traces,
-replays, diagnostics, images, or reports without exposing private seeds,
-paths, or execution evidence.
+`events.jsonl`, the final `run.json`, separate Agent logs, and—when
+configured—an aggregate `validation/report.json`. Benchmark authors control
+the public Feedback content and may publish bounded traces, replays,
+diagnostics, images, or reports without exposing private seeds, paths, or
+execution evidence.
 
 `ProcessExecution` is **not a sandbox**. The Agent and Policy processes run
 with the authority of the current operating-system user. Use it only with

--- a/scripts/run_balatro_codex.py
+++ b/scripts/run_balatro_codex.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from balatro import BalatroBenchmark, baseline_program
 
-from evopolicygym import RunConfig, run
+from evopolicygym import RunConfig, ValidationConfig, run
 from evopolicygym.agents import Codex
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import ConsoleProgress
@@ -46,6 +46,17 @@ def main(arguments: list[str] | None = None) -> int:
                 namespace.max_episodes_per_submission
             ),
             use_benchmark_skill=namespace.benchmark_skill,
+            validation=(
+                None
+                if namespace.validation_episodes_per_candidate is None
+                else ValidationConfig(
+                    split=namespace.validation_split,
+                    episodes_per_candidate=(
+                        namespace.validation_episodes_per_candidate
+                    ),
+                    max_candidates=namespace.validation_max_candidates,
+                )
+            ),
             seed=namespace.seed,
             episode_timeout_seconds=namespace.episode_timeout_seconds,
             agent_timeout_seconds=namespace.agent_timeout_seconds,
@@ -61,6 +72,28 @@ def main(arguments: list[str] | None = None) -> int:
             {
                 "terminal_reason": result.terminal_reason,
                 "final_submission_id": result.final_submission_id,
+                "candidate_submission_ids": list(
+                    result.candidate_submission_ids
+                ),
+                "validation": (
+                    None
+                    if result.validation is None
+                    else {
+                        "selected_submission_id": (
+                            result.validation.selected_submission_id
+                        ),
+                        "candidates": [
+                            {
+                                "submission_id": candidate.submission_id,
+                                "score": candidate.score,
+                                "policy_failures": (
+                                    candidate.policy_failures
+                                ),
+                            }
+                            for candidate in result.validation.candidates
+                        ],
+                    }
+                ),
                 "record": str(record_to),
                 "submissions": [
                     {
@@ -94,6 +127,21 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-submissions", type=int, default=16)
     parser.add_argument("--episode-budget", type=int, default=48)
     parser.add_argument("--max-episodes-per-submission", type=int)
+    parser.add_argument(
+        "--validation-episodes-per-candidate",
+        type=int,
+        help="enable post-Agent server-side Validation",
+    )
+    parser.add_argument(
+        "--validation-split",
+        choices=("train", "validation", "test"),
+        default="validation",
+    )
+    parser.add_argument(
+        "--validation-max-candidates",
+        type=int,
+        default=3,
+    )
     parser.add_argument(
         "--benchmark-skill",
         action="store_true",

--- a/scripts/run_cartpole_codex.py
+++ b/scripts/run_cartpole_codex.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from cartpole import CartPoleBenchmark, baseline_program
 
-from evopolicygym import RunConfig, run
+from evopolicygym import RunConfig, ValidationConfig, run
 from evopolicygym.agents import Codex
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import ConsoleProgress
@@ -45,6 +45,17 @@ def main(arguments: list[str] | None = None) -> int:
             max_episodes_per_submission=(
                 namespace.max_episodes_per_submission
             ),
+            validation=(
+                None
+                if namespace.validation_episodes_per_candidate is None
+                else ValidationConfig(
+                    split=namespace.validation_split,
+                    episodes_per_candidate=(
+                        namespace.validation_episodes_per_candidate
+                    ),
+                    max_candidates=namespace.validation_max_candidates,
+                )
+            ),
             seed=namespace.seed,
             episode_timeout_seconds=namespace.episode_timeout_seconds,
             agent_timeout_seconds=namespace.agent_timeout_seconds,
@@ -60,6 +71,28 @@ def main(arguments: list[str] | None = None) -> int:
             {
                 "terminal_reason": result.terminal_reason,
                 "final_submission_id": result.final_submission_id,
+                "candidate_submission_ids": list(
+                    result.candidate_submission_ids
+                ),
+                "validation": (
+                    None
+                    if result.validation is None
+                    else {
+                        "selected_submission_id": (
+                            result.validation.selected_submission_id
+                        ),
+                        "candidates": [
+                            {
+                                "submission_id": candidate.submission_id,
+                                "score": candidate.score,
+                                "policy_failures": (
+                                    candidate.policy_failures
+                                ),
+                            }
+                            for candidate in result.validation.candidates
+                        ],
+                    }
+                ),
                 "record": str(record_to),
                 "submissions": [
                     {
@@ -93,6 +126,21 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-submissions", type=int, default=2)
     parser.add_argument("--episode-budget", type=int, default=6)
     parser.add_argument("--max-episodes-per-submission", type=int)
+    parser.add_argument(
+        "--validation-episodes-per-candidate",
+        type=int,
+        help="enable post-Agent server-side Validation",
+    )
+    parser.add_argument(
+        "--validation-split",
+        choices=("train", "validation", "test"),
+        default="validation",
+    )
+    parser.add_argument(
+        "--validation-max-candidates",
+        type=int,
+        default=2,
+    )
     parser.add_argument("--episode-timeout-seconds", type=float, default=20)
     parser.add_argument("--agent-timeout-seconds", type=float, default=600)
     parser.add_argument(

--- a/skills/use-evopolicygym/SKILL.md
+++ b/skills/use-evopolicygym/SKILL.md
@@ -8,7 +8,8 @@ description: Set up, run, extend, and diagnose EvoPolicyGym policy-evolution wor
 Use the public EvoPolicyGym SDK to build a complete bounded loop:
 
 ```text
-Program → Evaluation → Feedback → Coding Agent edit → Submission → selection
+Program → Evaluation → Feedback → Agent edit → Submission → candidate handoff
+→ Host selection
 ```
 
 Preserve the separation between the trusted Host and Benchmark, the Coding
@@ -85,8 +86,15 @@ authority.
   it does not replace the Host task or expose data to the Policy.
 - Add `ConsoleProgress()` when interactive progress is useful.
 - Require the Agent to publish candidates through
-  `evopolicygym submit program --episodes N` and finish by selecting a
-  published submission with `evopolicygym finish SUBMISSION_ID`.
+  `evopolicygym submit program --episodes N` and finish by handing the Host
+  one or more published IDs with
+  `evopolicygym finish SUBMISSION_ID [SUBMISSION_ID ...]`.
+- Use `ValidationConfig` when the Host should compare multiple candidates.
+  Give every candidate the same split, derived seed, Episode count, and Policy
+  seeds. Its Episode allocation is separate from the Agent search budget.
+- Treat successful `finish` as an authority boundary. Validation and final
+  selection occur only after the Agent process is reaped; do not expose their
+  evidence in workspace Feedback.
 - Treat failed trusted evaluation attempts as consumed budget. Never rewrite
   accounting after a failure.
 
@@ -118,5 +126,6 @@ commands in that package. Test deterministic Episode planning, cleanup,
 Policy-failure classification, Feedback privacy, and Artifact bounds.
 
 Report the selected Benchmark, Program digest or source, split, seed, Episode
-budget, terminal reason, final submission, validation commands, and the
-remaining lack of process isolation.
+budget, ordered candidate IDs, Validation configuration and aggregate result,
+terminal reason, final submission, verification commands, and the remaining
+lack of process isolation.

--- a/skills/use-evopolicygym/references/api.md
+++ b/skills/use-evopolicygym/references/api.md
@@ -40,7 +40,7 @@ construction failure; it is not a Policy penalty.
 ```python
 from example_benchmark import ExampleBenchmark, baseline_program
 
-from evopolicygym import RunConfig, run
+from evopolicygym import RunConfig, ValidationConfig, run
 from evopolicygym.agents import Codex
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import ConsoleProgress
@@ -57,6 +57,11 @@ result = run(
         episode_budget=48,
         max_episodes_per_submission=4,
         use_benchmark_skill=True,
+        validation=ValidationConfig(
+            split="validation",
+            episodes_per_candidate=10,
+            max_candidates=3,
+        ),
         seed=0,
         episode_timeout_seconds=30,
         agent_timeout_seconds=3600,
@@ -65,13 +70,28 @@ result = run(
 )
 
 print(result.terminal_reason)
+print(result.candidate_submission_ids)
 print(result.final_submission_id)
+print(result.validation)
 ```
 
 Use a unique `record_to`. Its parent must already exist and the Run directory
 must not. Omit `max_episodes_per_submission` only when the selected Benchmark's
 Feedback remains bounded for any allowed batch size and Agent-controlled
 allocation is intentional.
+
+During search, the Agent uses:
+
+```console
+evopolicygym submit program --episodes 4
+evopolicygym finish submission-000003 submission-000011
+```
+
+`finish` atomically accepts an ordered candidate list. With
+`ValidationConfig`, the Host closes Agent authority, reaps the Agent, evaluates
+all candidates on identical private Validation Episodes, and selects by score
+direction, fewer Policy failures, then argument order. Without it, exactly one
+candidate is accepted. Validation is not returned through workspace Feedback.
 
 ## Other command-line Coding Agents
 

--- a/skills/use-evopolicygym/references/authoring.md
+++ b/skills/use-evopolicygym/references/authoring.md
@@ -65,6 +65,12 @@ count while keeping aggregate scoring based on every record.
 If supplying `BenchmarkSpec.agent_skill`, keep it task-specific, bounded, and
 free of private state. It is projected read-only only when a Run opts in.
 
+The same `episodes()`, `make_environment()`, and `feedback()` methods may be
+used for server-side candidate Validation. Keep splits genuinely disjoint when
+the Benchmark promises disjoint data. The Kernel retains only aggregate score
+and Policy-failure counts from Validation; Benchmark-defined content and
+Artifacts are not published to the Agent workspace.
+
 ## Test before distribution
 
 Use `BenchmarkFixture` and `check_benchmark()` to replay deterministic Action

--- a/skills/use-evopolicygym/references/diagnostics.md
+++ b/skills/use-evopolicygym/references/diagnostics.md
@@ -19,6 +19,8 @@ run-root/
 │       ├── program/
 │       ├── feedback.json
 │       └── artifacts/
+├── validation/                 only after successful configured Validation
+│   └── report.json             aggregate candidate evidence
 └── agent/
     ├── invocation.json
     ├── instructions.md
@@ -33,7 +35,8 @@ only after its Program and public Feedback commit successfully.
 ## Diagnose in order
 
 1. Read `run.json`: benchmark ID, config, terminal reason, final submission,
-   published submissions, and Agent exit.
+   ordered candidates, published submissions, optional Validation report, and
+   Agent exit.
 2. Read the final events in `events.jsonl`: determine whether failure occurred
    before an Episode, during an Episode, after all Episodes, or during
    publication.
@@ -46,13 +49,16 @@ only after its Program and public Feedback commit successfully.
 
 ## Interpret common outcomes
 
-- `finished`: the Agent selected a published submission.
+- `finished`: the Agent handed off candidates and the Host selected a final
+  published submission.
 - `budget_exhausted`: no Episode authority remains without a successful
   selection.
 - `agent_exited`: the Agent process exited before a terminal selection.
 - `agent_failed`: the Agent could not start, timed out, or violated its process
   contract.
 - `evaluation_failed`: trusted evaluation could not produce a valid result.
+- `validation_failed`: post-Agent candidate Validation failed; no partial
+  final selection or report is authoritative.
 
 An Episode status of `policy_failed` is a scored Policy outcome, not a trusted
 evaluation failure. Its failure code is one of `exception`, `timeout`,

--- a/src/evopolicygym/__init__.py
+++ b/src/evopolicygym/__init__.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .evaluation import EvaluationConfig, evaluate
     from .program import Program
     from .results import EvaluationResult, RunResult
-    from .run import RunConfig, run
+    from .run import RunConfig, ValidationConfig, run
 
 _EXPORTS = {
     "Benchmark": (".benchmark", "Benchmark"),
@@ -21,6 +21,7 @@ _EXPORTS = {
     "Program": (".program", "Program"),
     "RunConfig": (".run", "RunConfig"),
     "RunResult": (".results", "RunResult"),
+    "ValidationConfig": (".run", "ValidationConfig"),
     "evaluate": (".evaluation", "evaluate"),
     "run": (".run", "run"),
 }
@@ -32,6 +33,7 @@ __all__ = [
     "Program",
     "RunConfig",
     "RunResult",
+    "ValidationConfig",
     "__version__",
     "evaluate",
     "run",

--- a/src/evopolicygym/_protocol/session.py
+++ b/src/evopolicygym/_protocol/session.py
@@ -2,7 +2,7 @@
 
 from ._framing import JsonFrameCodec
 
-SESSION_PROTOCOL = "agent-session/v1"
+SESSION_PROTOCOL = "agent-session/v2"
 SESSION_MAX_FRAME_BYTES = 64 * 1024
 
 SESSION_FRAMES = JsonFrameCodec(

--- a/src/evopolicygym/cli.py
+++ b/src/evopolicygym/cli.py
@@ -79,9 +79,9 @@ def _parser() -> argparse.ArgumentParser:
 
     finish = subcommands.add_parser(
         "finish",
-        help="select one previously published submission",
+        help="finish search with one or more published candidates",
     )
-    finish.add_argument("submission_id")
+    finish.add_argument("submission_ids", nargs="+")
     return parser
 
 
@@ -101,7 +101,7 @@ def _request(namespace: argparse.Namespace) -> dict[str, object]:
         return {
             "protocol": SESSION_PROTOCOL,
             "method": "finish",
-            "submission_id": cast(str, namespace.submission_id),
+            "submission_ids": cast(list[str], namespace.submission_ids),
         }
     raise RuntimeError("unknown command")
 

--- a/src/evopolicygym/results.py
+++ b/src/evopolicygym/results.py
@@ -28,6 +28,7 @@ type RunTerminalReason = Literal[
     "budget_exhausted",
     "agent_failed",
     "evaluation_failed",
+    "validation_failed",
 ]
 
 
@@ -156,6 +157,82 @@ class SubmissionResult:
 
 
 @dataclass(frozen=True, slots=True)
+class ValidationCandidateResult:
+    """One aggregate server-side Validation outcome."""
+
+    submission_id: str
+    program_digest: str
+    score: float
+    episodes: int
+    policy_failures: int
+
+    def __post_init__(self) -> None:
+        _non_empty_text(self.submission_id, "submission_id")
+        _digest(self.program_digest, "program_digest")
+        if (
+            isinstance(self.score, bool)
+            or not isinstance(self.score, (int, float))
+            or not math.isfinite(float(self.score))
+        ):
+            raise ValueError("score must be a finite number")
+        if type(self.episodes) is not int or self.episodes <= 0:
+            raise ValueError("episodes must be a positive integer")
+        if (
+            type(self.policy_failures) is not int
+            or not 0 <= self.policy_failures <= self.episodes
+        ):
+            raise ValueError(
+                "policy_failures must be between zero and episodes"
+            )
+        object.__setattr__(self, "score", float(self.score))
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationResult:
+    """Aggregate server-side evidence and deterministic final selection."""
+
+    split: str
+    episodes_per_candidate: int
+    primary_metric: str
+    score_direction: Literal["maximize", "minimize"]
+    candidates: tuple[ValidationCandidateResult, ...]
+    selected_submission_id: str
+
+    def __post_init__(self) -> None:
+        _non_empty_text(self.split, "split")
+        _non_empty_text(self.primary_metric, "primary_metric")
+        if (
+            type(self.episodes_per_candidate) is not int
+            or self.episodes_per_candidate <= 0
+        ):
+            raise ValueError(
+                "episodes_per_candidate must be a positive integer"
+            )
+        if self.score_direction not in {"maximize", "minimize"}:
+            raise ValueError(
+                "score_direction must be 'maximize' or 'minimize'"
+            )
+        candidates = tuple(self.candidates)
+        if not candidates or any(
+            type(candidate) is not ValidationCandidateResult
+            for candidate in candidates
+        ):
+            raise TypeError(
+                "candidates must contain ValidationCandidateResult values"
+            )
+        identifiers = tuple(
+            candidate.submission_id for candidate in candidates
+        )
+        if len(identifiers) != len(set(identifiers)):
+            raise ValueError("validation candidate IDs must be unique")
+        if self.selected_submission_id not in identifiers:
+            raise ValueError(
+                "selected_submission_id must select a validation candidate"
+            )
+        object.__setattr__(self, "candidates", candidates)
+
+
+@dataclass(frozen=True, slots=True)
 class RunResult:
     """The detached public outcome of one Coding Agent development run."""
 
@@ -163,6 +240,8 @@ class RunResult:
     final_submission_id: str | None
     submissions: tuple[SubmissionResult, ...]
     terminal_reason: RunTerminalReason
+    candidate_submission_ids: tuple[str, ...] = ()
+    validation: ValidationResult | None = None
 
     def __post_init__(self) -> None:
         if self.final_program is not None and type(self.final_program) is not Program:
@@ -190,15 +269,67 @@ class RunResult:
                 raise ValueError(
                     "final Program must match the selected submission"
                 )
+        candidates = tuple(self.candidate_submission_ids)
+        if any(type(item) is not str or not item for item in candidates):
+            raise ValueError(
+                "candidate_submission_ids must contain non-empty text"
+            )
+        if len(candidates) != len(set(candidates)):
+            raise ValueError("candidate submission IDs must be unique")
+        if any(item not in submission_ids for item in candidates):
+            raise ValueError(
+                "candidate submission IDs must select submissions"
+            )
+        if (
+            self.final_submission_id is not None
+            and self.final_submission_id not in candidates
+        ):
+            raise ValueError("final submission must be a finished candidate")
+        if self.validation is not None:
+            if type(self.validation) is not ValidationResult:
+                raise TypeError("validation must be ValidationResult or None")
+            validation_ids = tuple(
+                item.submission_id for item in self.validation.candidates
+            )
+            if validation_ids != candidates:
+                raise ValueError(
+                    "validation candidates must match finished candidates"
+                )
+            if self.final_submission_id != self.validation.selected_submission_id:
+                raise ValueError(
+                    "final submission must match validation selection"
+                )
+        if self.terminal_reason == "finished":
+            if self.final_submission_id is None or not candidates:
+                raise ValueError(
+                    "a finished Run requires a final candidate"
+                )
+        elif self.final_submission_id is not None:
+            raise ValueError(
+                "only a finished Run can contain a final Program"
+            )
+        if self.validation is not None and self.terminal_reason != "finished":
+            raise ValueError(
+                "only a finished Run can contain Validation results"
+            )
+        if (
+            candidates
+            and self.terminal_reason not in {"finished", "validation_failed"}
+        ):
+            raise ValueError(
+                "only finished or failed Validation can contain candidates"
+            )
         if self.terminal_reason not in {
             "finished",
             "agent_exited",
             "budget_exhausted",
             "agent_failed",
             "evaluation_failed",
+            "validation_failed",
         }:
             raise ValueError("terminal_reason is invalid")
         object.__setattr__(self, "submissions", submissions)
+        object.__setattr__(self, "candidate_submission_ids", candidates)
 
 
 def _non_empty_text(value: object, name: str) -> str:
@@ -231,4 +362,6 @@ __all__ = [
     "RunResult",
     "RunTerminalReason",
     "SubmissionResult",
+    "ValidationCandidateResult",
+    "ValidationResult",
 ]

--- a/src/evopolicygym/run/__init__.py
+++ b/src/evopolicygym/run/__init__.py
@@ -16,6 +16,23 @@ from .progress import ConsoleProgress, RunEvent, RunObserver
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
+class ValidationConfig:
+    """Fixed server-side evidence used to select finished candidates."""
+
+    episodes_per_candidate: int
+    split: str = "validation"
+    max_candidates: int = 3
+
+    def __post_init__(self) -> None:
+        if type(self.split) is not str or not self.split:
+            raise ValueError("validation split must be non-empty text")
+        for name in ("episodes_per_candidate", "max_candidates"):
+            value = getattr(self, name)
+            if type(value) is not int or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
 class RunConfig:
     """Finite authority granted to one Program Evolution Run."""
 
@@ -24,6 +41,7 @@ class RunConfig:
     episode_budget: int = 1_000
     max_episodes_per_submission: int | None = None
     use_benchmark_skill: bool = False
+    validation: ValidationConfig | None = None
     seed: int = 0
     episode_timeout_seconds: float = 30.0
     agent_timeout_seconds: float = 3_600.0
@@ -50,6 +68,13 @@ class RunConfig:
                 )
         if type(self.use_benchmark_skill) is not bool:
             raise TypeError("use_benchmark_skill must be bool")
+        if self.validation is not None:
+            if type(self.validation) is not ValidationConfig:
+                raise TypeError("validation must be ValidationConfig or None")
+            if self.validation.max_candidates > self.max_submissions:
+                raise ValueError(
+                    "validation max_candidates cannot exceed max_submissions"
+                )
         if type(self.seed) is not int or not 0 <= self.seed <= 2**64 - 1:
             raise ValueError("seed must be an unsigned 64-bit integer")
         for name in ("episode_timeout_seconds", "agent_timeout_seconds"):
@@ -116,5 +141,6 @@ __all__ = [
     "RunEvent",
     "RunObserver",
     "RunResult",
+    "ValidationConfig",
     "run",
 ]

--- a/src/evopolicygym/run/_directory.py
+++ b/src/evopolicygym/run/_directory.py
@@ -21,9 +21,10 @@ from ..results import RunResult
 from . import RunConfig
 from .progress import RunEvent, RunEventValue, RunObserver
 
-_RUN_RECORD_SCHEMA = "evopolicygym/run-record/v1"
+_RUN_RECORD_SCHEMA = "evopolicygym/run-record/v2"
 _RUN_EVENT_SCHEMA = "evopolicygym/run-event/v1"
 _INVOCATION_SCHEMA = "evopolicygym/agent-invocation/v1"
+_VALIDATION_REPORT_SCHEMA = "evopolicygym/validation-report/v1"
 _SESSION_SOCKET_VARIABLE = "EVOPOLICYGYM_SESSION_SOCKET"
 _WORKSPACE_VARIABLE = "EVOPOLICYGYM_WORKSPACE"
 
@@ -38,6 +39,7 @@ class RunDirectoryPaths:
     initial: Path
     submissions: Path
     agent: Path
+    validation: Path
     control: Path
     socket: Path
     events: Path
@@ -55,6 +57,7 @@ class RunDirectoryPaths:
             initial=root / "initial",
             submissions=root / "submissions",
             agent=root / "agent",
+            validation=root / "validation",
             control=control,
             socket=control / "session.sock",
             events=root / "events.jsonl",
@@ -129,6 +132,11 @@ class RunDirectoryRecorder:
                     self._observer = None
 
     def commit(self, result: RunResult, agent_exit: AgentExit) -> None:
+        if result.validation is not None:
+            _write_validation_report(
+                self._paths.validation,
+                result,
+            )
         _write_run_manifest(
             self._paths.root / "run.json",
             result,
@@ -321,6 +329,19 @@ def _write_run_manifest(
                 "use_benchmark_skill": config.use_benchmark_skill,
                 "episode_timeout_seconds": config.episode_timeout_seconds,
                 "agent_timeout_seconds": config.agent_timeout_seconds,
+                "validation": (
+                    None
+                    if config.validation is None
+                    else {
+                        "split": config.validation.split,
+                        "episodes_per_candidate": (
+                            config.validation.episodes_per_candidate
+                        ),
+                        "max_candidates": (
+                            config.validation.max_candidates
+                        ),
+                    }
+                ),
             },
             "agent": {
                 **agent_identity,
@@ -336,12 +357,71 @@ def _write_run_manifest(
             },
             "terminal_reason": result.terminal_reason,
             "final_submission_id": result.final_submission_id,
+            "candidate_submission_ids": list(
+                result.candidate_submission_ids
+            ),
+            "validation": (
+                None
+                if result.validation is None
+                else {"report": "validation/report.json"}
+            ),
             "submissions": submissions,
         },
     )
 
 
-def _write_json_atomic(path: Path, document: dict[str, object]) -> None:
+def _write_validation_report(
+    directory: Path,
+    result: RunResult,
+) -> None:
+    validation = result.validation
+    assert validation is not None
+    try:
+        directory.mkdir(mode=0o700)
+    except OSError as error:
+        raise AgentRunError(
+            "Validation record could not be committed"
+        ) from error
+    _write_json_atomic(
+        directory / "report.json",
+        {
+            "schema": _VALIDATION_REPORT_SCHEMA,
+            "split": validation.split,
+            "episodes_per_candidate": (
+                validation.episodes_per_candidate
+            ),
+            "primary_metric": validation.primary_metric,
+            "score_direction": validation.score_direction,
+            "candidates": [
+                {
+                    "submission_id": candidate.submission_id,
+                    "program_digest": candidate.program_digest,
+                    "score": candidate.score,
+                    "episodes": candidate.episodes,
+                    "policy_failures": candidate.policy_failures,
+                }
+                for candidate in validation.candidates
+            ],
+            "selected_submission_id": (
+                validation.selected_submission_id
+            ),
+        },
+        error_message="Validation record could not be committed",
+    )
+    try:
+        os.chmod(directory, 0o500)
+    except OSError as error:
+        raise AgentRunError(
+            "Validation record could not be committed"
+        ) from error
+
+
+def _write_json_atomic(
+    path: Path,
+    document: dict[str, object],
+    *,
+    error_message: str = "Run record could not be committed",
+) -> None:
     payload = (
         json.dumps(
             document,
@@ -361,7 +441,7 @@ def _write_json_atomic(path: Path, document: dict[str, object]) -> None:
         os.chmod(temporary, 0o400)
         os.replace(temporary, path)
     except OSError as error:
-        raise AgentRunError("Run record could not be committed") from error
+        raise AgentRunError(error_message) from error
     finally:
         temporary.unlink(missing_ok=True)
 

--- a/src/evopolicygym/run/_service.py
+++ b/src/evopolicygym/run/_service.py
@@ -9,11 +9,16 @@ from typing import Protocol
 
 from ..agents import AgentInvocation, CodingAgent
 from ..benchmark import Benchmark, BenchmarkSpec
-from ..errors import AgentRunError
+from ..errors import AgentRunError, EvaluationError
 from ..execution.process.agent.runner import AgentExit
 from ..program import Program
-from ..results import RunResult, RunTerminalReason, SubmissionResult
+from ..results import (
+    RunResult,
+    RunTerminalReason,
+    SubmissionResult,
+)
 from . import RunConfig
+from ._validation import CandidateSelection
 from .progress import RunObserver
 
 
@@ -50,11 +55,7 @@ class EvolutionSession(Protocol):
         ...
 
     @property
-    def final_submission_id(self) -> str | None:
-        ...
-
-    @property
-    def final_program(self) -> Program | None:
+    def candidate_submission_ids(self) -> tuple[str, ...]:
         ...
 
     @property
@@ -63,6 +64,15 @@ class EvolutionSession(Protocol):
 
     @property
     def authority_exhausted(self) -> bool:
+        ...
+
+
+class CandidateSelectionService(Protocol):
+    def select(
+        self,
+        submissions: tuple[SubmissionResult, ...],
+        candidate_submission_ids: tuple[str, ...],
+    ) -> CandidateSelection:
         ...
 
 
@@ -89,6 +99,7 @@ class ProgramEvolutionRun:
         session: EvolutionSession,
         gateway: SessionGateway,
         agent_runner: AgentRunner,
+        candidate_selector: CandidateSelectionService,
         recorder: RunRecorder,
         agent_timeout_seconds: float,
     ) -> None:
@@ -103,6 +114,7 @@ class ProgramEvolutionRun:
         self._session = session
         self._gateway = gateway
         self._agent_runner = agent_runner
+        self._candidate_selector = candidate_selector
         self._recorder = recorder
         self._agent_timeout_seconds = agent_timeout_seconds
 
@@ -128,11 +140,56 @@ class ProgramEvolutionRun:
             self._gateway.close()
 
         assert agent_exit is not None
+        candidate_ids = self._session.candidate_submission_ids
+        selection: CandidateSelection | None = None
+        terminal_reason = _terminal_reason(self._session, agent_exit)
+        if candidate_ids and self._session.terminal_reason is None:
+            try:
+                selection = self._candidate_selector.select(
+                    self._session.submissions,
+                    candidate_ids,
+                )
+            except EvaluationError:
+                terminal_reason = "validation_failed"
+                self._recorder.record_event(
+                    "validation_failed",
+                    {"candidate_count": len(candidate_ids)},
+                )
+            else:
+                terminal_reason = "finished"
+                self._recorder.record_event(
+                    "final_submission_selected",
+                    {
+                        "submission_id": selection.submission.submission_id,
+                        "program_digest": (
+                            selection.submission.program_digest
+                        ),
+                    },
+                )
+                self._recorder.record_event(
+                    "run_finished",
+                    {
+                        "submission_id": selection.submission.submission_id,
+                        "program_digest": (
+                            selection.submission.program_digest
+                        ),
+                    },
+                )
         result = RunResult(
-            final_program=self._session.final_program,
-            final_submission_id=self._session.final_submission_id,
+            final_program=(
+                None if selection is None else selection.submission.program
+            ),
+            final_submission_id=(
+                None
+                if selection is None
+                else selection.submission.submission_id
+            ),
             submissions=self._session.submissions,
-            terminal_reason=_terminal_reason(self._session, agent_exit),
+            terminal_reason=terminal_reason,
+            candidate_submission_ids=candidate_ids,
+            validation=(
+                None if selection is None else selection.validation
+            ),
         )
         self._recorder.commit(result, agent_exit)
         return result
@@ -241,6 +298,7 @@ def run_process_agent(
     from ._feedback import FilesystemSubmissionPublisher
     from ._session import SubmissionSession
     from ._socket import UnixSessionGateway
+    from ._validation import CandidateSelector
 
     if type(initial_program) is not Program:
         raise TypeError("initial_program must be Program")
@@ -276,12 +334,13 @@ def run_process_agent(
             agent_identity=invocation.identity,
             observer=observer,
         ) as recorder:
+            evaluator = EvaluationService(
+                policy_runtimes=ProcessPolicyRuntimeFactory(),
+                monotonic=monotonic,
+            )
             session = SubmissionSession(
                 programs=WorkspaceProgramSource(paths.program),
-                evaluator=EvaluationService(
-                    policy_runtimes=ProcessPolicyRuntimeFactory(),
-                    monotonic=monotonic,
-                ),
+                evaluator=evaluator,
                 publisher=FilesystemSubmissionPublisher(
                     submissions_root=paths.submissions,
                     feedback_root=paths.feedback,
@@ -308,6 +367,13 @@ def run_process_agent(
                 session=session,
                 gateway=gateway,
                 agent_runner=runner,
+                candidate_selector=CandidateSelector(
+                    evaluator=evaluator,
+                    benchmark=benchmark,
+                    spec=selected_spec,
+                    config=config,
+                    recorder=recorder,
+                ),
                 recorder=recorder,
                 agent_timeout_seconds=config.agent_timeout_seconds,
             )

--- a/src/evopolicygym/run/_session.py
+++ b/src/evopolicygym/run/_session.py
@@ -1,4 +1,4 @@
-"""Submission accounting, receipts, and final-selection rules."""
+"""Submission accounting, receipts, and atomic candidate handoff."""
 
 from __future__ import annotations
 
@@ -49,10 +49,9 @@ class SubmissionReceipt:
 
 @dataclass(frozen=True, slots=True)
 class FinishReceipt:
-    """Agent-visible receipt selecting the final Program."""
+    """Agent-visible receipt transferring candidate selection to the Host."""
 
-    submission_id: str
-    program_digest: str
+    candidate_submission_ids: tuple[str, ...]
 
 
 type SubmissionOutcome = SubmissionReceipt | SessionError
@@ -113,7 +112,7 @@ class SubmissionSession:
         self._recorder = recorder
         self._episodes_remaining = config.episode_budget
         self._submissions: list[SubmissionResult] = []
-        self._final_submission_id: str | None = None
+        self._candidate_submission_ids: tuple[str, ...] | None = None
         self._terminal_reason: RunTerminalReason | None = None
 
     @property
@@ -121,23 +120,19 @@ class SubmissionSession:
         return tuple(self._submissions)
 
     @property
-    def final_submission_id(self) -> str | None:
-        return self._final_submission_id
-
-    @property
-    def final_program(self) -> Program | None:
-        identifier = self._final_submission_id
-        if identifier is None:
-            return None
-        return next(
-            item.program
-            for item in self._submissions
-            if item.submission_id == identifier
-        )
+    def candidate_submission_ids(self) -> tuple[str, ...]:
+        return self._candidate_submission_ids or ()
 
     @property
     def terminal_reason(self) -> RunTerminalReason | None:
         return self._terminal_reason
+
+    @property
+    def agent_authority_closed(self) -> bool:
+        return (
+            self._candidate_submission_ids is not None
+            or self._terminal_reason is not None
+        )
 
     @property
     def authority_exhausted(self) -> bool:
@@ -147,7 +142,7 @@ class SubmissionSession:
         )
 
     def submit(self, episodes: object) -> SubmissionOutcome:
-        if self._terminal_reason is not None:
+        if self.agent_authority_closed:
             return _error("session_closed", "the Agent Session is already closed")
         if type(episodes) is not int or episodes <= 0:
             return _error("invalid_request", "episodes must be a positive integer")
@@ -269,40 +264,77 @@ class SubmissionSession:
             episodes_remaining=self._episodes_remaining,
         )
 
-    def finish(self, submission_id: object) -> FinishOutcome:
-        if self._terminal_reason is not None:
+    def finish(self, submission_ids: object) -> FinishOutcome:
+        if self.agent_authority_closed:
             return _error("session_closed", "the Agent Session is already closed")
-        selected = tuple(
-            item
-            for item in self._submissions
-            if item.submission_id == submission_id
-        )
-        if type(submission_id) is not str or len(selected) != 1:
-            return _error(
-                "unknown_submission",
-                "finish must select a published submission",
+
+        if type(submission_ids) is not list or not submission_ids:
+            return self._reject_finish(
+                "invalid_request",
+                "finish requires a non-empty submission_ids list",
             )
-        assert isinstance(submission_id, str)
-        self._final_submission_id = submission_id
-        self._terminal_reason = "finished"
-        program = selected[0].program
+        if any(
+            type(submission_id) is not str or not submission_id
+            for submission_id in submission_ids
+        ):
+            return self._reject_finish(
+                "invalid_request",
+                "submission_ids must contain non-empty text",
+                candidate_count=len(submission_ids),
+            )
+
+        identifiers = tuple(submission_ids)
+        candidate_limit = (
+            1
+            if self._config.validation is None
+            else self._config.validation.max_candidates
+        )
+        if len(identifiers) > candidate_limit:
+            return self._reject_finish(
+                "candidate_limit",
+                "finish exceeds the candidate limit",
+                candidate_count=len(identifiers),
+            )
+        if len(identifiers) != len(set(identifiers)):
+            return self._reject_finish(
+                "duplicate_submission",
+                "finish candidates must be unique",
+                candidate_count=len(identifiers),
+            )
+
+        published = {item.submission_id for item in self._submissions}
+        if any(identifier not in published for identifier in identifiers):
+            return self._reject_finish(
+                "unknown_submission",
+                "finish candidates must be published submissions",
+                candidate_count=len(identifiers),
+            )
+
         self._recorder.record_event(
-            "run_finished",
-            {
-                "submission_id": submission_id,
-                "program_digest": program.digest,
-            },
+            "finish_requested",
+            {"candidate_count": len(identifiers)},
         )
-        return FinishReceipt(
-            submission_id=submission_id,
-            program_digest=program.digest,
-        )
+        self._candidate_submission_ids = identifiers
+        return FinishReceipt(candidate_submission_ids=identifiers)
 
     def fail(self) -> None:
         """Close admission after an unexpected Host-side gateway fault."""
 
-        if self._terminal_reason is None:
+        if not self.agent_authority_closed:
             self._terminal_reason = "evaluation_failed"
+
+    def _reject_finish(
+        self,
+        code: str,
+        message: str,
+        *,
+        candidate_count: int | None = None,
+    ) -> SessionError:
+        fields: dict[str, object] = {"reason": code}
+        if candidate_count is not None:
+            fields["candidate_count"] = candidate_count
+        self._recorder.record_event("finish_rejected", fields)
+        return _error(code, message)
 
 
 def _submission_seed(run_seed: int, ordinal: int) -> int:

--- a/src/evopolicygym/run/_socket.py
+++ b/src/evopolicygym/run/_socket.py
@@ -104,7 +104,7 @@ class UnixSessionGateway:
                     send_session_message(connection, response)
                 except (OSError, ValueError):
                     pass
-            if self._session.terminal_reason is not None:
+            if self._session.agent_authority_closed:
                 self.terminal.set()
 
 
@@ -112,7 +112,7 @@ def _handle_request(
     session: SubmissionSession,
     request: dict[str, object],
 ) -> dict[str, object]:
-    if session.terminal_reason is not None:
+    if session.agent_authority_closed:
         return _error("session_closed", "the Agent Session is already closed")
     if request.get("protocol") != SESSION_PROTOCOL:
         return _error("protocol_mismatch", "unsupported Agent Session protocol")
@@ -140,9 +140,9 @@ def _handle_request(
             },
         }
     if method == "finish":
-        if set(request) != {"protocol", "method", "submission_id"}:
+        if set(request) != {"protocol", "method", "submission_ids"}:
             return _error("invalid_request", "finish request fields are invalid")
-        finish_outcome = session.finish(request["submission_id"])
+        finish_outcome = session.finish(request["submission_ids"])
         if isinstance(finish_outcome, SessionError):
             return _error(finish_outcome.code, finish_outcome.message)
         assert isinstance(finish_outcome, FinishReceipt)
@@ -150,8 +150,10 @@ def _handle_request(
             "protocol": SESSION_PROTOCOL,
             "ok": True,
             "result": {
-                "submission_id": finish_outcome.submission_id,
-                "program_digest": finish_outcome.program_digest,
+                "candidate_submission_ids": list(
+                    finish_outcome.candidate_submission_ids
+                ),
+                "agent_authority_closed": True,
             },
         }
     return _error("invalid_request", "unknown Session method")

--- a/src/evopolicygym/run/_task.py
+++ b/src/evopolicygym/run/_task.py
@@ -28,6 +28,32 @@ def build_agent_task(spec: BenchmarkSpec, config: RunConfig) -> AgentTask:
             f"The whole Run has {config.episode_budget} Episode units and at most "
             f"{config.max_submissions} submissions."
         )
+    validation = config.validation
+    if validation is None:
+        finish_guidance = """\
+When you have selected the best published submission, end the Run with:
+
+    evopolicygym finish SUBMISSION_ID
+
+finish accepts exactly one published submission. A successful finish closes
+your authority; the Host selects that sole candidate only after your process
+has exited.
+"""
+    else:
+        finish_guidance = f"""\
+When you are ready to end search, pass an ordered set of one to
+{validation.max_candidates} published candidates:
+
+    evopolicygym finish SUBMISSION_ID [SUBMISSION_ID ...]
+
+A successful finish closes your authority. Only after your process has exited,
+the Host evaluates every candidate on identical private Validation Episodes and
+selects the final Program by {spec.primary_metric} ({spec.score_direction}),
+then fewer Policy failures, then your argument order. Validation results are
+not returned to this Agent Session. Exceeding the candidate limit, repeating a
+candidate, or naming an unpublished submission rejects the whole finish
+request, so you may correct it and retry.
+"""
     public_spec = {
         "id": spec.id,
         "description": spec.description,
@@ -88,13 +114,11 @@ their structure, names, media types, and contents to understand the available
 development evidence.
 
 Iterate by inspecting the Program, editing it, submitting it, and using the
-published Feedback. When you have selected the best published submission, end
-the Run with:
+published Feedback.
 
-    evopolicygym finish SUBMISSION_ID
-
-finish accepts only a published submission. Unsubmitted workspace edits are
-never the final Program. Do not exit before calling finish successfully.
+{finish_guidance}
+Unsubmitted workspace edits are never candidates or the final Program. Do not
+exit before calling finish successfully.
 
 Benchmark public specification:
 

--- a/src/evopolicygym/run/_validation.py
+++ b/src/evopolicygym/run/_validation.py
@@ -1,0 +1,248 @@
+"""Host-side candidate validation after Coding Agent authority has closed."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Protocol
+
+from ..benchmark import Benchmark, BenchmarkSpec
+from ..errors import EvaluationError
+from ..evaluation import EvaluationConfig
+from ..program import Program
+from ..results import (
+    EpisodeSummary,
+    EvaluationResult,
+    SubmissionResult,
+    ValidationCandidateResult,
+    ValidationResult,
+)
+from . import RunConfig
+
+_VALIDATION_SEED_DOMAIN = b"evopolicygym/validation-seed/v1\0"
+
+
+class ProgramEvaluator(Protocol):
+    def evaluate(
+        self,
+        program: Program,
+        benchmark: Benchmark,
+        config: EvaluationConfig,
+        *,
+        episode_completed: (
+            Callable[[int, int, EpisodeSummary], None] | None
+        ) = None,
+    ) -> EvaluationResult:
+        ...
+
+
+class EventRecorder(Protocol):
+    def record_event(
+        self,
+        event: str,
+        fields: Mapping[str, object],
+    ) -> None:
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateSelection:
+    """Internal detached selection returned to the Run coordinator."""
+
+    submission: SubmissionResult
+    validation: ValidationResult | None
+
+
+class CandidateSelector:
+    """Evaluate an ordered candidate set and select it deterministically."""
+
+    def __init__(
+        self,
+        *,
+        evaluator: ProgramEvaluator,
+        benchmark: Benchmark,
+        spec: BenchmarkSpec,
+        config: RunConfig,
+        recorder: EventRecorder,
+    ) -> None:
+        self._evaluator = evaluator
+        self._benchmark = benchmark
+        self._spec = spec
+        self._config = config
+        self._recorder = recorder
+
+    def select(
+        self,
+        submissions: tuple[SubmissionResult, ...],
+        candidate_submission_ids: tuple[str, ...],
+    ) -> CandidateSelection:
+        candidates = _resolve_candidates(
+            submissions,
+            candidate_submission_ids,
+        )
+        validation_config = self._config.validation
+        if validation_config is None:
+            if len(candidates) != 1:
+                raise EvaluationError(
+                    "finish requires exactly one candidate without Validation"
+                )
+            return CandidateSelection(
+                submission=candidates[0],
+                validation=None,
+            )
+
+        evaluation_config = EvaluationConfig(
+            split=validation_config.split,
+            episodes=validation_config.episodes_per_candidate,
+            seed=_validation_seed(self._config.seed),
+            episode_timeout_seconds=self._config.episode_timeout_seconds,
+        )
+        self._recorder.record_event(
+            "validation_started",
+            {
+                "split": validation_config.split,
+                "candidate_count": len(candidates),
+                "episodes_per_candidate": (
+                    validation_config.episodes_per_candidate
+                ),
+                "primary_metric": self._spec.primary_metric,
+                "score_direction": self._spec.score_direction,
+            },
+        )
+
+        aggregate: list[ValidationCandidateResult] = []
+        for candidate in candidates:
+            identifier = candidate.submission_id
+            self._recorder.record_event(
+                "validation_candidate_started",
+                {
+                    "submission_id": identifier,
+                    "episodes": validation_config.episodes_per_candidate,
+                },
+            )
+
+            def episode_completed(
+                completed: int,
+                total: int,
+                summary: EpisodeSummary,
+                *,
+                submission_id: str = identifier,
+            ) -> None:
+                self._recorder.record_event(
+                    "validation_episode_completed",
+                    {
+                        "submission_id": submission_id,
+                        "completed": completed,
+                        "total": total,
+                        "status": summary.status,
+                    },
+                )
+
+            try:
+                evaluated = self._evaluator.evaluate(
+                    candidate.program,
+                    self._benchmark,
+                    evaluation_config,
+                    episode_completed=episode_completed,
+                )
+            except EvaluationError:
+                raise
+            except Exception:
+                raise EvaluationError(
+                    "trusted Validation evaluation failed"
+                ) from None
+            if (
+                type(evaluated) is not EvaluationResult
+                or evaluated.benchmark_id != self._spec.id
+                or evaluated.program_digest != candidate.program_digest
+                or len(evaluated.episodes)
+                != validation_config.episodes_per_candidate
+            ):
+                raise EvaluationError(
+                    "Validation evaluation returned an invalid result"
+                )
+
+            policy_failures = sum(
+                episode.status == "policy_failed"
+                for episode in evaluated.episodes
+            )
+            result = ValidationCandidateResult(
+                submission_id=identifier,
+                program_digest=candidate.program_digest,
+                score=evaluated.feedback.score,
+                episodes=len(evaluated.episodes),
+                policy_failures=policy_failures,
+            )
+            aggregate.append(result)
+            self._recorder.record_event(
+                "validation_candidate_completed",
+                {
+                    "submission_id": identifier,
+                    "score": result.score,
+                    "policy_failures": result.policy_failures,
+                },
+            )
+
+        selected_index = min(
+            range(len(aggregate)),
+            key=lambda index: _selection_key(
+                aggregate[index],
+                index=index,
+                score_direction=self._spec.score_direction,
+            ),
+        )
+        selected = candidates[selected_index]
+        validation = ValidationResult(
+            split=validation_config.split,
+            episodes_per_candidate=validation_config.episodes_per_candidate,
+            primary_metric=self._spec.primary_metric,
+            score_direction=self._spec.score_direction,
+            candidates=tuple(aggregate),
+            selected_submission_id=selected.submission_id,
+        )
+        return CandidateSelection(
+            submission=selected,
+            validation=validation,
+        )
+
+
+def _resolve_candidates(
+    submissions: tuple[SubmissionResult, ...],
+    identifiers: tuple[str, ...],
+) -> tuple[SubmissionResult, ...]:
+    if not identifiers:
+        raise EvaluationError("finish did not provide candidates")
+    by_identifier = {
+        submission.submission_id: submission for submission in submissions
+    }
+    try:
+        return tuple(by_identifier[identifier] for identifier in identifiers)
+    except KeyError:
+        raise EvaluationError(
+            "finish selected an unavailable submission"
+        ) from None
+
+
+def _selection_key(
+    candidate: ValidationCandidateResult,
+    *,
+    index: int,
+    score_direction: str,
+) -> tuple[float, int, int]:
+    score = (
+        -candidate.score
+        if score_direction == "maximize"
+        else candidate.score
+    )
+    return (score, candidate.policy_failures, index)
+
+
+def _validation_seed(run_seed: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_VALIDATION_SEED_DOMAIN)
+    digest.update(run_seed.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+__all__: list[str] = []

--- a/src/evopolicygym/run/progress.py
+++ b/src/evopolicygym/run/progress.py
@@ -141,6 +141,62 @@ class ConsoleProgress:
             label = event.name.replace("_", " ")
             return (f"{submission} · {label}", False)
 
+        if event.name == "finish_requested":
+            candidates = _integer(fields, "candidate_count")
+            return (
+                f"Agent finished · {candidates} candidate(s) handed to Host",
+                False,
+            )
+
+        if event.name == "validation_started":
+            candidates = _integer(fields, "candidate_count")
+            episodes = _integer(fields, "episodes_per_candidate")
+            return (
+                f"Validation started · {candidates} candidate(s)"
+                f" · {episodes} Episodes each",
+                False,
+            )
+
+        if event.name == "validation_candidate_started":
+            submission = _text(fields, "submission_id")
+            episodes = _integer(fields, "episodes")
+            self._evaluation_started[submission] = event.monotonic_ns
+            return (
+                f"{submission} · validating {episodes} Episodes",
+                True,
+            )
+
+        if event.name == "validation_episode_completed":
+            submission = _text(fields, "submission_id")
+            completed = _integer(fields, "completed")
+            total = _integer(fields, "total")
+            status = _text(fields, "status")
+            started = self._evaluation_started.get(submission)
+            elapsed = (
+                ""
+                if started is None
+                else f" · {(event.monotonic_ns - started) / 1_000_000_000:.1f}s"
+            )
+            return (
+                f"{submission} · Validation Episodes {completed}/{total}"
+                f"{elapsed} · {status}",
+                True,
+            )
+
+        if event.name == "validation_candidate_completed":
+            submission = _text(fields, "submission_id")
+            score = _number(fields, "score")
+            failures = _integer(fields, "policy_failures")
+            self._evaluation_started.pop(submission, None)
+            return (
+                f"{submission} · validation score {score:g}"
+                f" · {failures} Policy failure(s)",
+                False,
+            )
+
+        if event.name == "validation_failed":
+            return ("Validation failed", False)
+
         if event.name == "run_finished":
             submission = _text(fields, "submission_id")
             return (f"Run finished · selected {submission}", False)
@@ -152,7 +208,7 @@ class ConsoleProgress:
             return ("Agent failed to start", False)
 
         if event.name == "agent_stopped_after_terminal":
-            return ("Agent stopped after terminal Run state", False)
+            return ("Agent stopped after Session authority closed", False)
 
         if event.name == "agent_exited":
             return (

--- a/tests/test_codex_integration.py
+++ b/tests/test_codex_integration.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from evopolicygym.agents import Codex, CodingAgent, resolve_executable
 from evopolicygym.authoring import BenchmarkSpec
-from evopolicygym.run import RunConfig
+from evopolicygym.run import RunConfig, ValidationConfig
 from evopolicygym.run._task import build_agent_task
 
 
@@ -100,6 +100,39 @@ class CodexIntegrationTests(unittest.TestCase):
 
         self.assertNotIn("skill/SKILL.md", without_skill.instructions)
         self.assertIn("skill/SKILL.md", with_skill.instructions)
+
+    def test_validation_handoff_rules_are_owned_by_the_host_task(self) -> None:
+        spec = BenchmarkSpec(
+            id="example/validation-task-v1",
+            description="Validation task fixture.",
+            observation_space=None,
+            action_space=None,
+            metadata={},
+            max_episode_steps=1,
+            primary_metric="loss",
+            score_direction="minimize",
+        )
+
+        task = build_agent_task(
+            spec,
+            RunConfig(
+                validation=ValidationConfig(
+                    episodes_per_candidate=5,
+                    max_candidates=3,
+                ),
+            ),
+        )
+
+        self.assertIn(
+            "evopolicygym finish SUBMISSION_ID [SUBMISSION_ID ...]",
+            task.instructions,
+        )
+        self.assertIn(
+            "Host evaluates every candidate on identical private Validation",
+            task.instructions,
+        )
+        self.assertIn("loss (minimize)", task.instructions)
+        self.assertIn("argument order", task.instructions)
 
 
 if __name__ == "__main__":

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -90,10 +90,17 @@ import sys
 from evopolicygym.agents.codex import Codex
 from evopolicygym.evaluation import EvaluationConfig
 from evopolicygym.execution import ProcessExecution
-from evopolicygym.run import ConsoleProgress, RunConfig, RunEvent, RunObserver
+from evopolicygym.run import (
+    ConsoleProgress,
+    RunConfig,
+    RunEvent,
+    RunObserver,
+    ValidationConfig,
+)
 
 assert EvaluationConfig.__module__ == "evopolicygym.evaluation"
 assert RunConfig.__module__ == "evopolicygym.run"
+assert ValidationConfig.__module__ == "evopolicygym.run"
 assert ConsoleProgress.__module__ == "evopolicygym.run.progress"
 assert RunEvent.__module__ == "evopolicygym.run.progress"
 assert RunObserver.__module__ == "evopolicygym.run.progress"
@@ -163,6 +170,20 @@ assert not any(name in sys.modules for name in forbidden)
                     )
                 )
                 for name in imports(session)
+            )
+        )
+
+    def test_validation_rules_do_not_select_execution_or_provider(self) -> None:
+        validation = PACKAGE / "run" / "_validation.py"
+        self.assertFalse(
+            any(
+                name.startswith(
+                    (
+                        "evopolicygym.execution",
+                        "evopolicygym.agents",
+                    )
+                )
+                for name in imports(validation)
             )
         )
 

--- a/tests/test_program_evolution.py
+++ b/tests/test_program_evolution.py
@@ -5,13 +5,21 @@ import unittest
 from collections.abc import Mapping
 from pathlib import Path
 
+from evopolicygym.errors import EvaluationError
 from evopolicygym.execution.process.agent.runner import AgentExit
 from evopolicygym.program import Program
-from evopolicygym.results import RunResult, RunTerminalReason, SubmissionResult
+from evopolicygym.results import (
+    EpisodeSummary,
+    Feedback,
+    RunResult,
+    RunTerminalReason,
+    SubmissionResult,
+)
 from evopolicygym.run._service import (
     ProgramEvolutionRun,
     TerminalSignal,
 )
+from evopolicygym.run._validation import CandidateSelection
 
 
 class FakeTerminal:
@@ -55,12 +63,42 @@ class FakeSession:
         *,
         terminal_reason: RunTerminalReason | None = None,
         authority_exhausted: bool = False,
+        submissions: tuple[SubmissionResult, ...] = (),
+        candidate_submission_ids: tuple[str, ...] = (),
     ) -> None:
-        self.submissions: tuple[SubmissionResult, ...] = ()
-        self.final_submission_id: str | None = None
-        self.final_program: Program | None = None
+        self.submissions = submissions
+        self.candidate_submission_ids = candidate_submission_ids
         self.terminal_reason = terminal_reason
         self.authority_exhausted = authority_exhausted
+
+
+class FakeCandidateSelector:
+    def __init__(
+        self,
+        selection: CandidateSelection | None = None,
+        *,
+        gateway: FakeGateway | None = None,
+        fail: bool = False,
+    ) -> None:
+        self.selection = selection
+        self.gateway = gateway
+        self.fail = fail
+        self.calls = 0
+
+    def select(
+        self,
+        submissions: tuple[SubmissionResult, ...],
+        candidate_submission_ids: tuple[str, ...],
+    ) -> CandidateSelection:
+        del submissions, candidate_submission_ids
+        self.calls += 1
+        if self.gateway is not None:
+            assert self.gateway.closed
+        if self.fail:
+            raise EvaluationError("trusted fixture failure")
+        if self.selection is None:
+            raise AssertionError("candidate selection was not expected")
+        return self.selection
 
 
 class FakeRecorder:
@@ -104,6 +142,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
                 session=session,
                 gateway=gateway,
                 agent_runner=runner,
+                candidate_selector=FakeCandidateSelector(),
                 recorder=recorder,
                 agent_timeout_seconds=10,
             ).execute()
@@ -137,6 +176,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
                 session=session,
                 gateway=gateway,
                 agent_runner=runner,
+                candidate_selector=FakeCandidateSelector(),
                 recorder=recorder,
                 agent_timeout_seconds=10,
             ).execute()
@@ -169,6 +209,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
                         start_errno=2,
                     )
                 ),
+                candidate_selector=FakeCandidateSelector(),
                 recorder=recorder,
                 agent_timeout_seconds=10,
             ).execute()
@@ -181,6 +222,119 @@ class ProgramEvolutionRunTests(unittest.TestCase):
                 {"error_type": "FileNotFoundError", "errno": 2},
             ),
         )
+
+    def test_finished_candidates_are_selected_only_after_agent_cleanup(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            program = make_program(Path(temporary))
+            submission = SubmissionResult(
+                submission_id="submission-000001",
+                program=program,
+                episodes_used=1,
+                episodes_remaining=0,
+                feedback=Feedback(score=1.0),
+                episodes=(
+                    EpisodeSummary(
+                        status="completed",
+                        reward=1.0,
+                        steps=1,
+                    ),
+                ),
+            )
+            session = FakeSession(
+                submissions=(submission,),
+                candidate_submission_ids=(submission.submission_id,),
+            )
+            gateway = FakeGateway()
+            selector = FakeCandidateSelector(
+                CandidateSelection(
+                    submission=submission,
+                    validation=None,
+                ),
+                gateway=gateway,
+            )
+            recorder = FakeRecorder()
+
+            result = ProgramEvolutionRun(
+                benchmark_id="example/benchmark-v1",
+                initial_program=program,
+                session=session,
+                gateway=gateway,
+                agent_runner=FakeAgentRunner(
+                    AgentExit(
+                        returncode=-15,
+                        stopped_after_terminal=True,
+                    )
+                ),
+                candidate_selector=selector,
+                recorder=recorder,
+                agent_timeout_seconds=10,
+            ).execute()
+
+        self.assertEqual(result.terminal_reason, "finished")
+        self.assertEqual(result.final_submission_id, submission.submission_id)
+        self.assertEqual(
+            result.candidate_submission_ids,
+            (submission.submission_id,),
+        )
+        self.assertEqual(selector.calls, 1)
+        self.assertEqual(
+            [event for event, _ in recorder.events],
+            [
+                "agent_started",
+                "agent_stopped_after_terminal",
+                "final_submission_selected",
+                "run_finished",
+            ],
+        )
+
+    def test_validation_failure_is_terminal_without_a_final_selection(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            program = make_program(Path(temporary))
+            submission = SubmissionResult(
+                submission_id="submission-000001",
+                program=program,
+                episodes_used=1,
+                episodes_remaining=0,
+                feedback=Feedback(score=1.0),
+                episodes=(
+                    EpisodeSummary(
+                        status="completed",
+                        reward=1.0,
+                        steps=1,
+                    ),
+                ),
+            )
+            recorder = FakeRecorder()
+
+            result = ProgramEvolutionRun(
+                benchmark_id="example/benchmark-v1",
+                initial_program=program,
+                session=FakeSession(
+                    submissions=(submission,),
+                    candidate_submission_ids=(
+                        submission.submission_id,
+                    ),
+                ),
+                gateway=FakeGateway(),
+                agent_runner=FakeAgentRunner(AgentExit(returncode=0)),
+                candidate_selector=FakeCandidateSelector(fail=True),
+                recorder=recorder,
+                agent_timeout_seconds=10,
+            ).execute()
+
+        self.assertEqual(result.terminal_reason, "validation_failed")
+        self.assertIsNone(result.final_program)
+        self.assertIsNone(result.final_submission_id)
+        self.assertEqual(
+            result.candidate_submission_ids,
+            (submission.submission_id,),
+        )
+        self.assertIsNone(result.validation)
+        self.assertEqual(recorder.events[-1][0], "validation_failed")
 
 
 if __name__ == "__main__":

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -11,6 +11,7 @@ from evopolicygym._protocol.policy import (
 from evopolicygym._protocol.session import (
     SESSION_FRAMES,
     SESSION_MAX_FRAME_BYTES,
+    SESSION_PROTOCOL,
 )
 from evopolicygym.policy import PolicyValue, TensorValue
 
@@ -48,10 +49,13 @@ class PolicyProtocolTests(unittest.TestCase):
 
 class AgentSessionProtocolTests(unittest.TestCase):
     def test_session_frame_round_trip_and_boundaries(self) -> None:
-        message = {
-            "protocol": "agent-session/v1",
-            "method": "submit",
-            "episodes": 3,
+        message: dict[str, object] = {
+            "protocol": SESSION_PROTOCOL,
+            "method": "finish",
+            "submission_ids": [
+                "submission-000001",
+                "submission-000002",
+            ],
         }
         frame = SESSION_FRAMES.encode(message)
         self.assertEqual(SESSION_FRAMES.decode(frame), message)

--- a/tests/test_public_contract.py
+++ b/tests/test_public_contract.py
@@ -18,6 +18,7 @@ from evopolicygym import (
     Program,
     RunConfig,
     RunResult,
+    ValidationConfig,
     evaluate,
     run,
 )
@@ -161,6 +162,7 @@ class PublicContractTests(unittest.TestCase):
                 "Program",
                 "RunConfig",
                 "RunResult",
+                "ValidationConfig",
                 "__version__",
                 "evaluate",
                 "run",
@@ -171,6 +173,7 @@ class PublicContractTests(unittest.TestCase):
         self.assertFalse(hasattr(evopolicygym, "PolicyValue"))
         self.assertTrue(callable(evaluate))
         self.assertTrue(callable(run))
+        self.assertIs(ValidationConfig, evopolicygym.ValidationConfig)
 
     def test_policy_and_benchmark_are_structural(self) -> None:
         policy = ConstantPolicy()
@@ -320,9 +323,20 @@ class PublicContractTests(unittest.TestCase):
             episode_budget=20,
             max_episodes_per_submission=5,
             use_benchmark_skill=True,
+            validation=ValidationConfig(
+                episodes_per_candidate=7,
+                max_candidates=2,
+            ),
         )
         self.assertEqual(capped.max_episodes_per_submission, 5)
         self.assertTrue(capped.use_benchmark_skill)
+        self.assertEqual(
+            capped.validation,
+            ValidationConfig(
+                episodes_per_candidate=7,
+                max_candidates=2,
+            ),
+        )
         self.assertEqual(agent.model, "gpt-5")
         with self.assertRaises(ValueError):
             RunConfig(episode_budget=0)
@@ -333,6 +347,14 @@ class PublicContractTests(unittest.TestCase):
             )
         with self.assertRaises(TypeError):
             RunConfig(use_benchmark_skill=1)  # type: ignore[arg-type]
+        with self.assertRaises(ValueError):
+            RunConfig(
+                max_submissions=1,
+                validation=ValidationConfig(
+                    episodes_per_candidate=1,
+                    max_candidates=2,
+                ),
+            )
 
     def test_public_results_compose_without_private_episode_records(self) -> None:
         feedback = Feedback(score=1.0, content={"outcome": "passed"})
@@ -401,6 +423,7 @@ class ProgramTests(unittest.TestCase):
                 final_submission_id=submission.submission_id,
                 submissions=(submission,),
                 terminal_reason="finished",
+                candidate_submission_ids=(submission.submission_id,),
             )
             self.assertEqual(run.final_program, first)
 
@@ -878,7 +901,18 @@ assert artifact.read_text() == "completed=1\\n"
     {unsubmitted_source!r},
     encoding="utf-8",
 )
-call("finish", second["result"]["submission_id"])
+assert not (workspace.parent / "validation").exists()
+finished = call(
+    "finish",
+    first["result"]["submission_id"],
+    second["result"]["submission_id"],
+)
+assert finished["result"]["candidate_submission_ids"] == [
+    first["result"]["submission_id"],
+    second["result"]["submission_id"],
+]
+assert finished["result"]["agent_authority_closed"] is True
+assert not (workspace.parent / "validation").exists()
 print("fake-agent-finished")
 """
         with tempfile.TemporaryDirectory() as temporary:
@@ -899,6 +933,10 @@ print("fake-agent-finished")
                 config=RunConfig(
                     max_submissions=2,
                     episode_budget=2,
+                    validation=ValidationConfig(
+                        episodes_per_candidate=2,
+                        max_candidates=2,
+                    ),
                     agent_timeout_seconds=10,
                 ),
                 observer=observer,
@@ -910,6 +948,9 @@ print("fake-agent-finished")
                 for line in (run_directory / "events.jsonl").read_text().splitlines()
             )
             manifest = json.loads((run_directory / "run.json").read_text())
+            validation = json.loads(
+                (run_directory / "validation" / "report.json").read_text()
+            )
             retained_workspace = run_directory / "workspace"
             first_record = (
                 run_directory
@@ -949,6 +990,11 @@ print("fake-agent-finished")
 
         self.assertEqual(result.terminal_reason, "finished")
         self.assertEqual(result.final_submission_id, "submission-000002")
+        self.assertEqual(
+            result.candidate_submission_ids,
+            ("submission-000001", "submission-000002"),
+        )
+        self.assertIsNotNone(result.validation)
         self.assertEqual(len(result.submissions), 2)
         self.assertEqual(result.submissions[0].episodes[0].failure, "invalid_action")
         self.assertEqual(result.submissions[1].feedback.score, 1.0)
@@ -974,9 +1020,48 @@ print("fake-agent-finished")
             [event.name for event in observer.events],
             [event["event"] for event in events],
         )
-        self.assertEqual(manifest["schema"], "evopolicygym/run-record/v1")
+        self.assertEqual(manifest["schema"], "evopolicygym/run-record/v2")
         self.assertEqual(manifest["terminal_reason"], "finished")
         self.assertEqual(manifest["final_submission_id"], "submission-000002")
+        self.assertEqual(
+            manifest["candidate_submission_ids"],
+            ["submission-000001", "submission-000002"],
+        )
+        self.assertEqual(
+            manifest["validation"],
+            {"report": "validation/report.json"},
+        )
+        self.assertEqual(
+            validation,
+            {
+                "schema": "evopolicygym/validation-report/v1",
+                "split": "validation",
+                "episodes_per_candidate": 2,
+                "primary_metric": "completed",
+                "score_direction": "maximize",
+                "candidates": [
+                    {
+                        "submission_id": "submission-000001",
+                        "program_digest": (
+                            result.submissions[0].program_digest
+                        ),
+                        "score": 0.0,
+                        "episodes": 2,
+                        "policy_failures": 2,
+                    },
+                    {
+                        "submission_id": "submission-000002",
+                        "program_digest": (
+                            result.submissions[1].program_digest
+                        ),
+                        "score": 2.0,
+                        "episodes": 2,
+                        "policy_failures": 0,
+                    },
+                ],
+                "selected_submission_id": "submission-000002",
+            },
+        )
         self.assertFalse(manifest["agent"]["stopped_after_terminal"])
         self.assertEqual(first_record_source, initial_source.encode())
         self.assertEqual(second_record_source, improved_source.encode())

--- a/tests/test_run_progress.py
+++ b/tests/test_run_progress.py
@@ -181,6 +181,66 @@ class ConsoleProgressTests(unittest.TestCase):
         )
         self.assertEqual(output.getvalue(), "")
 
+    def test_plain_progress_renders_post_agent_validation(self) -> None:
+        output = io.StringIO()
+        progress = ConsoleProgress(output, mode="plain")
+
+        progress.on_event(
+            event("finish_requested", 1, candidate_count=2)
+        )
+        progress.on_event(
+            event(
+                "validation_started",
+                2,
+                candidate_count=2,
+                episodes_per_candidate=3,
+            )
+        )
+        progress.on_event(
+            event(
+                "validation_candidate_started",
+                1_000_000_000,
+                submission_id="submission-000002",
+                episodes=3,
+            )
+        )
+        progress.on_event(
+            event(
+                "validation_episode_completed",
+                1_500_000_000,
+                submission_id="submission-000002",
+                completed=1,
+                total=3,
+                status="completed",
+            )
+        )
+        progress.on_event(
+            event(
+                "validation_candidate_completed",
+                2_000_000_000,
+                submission_id="submission-000002",
+                score=499.0,
+                policy_failures=0,
+            )
+        )
+
+        self.assertEqual(
+            output.getvalue().splitlines(),
+            [
+                "Agent finished · 2 candidate(s) handed to Host",
+                "Validation started · 2 candidate(s) · 3 Episodes each",
+                "submission-000002 · validating 3 Episodes",
+                (
+                    "submission-000002 · Validation Episodes 1/3"
+                    " · 0.5s · completed"
+                ),
+                (
+                    "submission-000002 · validation score 499"
+                    " · 0 Policy failure(s)"
+                ),
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_validation.py
+++ b/tests/test_run_validation.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Literal
+
+from evopolicygym.authoring import (
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+)
+from evopolicygym.benchmark import Benchmark
+from evopolicygym.errors import EvaluationError
+from evopolicygym.evaluation import EvaluationConfig
+from evopolicygym.program import Program
+from evopolicygym.results import (
+    EpisodeSummary,
+    EvaluationResult,
+    Feedback,
+    SubmissionResult,
+)
+from evopolicygym.run import RunConfig, ValidationConfig
+from evopolicygym.run._validation import CandidateSelector
+
+
+class StubBenchmark:
+    def __init__(
+        self,
+        *,
+        score_direction: Literal["maximize", "minimize"] = "maximize",
+    ) -> None:
+        self._spec = BenchmarkSpec(
+            id="example/validation-v1",
+            description="Validation selection fixture.",
+            observation_space=None,
+            action_space=None,
+            metadata={},
+            max_episode_steps=1,
+            primary_metric="reward",
+            score_direction=score_direction,
+        )
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        del split
+        return tuple(
+            EpisodeSpec(environment_seed=seed + index)
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        del episode
+        raise AssertionError("the fake evaluator owns evaluation")
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        del episodes
+        raise AssertionError("the fake evaluator owns evaluation")
+
+
+class FakeEvaluator:
+    def __init__(
+        self,
+        outcomes: Mapping[str, tuple[float, int]],
+        *,
+        fail_digest: str | None = None,
+    ) -> None:
+        self.outcomes = dict(outcomes)
+        self.fail_digest = fail_digest
+        self.configs: list[EvaluationConfig] = []
+
+    def evaluate(
+        self,
+        program: Program,
+        benchmark: Benchmark,
+        config: EvaluationConfig,
+        *,
+        episode_completed: (
+            Callable[[int, int, EpisodeSummary], None] | None
+        ) = None,
+    ) -> EvaluationResult:
+        self.configs.append(config)
+        if program.digest == self.fail_digest:
+            raise EvaluationError("trusted fixture failure")
+        score, failures = self.outcomes[program.digest]
+        episodes = tuple(
+            EpisodeSummary(
+                status="policy_failed",
+                reward=None,
+                steps=0,
+                failure="exception",
+            )
+            if index < failures
+            else EpisodeSummary(
+                status="completed",
+                reward=score,
+                steps=1,
+            )
+            for index in range(config.episodes)
+        )
+        if episode_completed is not None:
+            for index, episode in enumerate(episodes, start=1):
+                episode_completed(index, len(episodes), episode)
+        return EvaluationResult(
+            benchmark_id=benchmark.spec.id,
+            program_digest=program.digest,
+            feedback=Feedback(score=score),
+            episodes=episodes,
+        )
+
+
+class FakeRecorder:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def record_event(
+        self,
+        event: str,
+        fields: Mapping[str, object],
+    ) -> None:
+        self.events.append((event, dict(fields)))
+
+
+def make_submission(
+    root: Path,
+    ordinal: int,
+) -> SubmissionResult:
+    source = root / f"program-{ordinal}"
+    source.mkdir()
+    (source / "policy.py").write_text(
+        f"VALUE = {ordinal}\n"
+        "def make_policy(context):\n"
+        "    return object()\n",
+        encoding="utf-8",
+    )
+    return SubmissionResult(
+        submission_id=f"submission-{ordinal:06d}",
+        program=Program.from_directory(source),
+        episodes_used=1,
+        episodes_remaining=10 - ordinal,
+        feedback=Feedback(score=float(ordinal)),
+        episodes=(
+            EpisodeSummary(
+                status="completed",
+                reward=float(ordinal),
+                steps=1,
+            ),
+        ),
+    )
+
+
+class CandidateSelectorTests(unittest.TestCase):
+    def test_primary_score_outranks_policy_failure_count(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            submissions = tuple(
+                make_submission(root, ordinal)
+                for ordinal in range(1, 5)
+            )
+            ordered = (
+                submissions[1],
+                submissions[0],
+                submissions[2],
+                submissions[3],
+            )
+            outcomes = {
+                ordered[0].program_digest: (7.0, 0),
+                ordered[1].program_digest: (7.0, 0),
+                ordered[2].program_digest: (7.0, 1),
+                ordered[3].program_digest: (8.0, 2),
+            }
+            evaluator = FakeEvaluator(outcomes)
+            recorder = FakeRecorder()
+            benchmark = StubBenchmark()
+            selector = CandidateSelector(
+                evaluator=evaluator,
+                benchmark=benchmark,
+                spec=benchmark.spec,
+                config=RunConfig(
+                    max_submissions=4,
+                    validation=ValidationConfig(
+                        episodes_per_candidate=3,
+                        max_candidates=4,
+                    ),
+                    seed=41,
+                ),
+                recorder=recorder,
+            )
+
+            selection = selector.select(
+                submissions,
+                tuple(item.submission_id for item in ordered),
+            )
+
+        self.assertEqual(
+            selection.submission.submission_id,
+            ordered[3].submission_id,
+        )
+        self.assertIsNotNone(selection.validation)
+        assert selection.validation is not None
+        self.assertEqual(
+            tuple(
+                item.submission_id
+                for item in selection.validation.candidates
+            ),
+            tuple(item.submission_id for item in ordered),
+        )
+        self.assertEqual(len(evaluator.configs), 4)
+        self.assertTrue(
+            all(config == evaluator.configs[0] for config in evaluator.configs)
+        )
+        self.assertEqual(evaluator.configs[0].split, "validation")
+        self.assertEqual(evaluator.configs[0].episodes, 3)
+        self.assertEqual(
+            [name for name, _ in recorder.events].count(
+                "validation_episode_completed"
+            ),
+            12,
+        )
+
+    def test_fewer_policy_failures_break_a_score_tie(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            first = make_submission(root, 1)
+            second = make_submission(root, 2)
+            benchmark = StubBenchmark()
+            selector = CandidateSelector(
+                evaluator=FakeEvaluator(
+                    {
+                        first.program_digest: (4.0, 1),
+                        second.program_digest: (4.0, 0),
+                    }
+                ),
+                benchmark=benchmark,
+                spec=benchmark.spec,
+                config=RunConfig(
+                    max_submissions=2,
+                    validation=ValidationConfig(
+                        episodes_per_candidate=2,
+                        max_candidates=2,
+                    ),
+                ),
+                recorder=FakeRecorder(),
+            )
+
+            selection = selector.select(
+                (first, second),
+                (first.submission_id, second.submission_id),
+            )
+
+        self.assertEqual(
+            selection.submission.submission_id,
+            second.submission_id,
+        )
+
+    def test_minimize_and_finish_order_break_exact_ties(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            first = make_submission(root, 1)
+            second = make_submission(root, 2)
+            third = make_submission(root, 3)
+            outcomes = {
+                first.program_digest: (2.0, 0),
+                second.program_digest: (1.0, 1),
+                third.program_digest: (1.0, 1),
+            }
+            evaluator = FakeEvaluator(outcomes)
+            recorder = FakeRecorder()
+            benchmark = StubBenchmark(score_direction="minimize")
+            selector = CandidateSelector(
+                evaluator=evaluator,
+                benchmark=benchmark,
+                spec=benchmark.spec,
+                config=RunConfig(
+                    max_submissions=3,
+                    validation=ValidationConfig(
+                        episodes_per_candidate=2,
+                        max_candidates=3,
+                    ),
+                ),
+                recorder=recorder,
+            )
+
+            selection = selector.select(
+                (first, second, third),
+                (
+                    third.submission_id,
+                    second.submission_id,
+                    first.submission_id,
+                ),
+            )
+
+        self.assertEqual(
+            selection.submission.submission_id,
+            third.submission_id,
+        )
+
+    def test_validation_failure_does_not_return_a_partial_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            first = make_submission(root, 1)
+            second = make_submission(root, 2)
+            benchmark = StubBenchmark()
+            selector = CandidateSelector(
+                evaluator=FakeEvaluator(
+                    {
+                        first.program_digest: (1.0, 0),
+                        second.program_digest: (2.0, 0),
+                    },
+                    fail_digest=second.program_digest,
+                ),
+                benchmark=benchmark,
+                spec=benchmark.spec,
+                config=RunConfig(
+                    max_submissions=2,
+                    validation=ValidationConfig(
+                        episodes_per_candidate=2,
+                        max_candidates=2,
+                    ),
+                ),
+                recorder=FakeRecorder(),
+            )
+
+            with self.assertRaises(EvaluationError):
+                selector.select(
+                    (first, second),
+                    (first.submission_id, second.submission_id),
+                )
+
+    def test_without_validation_the_single_candidate_is_not_reevaluated(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            submission = make_submission(Path(temporary), 1)
+            evaluator = FakeEvaluator({})
+            recorder = FakeRecorder()
+            benchmark = StubBenchmark()
+            selector = CandidateSelector(
+                evaluator=evaluator,
+                benchmark=benchmark,
+                spec=benchmark.spec,
+                config=RunConfig(),
+                recorder=recorder,
+            )
+
+            selection = selector.select(
+                (submission,),
+                (submission.submission_id,),
+            )
+
+        self.assertEqual(selection.submission, submission)
+        self.assertIsNone(selection.validation)
+        self.assertEqual(evaluator.configs, [])
+        self.assertEqual(recorder.events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_submission_session.py
+++ b/tests/test_submission_session.py
@@ -22,7 +22,7 @@ from evopolicygym.results import (
     RunResult,
     SubmissionResult,
 )
-from evopolicygym.run import RunConfig
+from evopolicygym.run import RunConfig, ValidationConfig
 from evopolicygym.run._session import (
     FinishReceipt,
     SessionError,
@@ -257,11 +257,20 @@ class SubmissionSessionTests(unittest.TestCase):
 
             submitted = session.submit(2)
             assert isinstance(submitted, SubmissionReceipt)
-            finished = session.finish(submitted.submission_id)
+            finished = session.finish([submitted.submission_id])
 
         self.assertIsInstance(finished, FinishReceipt)
-        self.assertEqual(session.terminal_reason, "finished")
-        self.assertEqual(session.final_program, program)
+        assert isinstance(finished, FinishReceipt)
+        self.assertEqual(
+            finished.candidate_submission_ids,
+            (submitted.submission_id,),
+        )
+        self.assertIsNone(session.terminal_reason)
+        self.assertEqual(
+            session.candidate_submission_ids,
+            (submitted.submission_id,),
+        )
+        self.assertTrue(session.agent_authority_closed)
         self.assertEqual(len(publisher.results), 1)
         episode_events = [
             fields
@@ -312,12 +321,98 @@ class SubmissionSessionTests(unittest.TestCase):
                 FakePublisher(),
             )
 
-            outcome = session.finish("submission-999999")
+            outcome = session.finish(["submission-999999"])
 
         self.assertIsInstance(outcome, SessionError)
         assert isinstance(outcome, SessionError)
         self.assertEqual(outcome.code, "unknown_submission")
         self.assertIsNone(session.terminal_reason)
+        self.assertFalse(session.agent_authority_closed)
+
+    def test_finish_rejections_are_atomic_and_a_valid_retry_closes_authority(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            program = make_program(Path(temporary))
+            recorder = FakeRecorder()
+            session = self._session(
+                FakeProgramSource(program),
+                FakeEvaluator(),
+                FakePublisher(),
+                recorder=recorder,
+                episode_budget=4,
+                validation=ValidationConfig(
+                    episodes_per_candidate=3,
+                    max_candidates=2,
+                ),
+            )
+            first = session.submit(1)
+            second = session.submit(1)
+            assert isinstance(first, SubmissionReceipt)
+            assert isinstance(second, SubmissionReceipt)
+
+            malformed = session.finish([])
+            over_limit = session.finish(
+                [
+                    first.submission_id,
+                    second.submission_id,
+                    "submission-999999",
+                ]
+            )
+            duplicate = session.finish(
+                [first.submission_id, first.submission_id]
+            )
+            unknown = session.finish(
+                [first.submission_id, "submission-999999"]
+            )
+            accepted = session.finish(
+                [second.submission_id, first.submission_id]
+            )
+            closed = session.submit(1)
+
+        for outcome, code in (
+            (malformed, "invalid_request"),
+            (over_limit, "candidate_limit"),
+            (duplicate, "duplicate_submission"),
+            (unknown, "unknown_submission"),
+        ):
+            self.assertIsInstance(outcome, SessionError)
+            assert isinstance(outcome, SessionError)
+            self.assertEqual(outcome.code, code)
+        self.assertIsInstance(accepted, FinishReceipt)
+        self.assertEqual(
+            session.candidate_submission_ids,
+            (second.submission_id, first.submission_id),
+        )
+        self.assertIsInstance(closed, SessionError)
+        assert isinstance(closed, SessionError)
+        self.assertEqual(closed.code, "session_closed")
+        self.assertEqual(
+            [name for name, _ in recorder.events].count("finish_rejected"),
+            4,
+        )
+
+    def test_finish_without_validation_accepts_only_one_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            program = make_program(Path(temporary))
+            session = self._session(
+                FakeProgramSource(program),
+                FakeEvaluator(),
+                FakePublisher(),
+            )
+            first = session.submit(1)
+            second = session.submit(1)
+            assert isinstance(first, SubmissionReceipt)
+            assert isinstance(second, SubmissionReceipt)
+
+            outcome = session.finish(
+                [first.submission_id, second.submission_id]
+            )
+
+        self.assertIsInstance(outcome, SessionError)
+        assert isinstance(outcome, SessionError)
+        self.assertEqual(outcome.code, "candidate_limit")
+        self.assertFalse(session.agent_authority_closed)
 
     def _session(
         self,
@@ -328,6 +423,7 @@ class SubmissionSessionTests(unittest.TestCase):
         recorder: FakeRecorder | None = None,
         episode_budget: int = 5,
         max_episodes_per_submission: int | None = None,
+        validation: ValidationConfig | None = None,
     ) -> SubmissionSession:
         return SubmissionSession(
             programs=source,
@@ -337,6 +433,7 @@ class SubmissionSessionTests(unittest.TestCase):
             config=RunConfig(
                 episode_budget=episode_budget,
                 max_episodes_per_submission=max_episodes_per_submission,
+                validation=validation,
             ),
             recorder=FakeRecorder() if recorder is None else recorder,
         )


### PR DESCRIPTION
## Purpose

Move final candidate choice out of the Coding Agent Session and into a
Host-owned post-Agent phase. This establishes the authority boundary needed
for validation now and hidden assessment in a later change.

## What changed

- upgrade the Agent Session to `agent-session/v2`; `finish` atomically accepts
  an ordered `submission_ids` list
- reject malformed, duplicate, unknown, and over-limit candidate sets without
  closing the Session, so the Agent can retry
- close Agent authority after an accepted finish, reap the Agent process tree,
  and only then begin Host-side selection
- add public `ValidationConfig` and aggregate `ValidationResult` values
- evaluate every candidate with the same Validation split, derived seed,
  Episode count, and Policy seeds
- select by Benchmark score direction, fewer Policy failures, then finish
  argument order
- retain aggregate-only `validation/report.json`, run-record schema v2,
  lifecycle events, and console progress
- keep Validation evidence out of workspace Feedback and add
  `validation_failed` without partial final selection or retry
- update README, architecture, run scripts, changelog, and the repository usage
  skill

Without `ValidationConfig`, `finish` accepts exactly one candidate and the Host
selects it after Agent cleanup.

## User impact

Agents may now run:

```console
evopolicygym finish submission-000003 submission-000011
```

when the Run enables Validation. Existing single-candidate CLI usage remains
valid, but the Session wire contract intentionally changes from v1 to v2.

## Validation

- `ruff check src tests scripts`
- strict `mypy`
- `python -m unittest discover -s tests` — 76 tests passed, including local
  Unix-socket end-to-end coverage
- offline `uv build` — wheel and sdist succeeded

No real Codex run was performed. `ProcessExecution` remains explicitly unsafe
local process execution and does not provide isolation; whole-Run
virtualization and post-Run hidden assessment remain out of scope.
