### PR TITLE
run: add held-out final assessment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,10 @@ is under `src/evopolicygym/`:
   Benchmark distributions;
 - `evaluation/`: public `EvaluationConfig`/`evaluate()` and private direct
   Evaluation rules;
-- `run/`: public `RunConfig`/`run()` plus Session rules, Run records, Feedback
-  publication, non-authoritative progress observation, and Agent Session
-  transport;
+- `run/`: public Run/Validation/Assessment configuration and `run()` plus
+  Session rules, Host-side selection and held-out measurement, Run records,
+  Feedback publication, non-authoritative progress observation, and Agent
+  Session transport;
 - `execution/`: public execution selections; `execution/process/` contains only
   the current Policy and command-Agent process mechanisms;
 - `_protocol/`: pure versioned Policy/Agent bytes-to-value codecs; it never
@@ -89,6 +90,9 @@ the typed failure domain and cleanup behavior. Required invariants include:
 - Policy failure stops before another `World.step()`;
 - Environment and Backend faults do not become Policy penalties;
 - Feedback contains no private Case, seed, path, or execution evidence;
+- Validation and Assessment start only after Agent cleanup and never publish
+  evidence into workspace Feedback;
+- Assessment evaluates only the selected Program and never changes selection;
 - Run observers receive events only after persistence, and observer failure
   never changes Run semantics;
 - complete malformed guest frames, partial frames, and trusted-input errors keep

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # EvoPolicyGym kernel architecture
 
 This document is authoritative for the current clean-slate Kernel. It describes
-the local, non-durable product only. Docker, recovery, remote execution, and
-post-Run hidden assessment are not design inputs for this version.
+the local, non-durable product only. Docker, recovery, and remote execution are
+not design inputs for this version.
 
 ## Domain language
 
@@ -14,6 +14,8 @@ post-Run hidden assessment are not design inputs for this version.
 - `Validation` is a Host-only, post-Agent Evaluation of every finished
   candidate on identical Episodes. It selects the final Submission without
   publishing evidence back to the Agent workspace.
+- `Assessment` is a Host-only held-out Evaluation of the already selected
+  final Program. It measures the result but never participates in selection.
 - `Feedback` has a Kernel-required scalar score, Benchmark-defined public
   content, and optional public Artifact files.
 - A `ProgramEvolutionRun` is one bounded outer loop in which a Coding Agent
@@ -47,11 +49,12 @@ evopolicygym/
 │   └── _service.py             Episode rules and narrow runtime contracts
 │
 ├── run/                        complete Program-Evolution use case
-│   ├── __init__.py             RunConfig, ValidationConfig, and run()
+│   ├── __init__.py             Run/Validation/Assessment configs and run()
 │   ├── progress.py             public Run events, observer, and console reporter
 │   ├── _service.py             Run coordination and process-setting assembly
 │   ├── _session.py             Submission budget and atomic finish admission
 │   ├── _validation.py          post-Agent candidate evaluation and selection
+│   ├── _assessment.py          held-out final-Program measurement
 │   ├── _directory.py           workspace, events, invocation, and run.json
 │   ├── _feedback.py            Feedback and Artifact publication
 │   ├── _json.py                retained public-value JSON projection
@@ -123,6 +126,8 @@ The rules are:
 - `run/_validation.py` owns deterministic final selection. It starts only
   after the Agent runner has reaped the process tree and the Session gateway
   has closed;
+- `run/_assessment.py` evaluates only the selected Submission, uses its own
+  seed domain, and cannot replace or rerank candidates;
 - `run/` owns Run directories, Feedback publication, and Session transport;
   these responsibilities do not live under process execution;
 - `run/progress.py` owns non-authoritative observation and terminal
@@ -164,7 +169,13 @@ Agent search
                                 Host-only Validation
                                              │
                                              ▼
-                           final selection and Run commit
+                                      final selection
+                                             │
+                                             ▼
+                              held-out Assessment (optional)
+                                             │
+                                             ▼
+                                        Run commit
 ```
 
 `finish` uses `agent-session/v2` and accepts a non-empty
@@ -179,13 +190,23 @@ the Benchmark's declared direction, then Policy-failure count, then finish
 argument order. A trusted fault terminates the Run as `validation_failed`
 without a partial final selection or automatic retry.
 
+Assessment uses an independent Run-seed-derived domain and evaluates only the
+selected Submission. A trusted fault terminates as `assessment_failed` while
+retaining that final Program; it never falls back to another candidate and
+does not create a partial report.
+
 The Agent-visible `workspace/` contains only editable `program/`, public
-`feedback/`, and an optional Benchmark skill. `validation/` is not created
-until after Agent cleanup. A successful validated Run retains only aggregate
-candidate scores and Policy-failure counts in
-`validation/report.json`; private Episodes, seeds, cases, traces, and
-execution evidence do not cross into Feedback. `run.json` uses
-`evopolicygym/run-record/v2` and references that aggregate report.
+`feedback/`, and an optional Benchmark skill. `validation/` and `assessment/`
+are not created until after Agent cleanup. Successful phases retain only
+aggregate scores and Policy-failure counts in their reports; private Episodes,
+seeds, cases, traces, and execution evidence do not cross into Feedback.
+`run.json` uses `evopolicygym/run-record/v3` and references the available
+aggregate reports.
+
+This is a logical lifecycle and publication boundary, not a security boundary:
+`ProcessExecution` remains non-isolated. A Benchmark that requires
+cryptographically hidden Cases still needs future remote execution or
+whole-Run virtualization.
 
 ## Migration status
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added optional held-out final-Program Assessment with an independent seed
+  domain, aggregate results, progress events, and run-record schema v3.
+- Added `AssessmentConfig`, `AssessmentResult`, and the `assessment_failed`
+  terminal reason without candidate fallback.
 - Added atomic ordered candidate handoff through `agent-session/v2` and
   optional post-Agent server-side Validation with aggregate retained results.
 - Added `ValidationConfig`, candidate and Validation fields on `RunResult`,

--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ with `use_benchmark_skill=True`; the skill is never passed to the Policy:
 ```python
 from cartpole import CartPoleBenchmark, baseline_program
 
-from evopolicygym import RunConfig, ValidationConfig, run
+from evopolicygym import (
+    AssessmentConfig,
+    RunConfig,
+    ValidationConfig,
+    run,
+)
 from evopolicygym.agents import Codex
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import ConsoleProgress
@@ -142,6 +147,10 @@ result = run(
             split="validation",
             episodes_per_candidate=10,
             max_candidates=3,
+        ),
+        assessment=AssessmentConfig(
+            split="test",
+            episodes=20,
         ),
     ),
     observer=ConsoleProgress(),
@@ -164,12 +173,17 @@ order. Validation has a separate Episode allocation and is never published
 back into workspace Feedback. Without `ValidationConfig`, `finish` accepts
 exactly one candidate and the Host selects it after Agent cleanup.
 
+With `AssessmentConfig`, the Host then evaluates only the selected final
+Program on a separately seeded held-out split. Assessment never changes the
+selection and is never returned to the Agent. Its aggregate score and Policy
+failure count are the Run's final benchmark evidence.
+
 The Host retains submitted Programs, public Feedback and Artifacts,
 `events.jsonl`, the final `run.json`, separate Agent logs, and—when
-configured—an aggregate `validation/report.json`. Benchmark authors control
-the public Feedback content and may publish bounded traces, replays,
-diagnostics, images, or reports without exposing private seeds, paths, or
-execution evidence.
+configured—aggregate `validation/report.json` and
+`assessment/report.json` records. Benchmark authors control the public
+Feedback content and may publish bounded traces, replays, diagnostics, images,
+or reports without exposing private seeds, paths, or execution evidence.
 
 `ProcessExecution` is **not a sandbox**. The Agent and Policy processes run
 with the authority of the current operating-system user. Use it only with

--- a/scripts/run_balatro_codex.py
+++ b/scripts/run_balatro_codex.py
@@ -8,7 +8,12 @@ from pathlib import Path
 
 from balatro import BalatroBenchmark, baseline_program
 
-from evopolicygym import RunConfig, ValidationConfig, run
+from evopolicygym import (
+    AssessmentConfig,
+    RunConfig,
+    ValidationConfig,
+    run,
+)
 from evopolicygym.agents import Codex
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import ConsoleProgress
@@ -57,6 +62,14 @@ def main(arguments: list[str] | None = None) -> int:
                     max_candidates=namespace.validation_max_candidates,
                 )
             ),
+            assessment=(
+                None
+                if namespace.assessment_episodes is None
+                else AssessmentConfig(
+                    split=namespace.assessment_split,
+                    episodes=namespace.assessment_episodes,
+                )
+            ),
             seed=namespace.seed,
             episode_timeout_seconds=namespace.episode_timeout_seconds,
             agent_timeout_seconds=namespace.agent_timeout_seconds,
@@ -92,6 +105,17 @@ def main(arguments: list[str] | None = None) -> int:
                             }
                             for candidate in result.validation.candidates
                         ],
+                    }
+                ),
+                "assessment": (
+                    None
+                    if result.assessment is None
+                    else {
+                        "submission_id": result.assessment.submission_id,
+                        "score": result.assessment.score,
+                        "policy_failures": (
+                            result.assessment.policy_failures
+                        ),
                     }
                 ),
                 "record": str(record_to),
@@ -141,6 +165,16 @@ def _parser() -> argparse.ArgumentParser:
         "--validation-max-candidates",
         type=int,
         default=3,
+    )
+    parser.add_argument(
+        "--assessment-episodes",
+        type=int,
+        help="enable held-out final-Program Assessment",
+    )
+    parser.add_argument(
+        "--assessment-split",
+        choices=("train", "validation", "test"),
+        default="test",
     )
     parser.add_argument(
         "--benchmark-skill",

--- a/scripts/run_cartpole_codex.py
+++ b/scripts/run_cartpole_codex.py
@@ -8,7 +8,12 @@ from pathlib import Path
 
 from cartpole import CartPoleBenchmark, baseline_program
 
-from evopolicygym import RunConfig, ValidationConfig, run
+from evopolicygym import (
+    AssessmentConfig,
+    RunConfig,
+    ValidationConfig,
+    run,
+)
 from evopolicygym.agents import Codex
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import ConsoleProgress
@@ -56,6 +61,14 @@ def main(arguments: list[str] | None = None) -> int:
                     max_candidates=namespace.validation_max_candidates,
                 )
             ),
+            assessment=(
+                None
+                if namespace.assessment_episodes is None
+                else AssessmentConfig(
+                    split=namespace.assessment_split,
+                    episodes=namespace.assessment_episodes,
+                )
+            ),
             seed=namespace.seed,
             episode_timeout_seconds=namespace.episode_timeout_seconds,
             agent_timeout_seconds=namespace.agent_timeout_seconds,
@@ -91,6 +104,17 @@ def main(arguments: list[str] | None = None) -> int:
                             }
                             for candidate in result.validation.candidates
                         ],
+                    }
+                ),
+                "assessment": (
+                    None
+                    if result.assessment is None
+                    else {
+                        "submission_id": result.assessment.submission_id,
+                        "score": result.assessment.score,
+                        "policy_failures": (
+                            result.assessment.policy_failures
+                        ),
                     }
                 ),
                 "record": str(record_to),
@@ -140,6 +164,16 @@ def _parser() -> argparse.ArgumentParser:
         "--validation-max-candidates",
         type=int,
         default=2,
+    )
+    parser.add_argument(
+        "--assessment-episodes",
+        type=int,
+        help="enable held-out final-Program Assessment",
+    )
+    parser.add_argument(
+        "--assessment-split",
+        choices=("train", "validation", "test"),
+        default="test",
     )
     parser.add_argument("--episode-timeout-seconds", type=float, default=20)
     parser.add_argument("--agent-timeout-seconds", type=float, default=600)

--- a/skills/use-evopolicygym/SKILL.md
+++ b/skills/use-evopolicygym/SKILL.md
@@ -9,7 +9,7 @@ Use the public EvoPolicyGym SDK to build a complete bounded loop:
 
 ```text
 Program → Evaluation → Feedback → Agent edit → Submission → candidate handoff
-→ Host selection
+→ Host selection → held-out Assessment
 ```
 
 Preserve the separation between the trusted Host and Benchmark, the Coding
@@ -95,6 +95,10 @@ authority.
 - Treat successful `finish` as an authority boundary. Validation and final
   selection occur only after the Agent process is reaped; do not expose their
   evidence in workspace Feedback.
+- Use `AssessmentConfig` to measure only the selected Program on a separately
+  seeded held-out split. Assessment must not rerank candidates, publish
+  evidence to the Agent, retry automatically, or fall back after a trusted
+  failure.
 - Treat failed trusted evaluation attempts as consumed budget. Never rewrite
   accounting after a failure.
 
@@ -127,5 +131,6 @@ Policy-failure classification, Feedback privacy, and Artifact bounds.
 
 Report the selected Benchmark, Program digest or source, split, seed, Episode
 budget, ordered candidate IDs, Validation configuration and aggregate result,
-terminal reason, final submission, verification commands, and the remaining
-lack of process isolation.
+Assessment configuration and aggregate result, terminal reason, final
+submission, verification commands, and the remaining lack of process
+isolation.

--- a/skills/use-evopolicygym/references/api.md
+++ b/skills/use-evopolicygym/references/api.md
@@ -40,7 +40,12 @@ construction failure; it is not a Policy penalty.
 ```python
 from example_benchmark import ExampleBenchmark, baseline_program
 
-from evopolicygym import RunConfig, ValidationConfig, run
+from evopolicygym import (
+    AssessmentConfig,
+    RunConfig,
+    ValidationConfig,
+    run,
+)
 from evopolicygym.agents import Codex
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import ConsoleProgress
@@ -62,6 +67,10 @@ result = run(
             episodes_per_candidate=10,
             max_candidates=3,
         ),
+        assessment=AssessmentConfig(
+            split="test",
+            episodes=20,
+        ),
         seed=0,
         episode_timeout_seconds=30,
         agent_timeout_seconds=3600,
@@ -73,6 +82,7 @@ print(result.terminal_reason)
 print(result.candidate_submission_ids)
 print(result.final_submission_id)
 print(result.validation)
+print(result.assessment)
 ```
 
 Use a unique `record_to`. Its parent must already exist and the Run directory
@@ -92,6 +102,9 @@ evopolicygym finish submission-000003 submission-000011
 all candidates on identical private Validation Episodes, and selects by score
 direction, fewer Policy failures, then argument order. Without it, exactly one
 candidate is accepted. Validation is not returned through workspace Feedback.
+When `AssessmentConfig` is present, the Host subsequently evaluates only the
+selected Program on an independently seeded held-out split. Assessment does
+not affect selection and is not returned through workspace Feedback.
 
 ## Other command-line Coding Agents
 

--- a/skills/use-evopolicygym/references/authoring.md
+++ b/skills/use-evopolicygym/references/authoring.md
@@ -66,10 +66,11 @@ If supplying `BenchmarkSpec.agent_skill`, keep it task-specific, bounded, and
 free of private state. It is projected read-only only when a Run opts in.
 
 The same `episodes()`, `make_environment()`, and `feedback()` methods may be
-used for server-side candidate Validation. Keep splits genuinely disjoint when
-the Benchmark promises disjoint data. The Kernel retains only aggregate score
-and Policy-failure counts from Validation; Benchmark-defined content and
-Artifacts are not published to the Agent workspace.
+used for server-side candidate Validation and final Assessment. Keep training,
+Validation, and held-out splits genuinely disjoint when the Benchmark promises
+disjoint data. The Kernel retains only aggregate score and Policy-failure
+counts from these Host phases; Benchmark-defined content and Artifacts are not
+published to the Agent workspace.
 
 ## Test before distribution
 

--- a/skills/use-evopolicygym/references/diagnostics.md
+++ b/skills/use-evopolicygym/references/diagnostics.md
@@ -21,6 +21,8 @@ run-root/
 │       └── artifacts/
 ├── validation/                 only after successful configured Validation
 │   └── report.json             aggregate candidate evidence
+├── assessment/                 only after successful configured Assessment
+│   └── report.json             aggregate final-Program evidence
 └── agent/
     ├── invocation.json
     ├── instructions.md
@@ -35,8 +37,8 @@ only after its Program and public Feedback commit successfully.
 ## Diagnose in order
 
 1. Read `run.json`: benchmark ID, config, terminal reason, final submission,
-   ordered candidates, published submissions, optional Validation report, and
-   Agent exit.
+   ordered candidates, published submissions, optional Validation and
+   Assessment reports, and Agent exit.
 2. Read the final events in `events.jsonl`: determine whether failure occurred
    before an Episode, during an Episode, after all Episodes, or during
    publication.
@@ -59,6 +61,9 @@ only after its Program and public Feedback commit successfully.
 - `evaluation_failed`: trusted evaluation could not produce a valid result.
 - `validation_failed`: post-Agent candidate Validation failed; no partial
   final selection or report is authoritative.
+- `assessment_failed`: held-out Evaluation failed after final selection. The
+  selected Program remains final, but there is no authoritative Assessment
+  result or fallback candidate.
 
 An Episode status of `policy_failed` is a scored Policy outcome, not a trusted
 evaluation failure. Its failure code is one of `exception`, `timeout`,

--- a/src/evopolicygym/__init__.py
+++ b/src/evopolicygym/__init__.py
@@ -12,9 +12,10 @@ if TYPE_CHECKING:
     from .evaluation import EvaluationConfig, evaluate
     from .program import Program
     from .results import EvaluationResult, RunResult
-    from .run import RunConfig, ValidationConfig, run
+    from .run import AssessmentConfig, RunConfig, ValidationConfig, run
 
 _EXPORTS = {
+    "AssessmentConfig": (".run", "AssessmentConfig"),
     "Benchmark": (".benchmark", "Benchmark"),
     "EvaluationConfig": (".evaluation", "EvaluationConfig"),
     "EvaluationResult": (".results", "EvaluationResult"),
@@ -27,6 +28,7 @@ _EXPORTS = {
 }
 
 __all__ = [
+    "AssessmentConfig",
     "Benchmark",
     "EvaluationConfig",
     "EvaluationResult",

--- a/src/evopolicygym/results.py
+++ b/src/evopolicygym/results.py
@@ -29,6 +29,7 @@ type RunTerminalReason = Literal[
     "agent_failed",
     "evaluation_failed",
     "validation_failed",
+    "assessment_failed",
 ]
 
 
@@ -157,6 +158,46 @@ class SubmissionResult:
 
 
 @dataclass(frozen=True, slots=True)
+class AssessmentResult:
+    """Aggregate held-out evidence for the selected final Program."""
+
+    submission_id: str
+    program_digest: str
+    split: str
+    episodes: int
+    primary_metric: str
+    score_direction: Literal["maximize", "minimize"]
+    score: float
+    policy_failures: int
+
+    def __post_init__(self) -> None:
+        _non_empty_text(self.submission_id, "submission_id")
+        _digest(self.program_digest, "program_digest")
+        _non_empty_text(self.split, "split")
+        _non_empty_text(self.primary_metric, "primary_metric")
+        if type(self.episodes) is not int or self.episodes <= 0:
+            raise ValueError("episodes must be a positive integer")
+        if self.score_direction not in {"maximize", "minimize"}:
+            raise ValueError(
+                "score_direction must be 'maximize' or 'minimize'"
+            )
+        if (
+            isinstance(self.score, bool)
+            or not isinstance(self.score, (int, float))
+            or not math.isfinite(float(self.score))
+        ):
+            raise ValueError("score must be a finite number")
+        if (
+            type(self.policy_failures) is not int
+            or not 0 <= self.policy_failures <= self.episodes
+        ):
+            raise ValueError(
+                "policy_failures must be between zero and episodes"
+            )
+        object.__setattr__(self, "score", float(self.score))
+
+
+@dataclass(frozen=True, slots=True)
 class ValidationCandidateResult:
     """One aggregate server-side Validation outcome."""
 
@@ -242,6 +283,7 @@ class RunResult:
     terminal_reason: RunTerminalReason
     candidate_submission_ids: tuple[str, ...] = ()
     validation: ValidationResult | None = None
+    assessment: AssessmentResult | None = None
 
     def __post_init__(self) -> None:
         if self.final_program is not None and type(self.final_program) is not Program:
@@ -299,25 +341,49 @@ class RunResult:
                 raise ValueError(
                     "final submission must match validation selection"
                 )
-        if self.terminal_reason == "finished":
+        final_reasons = {"finished", "assessment_failed"}
+        if self.terminal_reason in final_reasons:
             if self.final_submission_id is None or not candidates:
                 raise ValueError(
-                    "a finished Run requires a final candidate"
+                    "a post-selection Run requires a final candidate"
                 )
         elif self.final_submission_id is not None:
             raise ValueError(
-                "only a finished Run can contain a final Program"
-            )
-        if self.validation is not None and self.terminal_reason != "finished":
-            raise ValueError(
-                "only a finished Run can contain Validation results"
+                "only a post-selection Run can contain a final Program"
             )
         if (
-            candidates
-            and self.terminal_reason not in {"finished", "validation_failed"}
+            self.validation is not None
+            and self.terminal_reason not in final_reasons
         ):
             raise ValueError(
-                "only finished or failed Validation can contain candidates"
+                "Validation results require completed candidate selection"
+            )
+        if self.assessment is not None:
+            if type(self.assessment) is not AssessmentResult:
+                raise TypeError("assessment must be AssessmentResult or None")
+            if self.terminal_reason != "finished":
+                raise ValueError(
+                    "Assessment results require a finished Run"
+                )
+            if (
+                self.assessment.submission_id
+                != self.final_submission_id
+            ):
+                raise ValueError(
+                    "Assessment must match the final submission"
+                )
+            assert self.final_program is not None
+            if self.assessment.program_digest != self.final_program.digest:
+                raise ValueError(
+                    "Assessment must match the final Program"
+                )
+        if (
+            candidates
+            and self.terminal_reason
+            not in {"finished", "validation_failed", "assessment_failed"}
+        ):
+            raise ValueError(
+                "only post-finish phases can contain candidates"
             )
         if self.terminal_reason not in {
             "finished",
@@ -326,6 +392,7 @@ class RunResult:
             "agent_failed",
             "evaluation_failed",
             "validation_failed",
+            "assessment_failed",
         }:
             raise ValueError("terminal_reason is invalid")
         object.__setattr__(self, "submissions", submissions)
@@ -354,6 +421,7 @@ def _digest(value: object, name: str) -> str:
 
 
 __all__ = [
+    "AssessmentResult",
     "EpisodeStatus",
     "EpisodeSummary",
     "EvaluationResult",

--- a/src/evopolicygym/run/__init__.py
+++ b/src/evopolicygym/run/__init__.py
@@ -16,6 +16,20 @@ from .progress import ConsoleProgress, RunEvent, RunObserver
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
+class AssessmentConfig:
+    """Fixed held-out evidence for the selected final Program."""
+
+    episodes: int
+    split: str = "test"
+
+    def __post_init__(self) -> None:
+        if type(self.split) is not str or not self.split:
+            raise ValueError("assessment split must be non-empty text")
+        if type(self.episodes) is not int or self.episodes <= 0:
+            raise ValueError("assessment episodes must be a positive integer")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
 class ValidationConfig:
     """Fixed server-side evidence used to select finished candidates."""
 
@@ -42,6 +56,7 @@ class RunConfig:
     max_episodes_per_submission: int | None = None
     use_benchmark_skill: bool = False
     validation: ValidationConfig | None = None
+    assessment: AssessmentConfig | None = None
     seed: int = 0
     episode_timeout_seconds: float = 30.0
     agent_timeout_seconds: float = 3_600.0
@@ -74,6 +89,11 @@ class RunConfig:
             if self.validation.max_candidates > self.max_submissions:
                 raise ValueError(
                     "validation max_candidates cannot exceed max_submissions"
+                )
+        if self.assessment is not None:
+            if type(self.assessment) is not AssessmentConfig:
+                raise TypeError(
+                    "assessment must be AssessmentConfig or None"
                 )
         if type(self.seed) is not int or not 0 <= self.seed <= 2**64 - 1:
             raise ValueError("seed must be an unsigned 64-bit integer")
@@ -136,6 +156,7 @@ def run(
 
 
 __all__ = [
+    "AssessmentConfig",
     "ConsoleProgress",
     "RunConfig",
     "RunEvent",

--- a/src/evopolicygym/run/_assessment.py
+++ b/src/evopolicygym/run/_assessment.py
@@ -1,0 +1,161 @@
+"""Held-out final-Program assessment after candidate selection."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Mapping
+from typing import Protocol
+
+from ..benchmark import Benchmark, BenchmarkSpec
+from ..errors import EvaluationError
+from ..evaluation import EvaluationConfig
+from ..program import Program
+from ..results import (
+    AssessmentResult,
+    EpisodeSummary,
+    EvaluationResult,
+    SubmissionResult,
+)
+from . import RunConfig
+
+_ASSESSMENT_SEED_DOMAIN = b"evopolicygym/assessment-seed/v1\0"
+
+
+class ProgramEvaluator(Protocol):
+    def evaluate(
+        self,
+        program: Program,
+        benchmark: Benchmark,
+        config: EvaluationConfig,
+        *,
+        episode_completed: (
+            Callable[[int, int, EpisodeSummary], None] | None
+        ) = None,
+    ) -> EvaluationResult:
+        ...
+
+
+class EventRecorder(Protocol):
+    def record_event(
+        self,
+        event: str,
+        fields: Mapping[str, object],
+    ) -> None:
+        ...
+
+
+class ProgramAssessor:
+    """Evaluate the selected Program once without influencing selection."""
+
+    def __init__(
+        self,
+        *,
+        evaluator: ProgramEvaluator,
+        benchmark: Benchmark,
+        spec: BenchmarkSpec,
+        config: RunConfig,
+        recorder: EventRecorder,
+    ) -> None:
+        self._evaluator = evaluator
+        self._benchmark = benchmark
+        self._spec = spec
+        self._config = config
+        self._recorder = recorder
+
+    def assess(
+        self,
+        submission: SubmissionResult,
+    ) -> AssessmentResult | None:
+        assessment_config = self._config.assessment
+        if assessment_config is None:
+            return None
+
+        identifier = submission.submission_id
+        self._recorder.record_event(
+            "assessment_started",
+            {
+                "submission_id": identifier,
+                "split": assessment_config.split,
+                "episodes": assessment_config.episodes,
+                "primary_metric": self._spec.primary_metric,
+                "score_direction": self._spec.score_direction,
+            },
+        )
+
+        def episode_completed(
+            completed: int,
+            total: int,
+            summary: EpisodeSummary,
+        ) -> None:
+            self._recorder.record_event(
+                "assessment_episode_completed",
+                {
+                    "submission_id": identifier,
+                    "completed": completed,
+                    "total": total,
+                    "status": summary.status,
+                },
+            )
+
+        try:
+            evaluated = self._evaluator.evaluate(
+                submission.program,
+                self._benchmark,
+                EvaluationConfig(
+                    split=assessment_config.split,
+                    episodes=assessment_config.episodes,
+                    seed=_assessment_seed(self._config.seed),
+                    episode_timeout_seconds=(
+                        self._config.episode_timeout_seconds
+                    ),
+                ),
+                episode_completed=episode_completed,
+            )
+        except EvaluationError:
+            raise
+        except Exception:
+            raise EvaluationError(
+                "trusted Assessment evaluation failed"
+            ) from None
+        if (
+            type(evaluated) is not EvaluationResult
+            or evaluated.benchmark_id != self._spec.id
+            or evaluated.program_digest != submission.program_digest
+            or len(evaluated.episodes) != assessment_config.episodes
+        ):
+            raise EvaluationError(
+                "Assessment evaluation returned an invalid result"
+            )
+
+        result = AssessmentResult(
+            submission_id=identifier,
+            program_digest=submission.program_digest,
+            split=assessment_config.split,
+            episodes=len(evaluated.episodes),
+            primary_metric=self._spec.primary_metric,
+            score_direction=self._spec.score_direction,
+            score=evaluated.feedback.score,
+            policy_failures=sum(
+                episode.status == "policy_failed"
+                for episode in evaluated.episodes
+            ),
+        )
+        self._recorder.record_event(
+            "assessment_completed",
+            {
+                "submission_id": identifier,
+                "score": result.score,
+                "policy_failures": result.policy_failures,
+            },
+        )
+        return result
+
+
+def _assessment_seed(run_seed: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_ASSESSMENT_SEED_DOMAIN)
+    digest.update(run_seed.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+__all__: list[str] = []

--- a/src/evopolicygym/run/_directory.py
+++ b/src/evopolicygym/run/_directory.py
@@ -21,10 +21,11 @@ from ..results import RunResult
 from . import RunConfig
 from .progress import RunEvent, RunEventValue, RunObserver
 
-_RUN_RECORD_SCHEMA = "evopolicygym/run-record/v2"
+_RUN_RECORD_SCHEMA = "evopolicygym/run-record/v3"
 _RUN_EVENT_SCHEMA = "evopolicygym/run-event/v1"
 _INVOCATION_SCHEMA = "evopolicygym/agent-invocation/v1"
 _VALIDATION_REPORT_SCHEMA = "evopolicygym/validation-report/v1"
+_ASSESSMENT_REPORT_SCHEMA = "evopolicygym/assessment-report/v1"
 _SESSION_SOCKET_VARIABLE = "EVOPOLICYGYM_SESSION_SOCKET"
 _WORKSPACE_VARIABLE = "EVOPOLICYGYM_WORKSPACE"
 
@@ -40,6 +41,7 @@ class RunDirectoryPaths:
     submissions: Path
     agent: Path
     validation: Path
+    assessment: Path
     control: Path
     socket: Path
     events: Path
@@ -58,6 +60,7 @@ class RunDirectoryPaths:
             submissions=root / "submissions",
             agent=root / "agent",
             validation=root / "validation",
+            assessment=root / "assessment",
             control=control,
             socket=control / "session.sock",
             events=root / "events.jsonl",
@@ -135,6 +138,11 @@ class RunDirectoryRecorder:
         if result.validation is not None:
             _write_validation_report(
                 self._paths.validation,
+                result,
+            )
+        if result.assessment is not None:
+            _write_assessment_report(
+                self._paths.assessment,
                 result,
             )
         _write_run_manifest(
@@ -342,6 +350,14 @@ def _write_run_manifest(
                         ),
                     }
                 ),
+                "assessment": (
+                    None
+                    if config.assessment is None
+                    else {
+                        "split": config.assessment.split,
+                        "episodes": config.assessment.episodes,
+                    }
+                ),
             },
             "agent": {
                 **agent_identity,
@@ -364,6 +380,11 @@ def _write_run_manifest(
                 None
                 if result.validation is None
                 else {"report": "validation/report.json"}
+            ),
+            "assessment": (
+                None
+                if result.assessment is None
+                else {"report": "assessment/report.json"}
             ),
             "submissions": submissions,
         },
@@ -413,6 +434,41 @@ def _write_validation_report(
     except OSError as error:
         raise AgentRunError(
             "Validation record could not be committed"
+        ) from error
+
+
+def _write_assessment_report(
+    directory: Path,
+    result: RunResult,
+) -> None:
+    assessment = result.assessment
+    assert assessment is not None
+    try:
+        directory.mkdir(mode=0o700)
+    except OSError as error:
+        raise AgentRunError(
+            "Assessment record could not be committed"
+        ) from error
+    _write_json_atomic(
+        directory / "report.json",
+        {
+            "schema": _ASSESSMENT_REPORT_SCHEMA,
+            "submission_id": assessment.submission_id,
+            "program_digest": assessment.program_digest,
+            "split": assessment.split,
+            "episodes": assessment.episodes,
+            "primary_metric": assessment.primary_metric,
+            "score_direction": assessment.score_direction,
+            "score": assessment.score,
+            "policy_failures": assessment.policy_failures,
+        },
+        error_message="Assessment record could not be committed",
+    )
+    try:
+        os.chmod(directory, 0o500)
+    except OSError as error:
+        raise AgentRunError(
+            "Assessment record could not be committed"
         ) from error
 
 

--- a/src/evopolicygym/run/_service.py
+++ b/src/evopolicygym/run/_service.py
@@ -13,6 +13,7 @@ from ..errors import AgentRunError, EvaluationError
 from ..execution.process.agent.runner import AgentExit
 from ..program import Program
 from ..results import (
+    AssessmentResult,
     RunResult,
     RunTerminalReason,
     SubmissionResult,
@@ -76,6 +77,14 @@ class CandidateSelectionService(Protocol):
         ...
 
 
+class FinalAssessmentService(Protocol):
+    def assess(
+        self,
+        submission: SubmissionResult,
+    ) -> AssessmentResult | None:
+        ...
+
+
 class RunRecorder(Protocol):
     def record_event(
         self,
@@ -100,6 +109,7 @@ class ProgramEvolutionRun:
         gateway: SessionGateway,
         agent_runner: AgentRunner,
         candidate_selector: CandidateSelectionService,
+        final_assessor: FinalAssessmentService,
         recorder: RunRecorder,
         agent_timeout_seconds: float,
     ) -> None:
@@ -115,6 +125,7 @@ class ProgramEvolutionRun:
         self._gateway = gateway
         self._agent_runner = agent_runner
         self._candidate_selector = candidate_selector
+        self._final_assessor = final_assessor
         self._recorder = recorder
         self._agent_timeout_seconds = agent_timeout_seconds
 
@@ -142,6 +153,7 @@ class ProgramEvolutionRun:
         assert agent_exit is not None
         candidate_ids = self._session.candidate_submission_ids
         selection: CandidateSelection | None = None
+        assessment: AssessmentResult | None = None
         terminal_reason = _terminal_reason(self._session, agent_exit)
         if candidate_ids and self._session.terminal_reason is None:
             try:
@@ -156,7 +168,6 @@ class ProgramEvolutionRun:
                     {"candidate_count": len(candidate_ids)},
                 )
             else:
-                terminal_reason = "finished"
                 self._recorder.record_event(
                     "final_submission_selected",
                     {
@@ -166,15 +177,33 @@ class ProgramEvolutionRun:
                         ),
                     },
                 )
-                self._recorder.record_event(
-                    "run_finished",
-                    {
-                        "submission_id": selection.submission.submission_id,
-                        "program_digest": (
-                            selection.submission.program_digest
-                        ),
-                    },
-                )
+                try:
+                    assessment = self._final_assessor.assess(
+                        selection.submission
+                    )
+                except EvaluationError:
+                    terminal_reason = "assessment_failed"
+                    self._recorder.record_event(
+                        "assessment_failed",
+                        {
+                            "submission_id": (
+                                selection.submission.submission_id
+                            ),
+                        },
+                    )
+                else:
+                    terminal_reason = "finished"
+                    self._recorder.record_event(
+                        "run_finished",
+                        {
+                            "submission_id": (
+                                selection.submission.submission_id
+                            ),
+                            "program_digest": (
+                                selection.submission.program_digest
+                            ),
+                        },
+                    )
         result = RunResult(
             final_program=(
                 None if selection is None else selection.submission.program
@@ -190,6 +219,7 @@ class ProgramEvolutionRun:
             validation=(
                 None if selection is None else selection.validation
             ),
+            assessment=assessment,
         )
         self._recorder.commit(result, agent_exit)
         return result
@@ -288,6 +318,7 @@ def run_process_agent(
         build_agent_environment,
     )
     from ..execution.process.policy.runtime import ProcessPolicyRuntimeFactory
+    from ._assessment import ProgramAssessor
     from ._directory import (
         RunDirectoryRecorder,
         WorkspaceProgramSource,
@@ -368,6 +399,13 @@ def run_process_agent(
                 gateway=gateway,
                 agent_runner=runner,
                 candidate_selector=CandidateSelector(
+                    evaluator=evaluator,
+                    benchmark=benchmark,
+                    spec=selected_spec,
+                    config=config,
+                    recorder=recorder,
+                ),
+                final_assessor=ProgramAssessor(
                     evaluator=evaluator,
                     benchmark=benchmark,
                     spec=selected_spec,

--- a/src/evopolicygym/run/_task.py
+++ b/src/evopolicygym/run/_task.py
@@ -54,6 +54,14 @@ not returned to this Agent Session. Exceeding the candidate limit, repeating a
 candidate, or naming an unpublished submission rejects the whole finish
 request, so you may correct it and retry.
 """
+    assessment_guidance = ""
+    if config.assessment is not None:
+        assessment_guidance = """\
+After final selection, the Host evaluates only the selected Program on
+held-out Assessment Episodes. Assessment never changes the selected candidate,
+and its results are not returned to this Agent Session.
+
+"""
     public_spec = {
         "id": spec.id,
         "description": spec.description,
@@ -117,6 +125,7 @@ Iterate by inspecting the Program, editing it, submitting it, and using the
 published Feedback.
 
 {finish_guidance}
+{assessment_guidance}\
 Unsubmitted workspace edits are never candidates or the final Program. Do not
 exit before calling finish successfully.
 

--- a/src/evopolicygym/run/progress.py
+++ b/src/evopolicygym/run/progress.py
@@ -197,6 +197,48 @@ class ConsoleProgress:
         if event.name == "validation_failed":
             return ("Validation failed", False)
 
+        if event.name == "assessment_started":
+            submission = _text(fields, "submission_id")
+            episodes = _integer(fields, "episodes")
+            self._evaluation_started[submission] = event.monotonic_ns
+            return (
+                f"{submission} · assessing {episodes} held-out Episodes",
+                True,
+            )
+
+        if event.name == "assessment_episode_completed":
+            submission = _text(fields, "submission_id")
+            completed = _integer(fields, "completed")
+            total = _integer(fields, "total")
+            status = _text(fields, "status")
+            started = self._evaluation_started.get(submission)
+            elapsed = (
+                ""
+                if started is None
+                else f" · {(event.monotonic_ns - started) / 1_000_000_000:.1f}s"
+            )
+            return (
+                f"{submission} · Assessment Episodes {completed}/{total}"
+                f"{elapsed} · {status}",
+                True,
+            )
+
+        if event.name == "assessment_completed":
+            submission = _text(fields, "submission_id")
+            score = _number(fields, "score")
+            failures = _integer(fields, "policy_failures")
+            self._evaluation_started.pop(submission, None)
+            return (
+                f"{submission} · assessment score {score:g}"
+                f" · {failures} Policy failure(s)",
+                False,
+            )
+
+        if event.name == "assessment_failed":
+            submission = _text(fields, "submission_id")
+            self._evaluation_started.pop(submission, None)
+            return (f"{submission} · Assessment failed", False)
+
         if event.name == "run_finished":
             submission = _text(fields, "submission_id")
             return (f"Run finished · selected {submission}", False)

--- a/tests/test_codex_integration.py
+++ b/tests/test_codex_integration.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from evopolicygym.agents import Codex, CodingAgent, resolve_executable
 from evopolicygym.authoring import BenchmarkSpec
-from evopolicygym.run import RunConfig, ValidationConfig
+from evopolicygym.run import AssessmentConfig, RunConfig, ValidationConfig
 from evopolicygym.run._task import build_agent_task
 
 
@@ -120,6 +120,7 @@ class CodexIntegrationTests(unittest.TestCase):
                     episodes_per_candidate=5,
                     max_candidates=3,
                 ),
+                assessment=AssessmentConfig(episodes=7),
             ),
         )
 
@@ -133,6 +134,14 @@ class CodexIntegrationTests(unittest.TestCase):
         )
         self.assertIn("loss (minimize)", task.instructions)
         self.assertIn("argument order", task.instructions)
+        self.assertIn(
+            "Host evaluates only the selected Program on",
+            task.instructions,
+        )
+        self.assertIn(
+            "Assessment never changes the selected candidate",
+            task.instructions,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -91,6 +91,7 @@ from evopolicygym.agents.codex import Codex
 from evopolicygym.evaluation import EvaluationConfig
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import (
+    AssessmentConfig,
     ConsoleProgress,
     RunConfig,
     RunEvent,
@@ -99,6 +100,7 @@ from evopolicygym.run import (
 )
 
 assert EvaluationConfig.__module__ == "evopolicygym.evaluation"
+assert AssessmentConfig.__module__ == "evopolicygym.run"
 assert RunConfig.__module__ == "evopolicygym.run"
 assert ValidationConfig.__module__ == "evopolicygym.run"
 assert ConsoleProgress.__module__ == "evopolicygym.run.progress"
@@ -184,6 +186,20 @@ assert not any(name in sys.modules for name in forbidden)
                     )
                 )
                 for name in imports(validation)
+            )
+        )
+
+    def test_assessment_rules_do_not_select_execution_or_provider(self) -> None:
+        assessment = PACKAGE / "run" / "_assessment.py"
+        self.assertFalse(
+            any(
+                name.startswith(
+                    (
+                        "evopolicygym.execution",
+                        "evopolicygym.agents",
+                    )
+                )
+                for name in imports(assessment)
             )
         )
 

--- a/tests/test_program_evolution.py
+++ b/tests/test_program_evolution.py
@@ -9,6 +9,7 @@ from evopolicygym.errors import EvaluationError
 from evopolicygym.execution.process.agent.runner import AgentExit
 from evopolicygym.program import Program
 from evopolicygym.results import (
+    AssessmentResult,
     EpisodeSummary,
     Feedback,
     RunResult,
@@ -101,6 +102,31 @@ class FakeCandidateSelector:
         return self.selection
 
 
+class FakeFinalAssessor:
+    def __init__(
+        self,
+        result: AssessmentResult | None = None,
+        *,
+        gateway: FakeGateway | None = None,
+        fail: bool = False,
+    ) -> None:
+        self.result = result
+        self.gateway = gateway
+        self.fail = fail
+        self.calls: list[str] = []
+
+    def assess(
+        self,
+        submission: SubmissionResult,
+    ) -> AssessmentResult | None:
+        self.calls.append(submission.submission_id)
+        if self.gateway is not None:
+            assert self.gateway.closed
+        if self.fail:
+            raise EvaluationError("trusted Assessment fixture failure")
+        return self.result
+
+
 class FakeRecorder:
     def __init__(self) -> None:
         self.events: list[tuple[str, dict[str, object]]] = []
@@ -143,6 +169,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
                 gateway=gateway,
                 agent_runner=runner,
                 candidate_selector=FakeCandidateSelector(),
+                final_assessor=FakeFinalAssessor(),
                 recorder=recorder,
                 agent_timeout_seconds=10,
             ).execute()
@@ -177,6 +204,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
                 gateway=gateway,
                 agent_runner=runner,
                 candidate_selector=FakeCandidateSelector(),
+                final_assessor=FakeFinalAssessor(),
                 recorder=recorder,
                 agent_timeout_seconds=10,
             ).execute()
@@ -210,6 +238,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
                     )
                 ),
                 candidate_selector=FakeCandidateSelector(),
+                final_assessor=FakeFinalAssessor(),
                 recorder=recorder,
                 agent_timeout_seconds=10,
             ).execute()
@@ -268,6 +297,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
                     )
                 ),
                 candidate_selector=selector,
+                final_assessor=FakeFinalAssessor(),
                 recorder=recorder,
                 agent_timeout_seconds=10,
             ).execute()
@@ -322,6 +352,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
                 gateway=FakeGateway(),
                 agent_runner=FakeAgentRunner(AgentExit(returncode=0)),
                 candidate_selector=FakeCandidateSelector(fail=True),
+                final_assessor=FakeFinalAssessor(),
                 recorder=recorder,
                 agent_timeout_seconds=10,
             ).execute()
@@ -335,6 +366,67 @@ class ProgramEvolutionRunTests(unittest.TestCase):
         )
         self.assertIsNone(result.validation)
         self.assertEqual(recorder.events[-1][0], "validation_failed")
+
+    def test_assessment_failure_retains_the_selected_final_program(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            program = make_program(Path(temporary))
+            submission = SubmissionResult(
+                submission_id="submission-000001",
+                program=program,
+                episodes_used=1,
+                episodes_remaining=0,
+                feedback=Feedback(score=1.0),
+                episodes=(
+                    EpisodeSummary(
+                        status="completed",
+                        reward=1.0,
+                        steps=1,
+                    ),
+                ),
+            )
+            gateway = FakeGateway()
+            assessor = FakeFinalAssessor(
+                gateway=gateway,
+                fail=True,
+            )
+            recorder = FakeRecorder()
+
+            result = ProgramEvolutionRun(
+                benchmark_id="example/benchmark-v1",
+                initial_program=program,
+                session=FakeSession(
+                    submissions=(submission,),
+                    candidate_submission_ids=(
+                        submission.submission_id,
+                    ),
+                ),
+                gateway=gateway,
+                agent_runner=FakeAgentRunner(AgentExit(returncode=0)),
+                candidate_selector=FakeCandidateSelector(
+                    CandidateSelection(
+                        submission=submission,
+                        validation=None,
+                    )
+                ),
+                final_assessor=assessor,
+                recorder=recorder,
+                agent_timeout_seconds=10,
+            ).execute()
+
+        self.assertEqual(result.terminal_reason, "assessment_failed")
+        self.assertEqual(result.final_program, program)
+        self.assertEqual(
+            result.final_submission_id,
+            submission.submission_id,
+        )
+        self.assertIsNone(result.assessment)
+        self.assertEqual(assessor.calls, [submission.submission_id])
+        self.assertEqual(
+            [name for name, _ in recorder.events][-2:],
+            ["final_submission_selected", "assessment_failed"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_public_contract.py
+++ b/tests/test_public_contract.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import evopolicygym
 from evopolicygym import (
+    AssessmentConfig,
     Benchmark,
     EvaluationConfig,
     EvaluationResult,
@@ -156,6 +157,7 @@ class PublicContractTests(unittest.TestCase):
         self.assertEqual(
             set(evopolicygym.__all__),
             {
+                "AssessmentConfig",
                 "Benchmark",
                 "EvaluationConfig",
                 "EvaluationResult",
@@ -174,6 +176,7 @@ class PublicContractTests(unittest.TestCase):
         self.assertTrue(callable(evaluate))
         self.assertTrue(callable(run))
         self.assertIs(ValidationConfig, evopolicygym.ValidationConfig)
+        self.assertIs(AssessmentConfig, evopolicygym.AssessmentConfig)
 
     def test_policy_and_benchmark_are_structural(self) -> None:
         policy = ConstantPolicy()
@@ -327,6 +330,9 @@ class PublicContractTests(unittest.TestCase):
                 episodes_per_candidate=7,
                 max_candidates=2,
             ),
+            assessment=AssessmentConfig(
+                episodes=11,
+            ),
         )
         self.assertEqual(capped.max_episodes_per_submission, 5)
         self.assertTrue(capped.use_benchmark_skill)
@@ -336,6 +342,10 @@ class PublicContractTests(unittest.TestCase):
                 episodes_per_candidate=7,
                 max_candidates=2,
             ),
+        )
+        self.assertEqual(
+            capped.assessment,
+            AssessmentConfig(episodes=11),
         )
         self.assertEqual(agent.model, "gpt-5")
         with self.assertRaises(ValueError):
@@ -355,6 +365,10 @@ class PublicContractTests(unittest.TestCase):
                     max_candidates=2,
                 ),
             )
+        with self.assertRaises(ValueError):
+            AssessmentConfig(episodes=0)
+        with self.assertRaises(TypeError):
+            RunConfig(assessment=object())  # type: ignore[arg-type]
 
     def test_public_results_compose_without_private_episode_records(self) -> None:
         feedback = Feedback(score=1.0, content={"outcome": "passed"})
@@ -902,6 +916,7 @@ assert artifact.read_text() == "completed=1\\n"
     encoding="utf-8",
 )
 assert not (workspace.parent / "validation").exists()
+assert not (workspace.parent / "assessment").exists()
 finished = call(
     "finish",
     first["result"]["submission_id"],
@@ -913,6 +928,7 @@ assert finished["result"]["candidate_submission_ids"] == [
 ]
 assert finished["result"]["agent_authority_closed"] is True
 assert not (workspace.parent / "validation").exists()
+assert not (workspace.parent / "assessment").exists()
 print("fake-agent-finished")
 """
         with tempfile.TemporaryDirectory() as temporary:
@@ -937,6 +953,7 @@ print("fake-agent-finished")
                         episodes_per_candidate=2,
                         max_candidates=2,
                     ),
+                    assessment=AssessmentConfig(episodes=3),
                     agent_timeout_seconds=10,
                 ),
                 observer=observer,
@@ -950,6 +967,9 @@ print("fake-agent-finished")
             manifest = json.loads((run_directory / "run.json").read_text())
             validation = json.loads(
                 (run_directory / "validation" / "report.json").read_text()
+            )
+            assessment = json.loads(
+                (run_directory / "assessment" / "report.json").read_text()
             )
             retained_workspace = run_directory / "workspace"
             first_record = (
@@ -995,6 +1015,10 @@ print("fake-agent-finished")
             ("submission-000001", "submission-000002"),
         )
         self.assertIsNotNone(result.validation)
+        self.assertIsNotNone(result.assessment)
+        assert result.assessment is not None
+        self.assertEqual(result.assessment.score, 3.0)
+        self.assertEqual(result.assessment.policy_failures, 0)
         self.assertEqual(len(result.submissions), 2)
         self.assertEqual(result.submissions[0].episodes[0].failure, "invalid_action")
         self.assertEqual(result.submissions[1].feedback.score, 1.0)
@@ -1017,10 +1041,16 @@ print("fake-agent-finished")
             2,
         )
         self.assertEqual(
+            [event["event"] for event in events].count(
+                "assessment_episode_completed"
+            ),
+            3,
+        )
+        self.assertEqual(
             [event.name for event in observer.events],
             [event["event"] for event in events],
         )
-        self.assertEqual(manifest["schema"], "evopolicygym/run-record/v2")
+        self.assertEqual(manifest["schema"], "evopolicygym/run-record/v3")
         self.assertEqual(manifest["terminal_reason"], "finished")
         self.assertEqual(manifest["final_submission_id"], "submission-000002")
         self.assertEqual(
@@ -1030,6 +1060,10 @@ print("fake-agent-finished")
         self.assertEqual(
             manifest["validation"],
             {"report": "validation/report.json"},
+        )
+        self.assertEqual(
+            manifest["assessment"],
+            {"report": "assessment/report.json"},
         )
         self.assertEqual(
             validation,
@@ -1062,12 +1096,32 @@ print("fake-agent-finished")
                 "selected_submission_id": "submission-000002",
             },
         )
+        self.assertEqual(
+            assessment,
+            {
+                "schema": "evopolicygym/assessment-report/v1",
+                "submission_id": "submission-000002",
+                "program_digest": (
+                    result.submissions[1].program_digest
+                ),
+                "split": "test",
+                "episodes": 3,
+                "primary_metric": "completed",
+                "score_direction": "maximize",
+                "score": 3.0,
+                "policy_failures": 0,
+            },
+        )
         self.assertFalse(manifest["agent"]["stopped_after_terminal"])
         self.assertEqual(first_record_source, initial_source.encode())
         self.assertEqual(second_record_source, improved_source.encode())
         self.assertEqual(initial_source_record, initial_source.encode())
         self.assertEqual(retained_workspace_source, unsubmitted_source.encode())
         self.assertNotEqual(*feedback_inodes)
+        self.assertFalse((retained_workspace / "assessment").exists())
+        self.assertFalse(
+            (retained_workspace / "feedback" / "assessment").exists()
+        )
         self.assertFalse(control_exists)
 
     def test_trusted_evaluation_failure_consumes_reserved_budget(self) -> None:

--- a/tests/test_run_assessment.py
+++ b/tests/test_run_assessment.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+
+from evopolicygym.authoring import (
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+)
+from evopolicygym.benchmark import Benchmark
+from evopolicygym.errors import EvaluationError
+from evopolicygym.evaluation import EvaluationConfig
+from evopolicygym.program import Program
+from evopolicygym.results import (
+    EpisodeSummary,
+    EvaluationResult,
+    Feedback,
+    SubmissionResult,
+)
+from evopolicygym.run import AssessmentConfig, RunConfig
+from evopolicygym.run._assessment import (
+    ProgramAssessor,
+    _assessment_seed,
+)
+from evopolicygym.run._validation import _validation_seed
+
+
+class StubBenchmark:
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return BenchmarkSpec(
+            id="example/assessment-v1",
+            description="Assessment fixture.",
+            observation_space=None,
+            action_space=None,
+            metadata={},
+            max_episode_steps=1,
+            primary_metric="reward",
+            score_direction="maximize",
+        )
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        del split
+        return tuple(
+            EpisodeSpec(environment_seed=seed + index)
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        del episode
+        raise AssertionError("the fake evaluator owns evaluation")
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        del episodes
+        raise AssertionError("the fake evaluator owns evaluation")
+
+
+class FakeEvaluator:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.configs: list[EvaluationConfig] = []
+
+    def evaluate(
+        self,
+        program: Program,
+        benchmark: Benchmark,
+        config: EvaluationConfig,
+        *,
+        episode_completed: (
+            Callable[[int, int, EpisodeSummary], None] | None
+        ) = None,
+    ) -> EvaluationResult:
+        self.configs.append(config)
+        if self.fail:
+            raise EvaluationError("trusted fixture failure")
+        episodes = tuple(
+            EpisodeSummary(
+                status="policy_failed",
+                reward=None,
+                steps=0,
+                failure="exception",
+            )
+            if index == 0
+            else EpisodeSummary(
+                status="completed",
+                reward=5.0,
+                steps=1,
+            )
+            for index in range(config.episodes)
+        )
+        if episode_completed is not None:
+            for index, episode in enumerate(episodes, start=1):
+                episode_completed(index, len(episodes), episode)
+        return EvaluationResult(
+            benchmark_id=benchmark.spec.id,
+            program_digest=program.digest,
+            feedback=Feedback(score=5.0),
+            episodes=episodes,
+        )
+
+
+class FakeRecorder:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def record_event(
+        self,
+        event: str,
+        fields: Mapping[str, object],
+    ) -> None:
+        self.events.append((event, dict(fields)))
+
+
+def make_submission(root: Path) -> SubmissionResult:
+    source = root / "program"
+    source.mkdir()
+    (source / "policy.py").write_text(
+        "def make_policy(context):\n"
+        "    return object()\n",
+        encoding="utf-8",
+    )
+    return SubmissionResult(
+        submission_id="submission-000001",
+        program=Program.from_directory(source),
+        episodes_used=1,
+        episodes_remaining=0,
+        feedback=Feedback(score=1.0),
+        episodes=(
+            EpisodeSummary(
+                status="completed",
+                reward=1.0,
+                steps=1,
+            ),
+        ),
+    )
+
+
+class ProgramAssessorTests(unittest.TestCase):
+    def test_assessment_evaluates_only_the_selected_submission(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            submission = make_submission(Path(temporary))
+            evaluator = FakeEvaluator()
+            recorder = FakeRecorder()
+            benchmark = StubBenchmark()
+            assessor = ProgramAssessor(
+                evaluator=evaluator,
+                benchmark=benchmark,
+                spec=benchmark.spec,
+                config=RunConfig(
+                    assessment=AssessmentConfig(
+                        split="held-out",
+                        episodes=3,
+                    ),
+                    seed=19,
+                ),
+                recorder=recorder,
+            )
+
+            result = assessor.assess(submission)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.submission_id, submission.submission_id)
+        self.assertEqual(result.program_digest, submission.program_digest)
+        self.assertEqual(result.split, "held-out")
+        self.assertEqual(result.episodes, 3)
+        self.assertEqual(result.score, 5.0)
+        self.assertEqual(result.policy_failures, 1)
+        self.assertEqual(len(evaluator.configs), 1)
+        self.assertEqual(evaluator.configs[0].split, "held-out")
+        self.assertEqual(evaluator.configs[0].episodes, 3)
+        self.assertEqual(
+            [name for name, _ in recorder.events],
+            [
+                "assessment_started",
+                "assessment_episode_completed",
+                "assessment_episode_completed",
+                "assessment_episode_completed",
+                "assessment_completed",
+            ],
+        )
+
+    def test_assessment_uses_an_independent_seed_domain(self) -> None:
+        self.assertNotEqual(
+            _assessment_seed(7),
+            _validation_seed(7),
+        )
+
+    def test_no_assessment_config_performs_no_evaluation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            submission = make_submission(Path(temporary))
+            evaluator = FakeEvaluator()
+            recorder = FakeRecorder()
+            benchmark = StubBenchmark()
+
+            result = ProgramAssessor(
+                evaluator=evaluator,
+                benchmark=benchmark,
+                spec=benchmark.spec,
+                config=RunConfig(),
+                recorder=recorder,
+            ).assess(submission)
+
+        self.assertIsNone(result)
+        self.assertEqual(evaluator.configs, [])
+        self.assertEqual(recorder.events, [])
+
+    def test_trusted_assessment_failure_produces_no_result(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            submission = make_submission(Path(temporary))
+            benchmark = StubBenchmark()
+            assessor = ProgramAssessor(
+                evaluator=FakeEvaluator(fail=True),
+                benchmark=benchmark,
+                spec=benchmark.spec,
+                config=RunConfig(
+                    assessment=AssessmentConfig(episodes=2),
+                ),
+                recorder=FakeRecorder(),
+            )
+
+            with self.assertRaises(EvaluationError):
+                assessor.assess(submission)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_progress.py
+++ b/tests/test_run_progress.py
@@ -241,6 +241,55 @@ class ConsoleProgressTests(unittest.TestCase):
             ],
         )
 
+    def test_plain_progress_renders_held_out_assessment(self) -> None:
+        output = io.StringIO()
+        progress = ConsoleProgress(output, mode="plain")
+
+        progress.on_event(
+            event(
+                "assessment_started",
+                1_000_000_000,
+                submission_id="submission-000002",
+                episodes=4,
+            )
+        )
+        progress.on_event(
+            event(
+                "assessment_episode_completed",
+                1_500_000_000,
+                submission_id="submission-000002",
+                completed=1,
+                total=4,
+                status="completed",
+            )
+        )
+        progress.on_event(
+            event(
+                "assessment_completed",
+                2_000_000_000,
+                submission_id="submission-000002",
+                score=500.0,
+                policy_failures=0,
+            )
+        )
+
+        self.assertEqual(
+            output.getvalue().splitlines(),
+            [
+                (
+                    "submission-000002 · assessing 4 held-out Episodes"
+                ),
+                (
+                    "submission-000002 · Assessment Episodes 1/4"
+                    " · 0.5s · completed"
+                ),
+                (
+                    "submission-000002 · assessment score 500"
+                    " · 0 Policy failure(s)"
+                ),
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Purpose

Add an optional held-out Assessment phase after final candidate selection, so
a Run can report final benchmark evidence without letting that evidence
influence Agent search or candidate selection.

## What changed

- add public `AssessmentConfig` and aggregate `AssessmentResult`
- evaluate only the selected final Program after the Agent process tree and
  Session gateway are closed
- derive Assessment Episodes from an independent Run-seed domain
- retain the final Program on trusted Assessment failure, terminate as
  `assessment_failed`, and never retry, rerank, or fall back
- persist Host-only progress events plus `assessment/report.json`; bump
  `run.json` to `evopolicygym/run-record/v3`
- keep Assessment feedback, artifacts, Episode identity, seeds, traces, paths,
  and execution evidence out of the Agent workspace
- expose Assessment options in the CartPole/Balatro scripts and update
  architecture, README, changelog, and project skill guidance

## Impact

Existing Runs are unchanged unless `RunConfig.assessment` is configured.
Assessment consumes its own Episode allocation and does not affect the Agent
search budget. The Agent Session protocol remains `agent-session/v2`.

## Validation

- `ruff check src tests scripts`
- `mypy` — 52 source files
- `python -m unittest discover -s tests` — 83 tests
- CartPole: Ruff, strict mypy, and 5 tests
- `UV_OFFLINE=1 uv build`
- `UV_OFFLINE=1 uv build environments/cartpole`
- `git diff --check`

## Limitation

`ProcessExecution` is still non-isolated. This PR provides lifecycle and
publication separation, not cryptographic secrecy; truly hidden cases still
require future remote execution or whole-Run virtualization.
