### PR TITLE
benchmarks: add standard MiniGrid environments

### DIFF
--- a/environments/minigrid/README.md
+++ b/environments/minigrid/README.md
@@ -1,0 +1,14 @@
+# MiniGrid environments
+
+MiniGrid Benchmark distributions exercise partially observable navigation,
+memory, and planning through the public EvoPolicyGym authoring surface.
+
+Suites are grouped below this directory using the upstream MiniGrid taxonomy:
+
+```text
+minigrid/
+└── memory/
+```
+
+Each leaf is independently installable. The collection directory is not a
+Python project.

--- a/environments/minigrid/minigrid/README.md
+++ b/environments/minigrid/minigrid/README.md
@@ -1,0 +1,10 @@
+# MiniGrid suite
+
+The MiniGrid suite contains compact language-conditioned grid worlds with
+egocentric observations and discrete actions.
+
+| Benchmark | Capability |
+| --- | --- |
+| [DoorKey](doorkey/) | Explore, collect a key, unlock a door, and reach a goal |
+| [KeyCorridor](keycorridor/) | Search multiple rooms for a matching key and target object |
+| [Memory](memory/) | Remember an object across a partially observable corridor |

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/.gitignore
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/README.md
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/README.md
@@ -1,0 +1,26 @@
+# MiniGrid BlockedUnlockPickup Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid BlockedUnlockPickup](https://minigrid.farama.org/environments/minigrid/BlockedUnlockPickupEnv/)
+long-horizon manipulation task.
+
+The Policy must move the ball obstructing a locked door, acquire the
+matching-color key, unlock the second room, and pick up the mission box.
+Feedback and the bounded semantic `trace.jsonl` expose the public progress
+ladder without publishing Episode seeds, private identity, or Host paths.
+
+```python
+from minigrid_blocked_unlock_pickup import (
+    BlockedUnlockPickupBenchmark,
+    baseline_program,
+)
+
+benchmark = BlockedUnlockPickupBenchmark()
+program = baseline_program()
+```
+
+The packaged baseline builds a relative map from Policy-visible observations
+and implements the complete object-moving and unlocking state machine. Tests
+using `ProcessExecution.unsafe()` execute trusted packaged code only; that
+backend is not a sandbox.
+

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/pyproject.toml
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-blocked-unlock-pickup"
+version = "0.1.0"
+description = "The MiniGrid BlockedUnlockPickup Benchmark for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_blocked_unlock_pickup"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/__init__.py
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/__init__.py
@@ -1,0 +1,7 @@
+"""The public BlockedUnlockPickup Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import BlockedUnlockPickupBenchmark
+
+__all__ = ["BlockedUnlockPickupBenchmark", "baseline_program"]
+

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/baseline.py
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/baseline.py
@@ -1,0 +1,22 @@
+"""Packaged initial Program for BlockedUnlockPickup Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_blocked_unlock_pickup").joinpath(
+        "programs",
+        "baseline",
+    )
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/benchmark.py
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/benchmark.py
@@ -1,0 +1,414 @@
+"""BlockedUnlockPickup with deterministic plans and milestone traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .environment import BlockedUnlockPickupEnvironment
+
+_EPISODE_SEED_DOMAIN = (
+    b"evopolicygym-minigrid-blocked-unlock-pickup/episode-seed/v1\0"
+)
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_ENVIRONMENT_ID = "MiniGrid-BlockedUnlockPickup-v0"
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_MISSIONS = tuple(f"pick up the {color} box" for color in _COLOR_NAMES)
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRIC_FIELDS = {
+    "blocker_found",
+    "blocker_moved",
+    "key_found",
+    "key_picked_up",
+    "door_opened",
+    "target_found",
+    "success",
+}
+
+
+class BlockedUnlockPickupBenchmark:
+    """Success rate for the complete blocked-door manipulation chain."""
+
+    def __init__(self) -> None:
+        self._spec = _benchmark_spec()
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return BlockedUnlockPickupEnvironment(episode)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        counts = {
+            name: _milestone_count(records, name)
+            for name in _METRIC_FIELDS - {"success"}
+        }
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        content: dict[str, PolicyValue] = {
+            "summary": (
+                f"Moved the blocker, unlocked the room, and collected the "
+                f"target in {successes}/{len(records)} Episodes "
+                f"({score:.3f} success rate)."
+            ),
+            "success_rate": score,
+            "mean_return": mean_return,
+            "mean_steps": mean_steps,
+            "mean_steps_on_success": (
+                statistics.fmean(record.steps for record in successful)
+                if successful
+                else None
+            ),
+            "episodes": len(records),
+            "successful_episodes": successes,
+            "truncated_episodes": truncations,
+            "policy_failures": failures,
+            "traced_episodes": len(traced),
+            "trace_episodes_omitted": len(records) - len(traced),
+            "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+            "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+        }
+        for name, value in counts.items():
+            content[f"{name}_episodes"] = value
+            content[f"{name}_rate"] = value / len(records)
+        return Feedback(
+            score=score,
+            content=content,
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec() -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/BlockedUnlockPickup-v0/success-rate-v1",
+        description=(
+            "Move the ball obstructing a locked door, acquire the matching "
+            "key, unlock the second room, and pick up the mission box."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "values": list(_MISSIONS)},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": _ENVIRONMENT_ID,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "room_size": 6,
+            "num_rows": 1,
+            "num_columns": 2,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission_template": "pick up the {color} box",
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for picking up the target box; "
+                "zero for timeout"
+            ),
+        },
+        max_episode_steps=16 * 6**2,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _milestone_count(
+    records: Sequence[EpisodeRecord],
+    name: str,
+) -> int:
+    return sum(
+        any(
+            type(transition.step.metrics) is dict
+            and transition.step.metrics.get(name) is True
+            for transition in record.transitions
+        )
+        for record in records
+    )
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError(
+                    "BlockedUnlockPickup trace Action is invalid"
+                )
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if (
+        type(metrics) is not dict
+        or set(metrics) != _METRIC_FIELDS
+        or any(type(value) is not bool for value in metrics.values())
+    ):
+        raise ValueError("BlockedUnlockPickup trace metrics are invalid")
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError("BlockedUnlockPickup trace observation is invalid")
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("BlockedUnlockPickup trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("BlockedUnlockPickup trace direction is invalid")
+    if type(mission) is not str or mission not in _MISSIONS:
+        raise ValueError("BlockedUnlockPickup trace mission is invalid")
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError(
+                    "BlockedUnlockPickup trace image codes are invalid"
+                )
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["BlockedUnlockPickupBenchmark"]

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/environment.py
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/environment.py
@@ -1,0 +1,261 @@
+"""One fresh BlockedUnlockPickup Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+_ENVIRONMENT_ID = "MiniGrid-BlockedUnlockPickup-v0"
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_DOOR = 4
+_KEY = 5
+_BALL = 6
+_BOX = 7
+_LOCKED = 2
+
+
+@dataclass(frozen=True, slots=True)
+class _Facts:
+    target: tuple[int, int]
+    carried: tuple[int, int] | None
+    key_visible: bool
+    blocker_visible: bool
+    target_visible: bool
+    front_object: int
+    front_locked_door_color: int | None
+
+
+class BlockedUnlockPickupEnvironment:
+    """Strict seeded adapter around the upstream environment."""
+
+    def __init__(self, episode: EpisodeSpec) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if episode.scenario is not None:
+            raise ValueError(
+                "BlockedUnlockPickup has no Episode scenario overrides"
+            )
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(_ENVIRONMENT_ID),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._target: tuple[int, int] | None = None
+        self._front_object = 0
+        self._front_locked_door_color: int | None = None
+        self._carried: tuple[int, int] | None = None
+        self._key_found = False
+        self._blocker_found = False
+        self._target_found = False
+        self._blocker_moved = False
+        self._key_picked_up = False
+        self._door_opened = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._target = facts.target
+        self._update(facts)
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        moved_blocker = bool(
+            action == 3
+            and self._carried is None
+            and self._front_object_is_blocker()
+        )
+        picked_key = bool(
+            action == 3
+            and self._carried is None
+            and self._front_object_is_key()
+        )
+        opened_door = bool(
+            action == 5
+            and self._front_locked_door_color is not None
+            and self._carried
+            == (_KEY, self._front_locked_door_color)
+        )
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError(
+                "MiniGrid BlockedUnlockPickup returned invalid flags"
+            )
+        number = _number(reward)
+        public, facts = _observation(observation)
+        if facts.target != self._target:
+            raise RuntimeError(
+                "MiniGrid BlockedUnlockPickup changed its mission"
+            )
+        self._blocker_moved = self._blocker_moved or moved_blocker
+        self._key_picked_up = self._key_picked_up or picked_key
+        self._door_opened = self._door_opened or opened_door
+        self._update(facts)
+        success = bool(terminated and number > 0.0)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "blocker_found": self._blocker_found,
+                "blocker_moved": self._blocker_moved,
+                "key_found": self._key_found,
+                "key_picked_up": self._key_picked_up,
+                "door_opened": self._door_opened,
+                "target_found": self._target_found,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+    def _update(self, facts: _Facts) -> None:
+        self._carried = facts.carried
+        self._front_object = facts.front_object
+        self._front_locked_door_color = facts.front_locked_door_color
+        self._key_found = self._key_found or facts.key_visible
+        self._blocker_found = self._blocker_found or facts.blocker_visible
+        self._target_found = self._target_found or facts.target_visible
+
+    def _front_object_is_blocker(self) -> bool:
+        return self._front_object == _BALL
+
+    def _front_object_is_key(self) -> bool:
+        return self._front_object == _KEY
+
+
+def _observation(value: object) -> tuple[dict[str, PolicyValue], _Facts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError(
+            "MiniGrid BlockedUnlockPickup returned invalid observation"
+        )
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError(
+            "MiniGrid BlockedUnlockPickup returned invalid image"
+        )
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid BlockedUnlockPickup returned invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError(
+            "MiniGrid BlockedUnlockPickup returned invalid direction"
+        )
+    mission = value["mission"]
+    if type(mission) is not str:
+        raise RuntimeError(
+            "MiniGrid BlockedUnlockPickup returned invalid mission"
+        )
+    target = _target(mission)
+    carried_code = int(image[3, 6, 0])
+    carried = (
+        (carried_code, int(image[3, 6, 1]))
+        if carried_code in {_KEY, _BALL, _BOX}
+        else None
+    )
+    front_locked_door_color = (
+        int(image[3, 5, 1])
+        if image[3, 5, 0] == _DOOR
+        and image[3, 5, 2] == _LOCKED
+        else None
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _Facts(
+            target=target,
+            carried=carried,
+            key_visible=bool(numpy.any(image[:, :, 0] == _KEY)),
+            blocker_visible=bool(numpy.any(image[:, :, 0] == _BALL)),
+            target_visible=bool(
+                numpy.any(
+                    (image[:, :, 0] == target[0])
+                    & (image[:, :, 1] == target[1])
+                )
+            ),
+            front_object=int(image[3, 5, 0]),
+            front_locked_door_color=front_locked_door_color,
+        ),
+    )
+
+
+def _target(mission: str) -> tuple[int, int]:
+    prefix = "pick up the "
+    if not mission.startswith(prefix):
+        raise RuntimeError(
+            "MiniGrid BlockedUnlockPickup returned invalid mission"
+        )
+    parts = mission.removeprefix(prefix).split(" ")
+    kinds = {"key": _KEY, "box": _BOX}
+    if len(parts) != 2 or parts[0] not in _COLORS or parts[1] not in kinds:
+        raise RuntimeError(
+            "MiniGrid BlockedUnlockPickup returned invalid mission"
+        )
+    return kinds[parts[1]], _COLORS.index(parts[0])
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(
+            "MiniGrid BlockedUnlockPickup returned invalid reward"
+        )
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(
+            "MiniGrid BlockedUnlockPickup returned non-finite reward"
+        )
+    return number
+
+
+__all__ = ["BlockedUnlockPickupEnvironment"]

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/programs/baseline/policy.py
@@ -1,0 +1,567 @@
+"""A public-observation planner for BlockedUnlockPickup."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_PICKUP = 3
+_DROP = 4
+_TOGGLE = 5
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Move the blocker, unlock the room, and collect the mission box."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._target: tuple[int, int] | None = None
+        self._carried: tuple[int, int] | None = None
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction, mission = self._read_observation(observation)
+        target = self._read_target(mission)
+        if self._target is None:
+            self._target = target
+        elif self._target != target:
+            raise ValueError("mission changed during the Episode")
+        self._integrate(image, direction)
+
+        if self._carried is not None:
+            carried_type, carried_color = self._carried
+            if carried_type == self._objects["key"]:
+                door = self._known_door(
+                    color=carried_color,
+                    state=self._states["locked"],
+                )
+                if door is not None:
+                    return self._interact(
+                        door,
+                        action=_TOGGLE,
+                        direction=direction,
+                    )
+            return self._drop_safely(direction)
+
+        target_position = self._known_matching(target)
+        if (
+            target_position is not None
+            and self._best_approach(target_position) is not None
+        ):
+            return self._interact(
+                target_position,
+                action=_PICKUP,
+                direction=direction,
+            )
+
+        locked_door = self._known_door(state=self._states["locked"])
+        if locked_door is not None:
+            blocker = self._door_blocker(locked_door)
+            if blocker is not None:
+                return self._interact(
+                    blocker,
+                    action=_PICKUP,
+                    direction=direction,
+                )
+            door_color = self._grid[locked_door][1]
+            key = self._known_matching(
+                (self._objects["key"], door_color)
+            )
+            if key is not None:
+                return self._interact(
+                    key,
+                    action=_PICKUP,
+                    direction=direction,
+                )
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int, str]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        mission = observation["mission"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        if type(mission) is not str:
+            raise ValueError("observation mission is invalid")
+        return image, direction, mission
+
+    def _read_target(self, mission: str) -> tuple[int, int]:
+        prefix = "pick up the "
+        if not mission.startswith(prefix):
+            raise ValueError("observation mission is invalid")
+        parts = mission.removeprefix(prefix).split(" ")
+        if (
+            len(parts) != 2
+            or parts[0] not in self._colors
+            or parts[1] not in {"box", "key"}
+        ):
+            raise ValueError("observation mission is invalid")
+        return self._objects[parts[1]], self._colors[parts[0]]
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+        carried_types = {
+            self._objects["key"],
+            self._objects["ball"],
+            self._objects["box"],
+        }
+        self._carried = None
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    if object_code in carried_types:
+                        self._carried = (object_code, color_code)
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_matching(
+        self,
+        target: tuple[int, int],
+    ) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[:2] == target
+            ),
+            None,
+        )
+
+    def _known_door(
+        self,
+        *,
+        color: int | None = None,
+        state: int | None = None,
+    ) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == self._objects["door"]
+                and (color is None or cell[1] == color)
+                and (state is None or cell[2] == state)
+            ),
+            None,
+        )
+
+    def _door_blocker(self, door: Position) -> Position | None:
+        for _, neighbor in _neighbors(door):
+            cell = self._grid.get(neighbor)
+            if (
+                cell is not None
+                and cell[0] == self._objects["ball"]
+                and self._best_approach(neighbor) is not None
+            ):
+                return neighbor
+        return None
+
+    def _interact(
+        self,
+        target: Position,
+        *,
+        action: int,
+        direction: int,
+    ) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+        target_direction = _direction_between(approach_position, target)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        if action == _PICKUP:
+            cell = self._grid[target]
+            self._carried = (cell[0], cell[1])
+            self._grid[target] = (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        elif action == _TOGGLE:
+            cell = self._grid[target]
+            self._grid[target] = (
+                self._objects["door"],
+                cell[1],
+                self._states["open"],
+            )
+        return action
+
+    def _drop_safely(self, direction: int) -> int:
+        plan = self._best_drop_plan(prefer_away_from_doors=True)
+        if plan is None:
+            plan = self._best_drop_plan(prefer_away_from_doors=False)
+        if plan is None:
+            return self._explore(direction)
+        approach, drop_position, path = plan
+        if path:
+            return self._follow(path, direction)
+        drop_direction = _direction_between(approach, drop_position)
+        turn = _turn_toward(direction, drop_direction)
+        if turn is not None:
+            return turn
+        if self._carried is None:
+            raise ValueError("carried object disappeared")
+        self._grid[drop_position] = (
+            self._carried[0],
+            self._carried[1],
+            self._states["open"],
+        )
+        self._carried = None
+        return _DROP
+
+    def _best_drop_plan(
+        self,
+        *,
+        prefer_away_from_doors: bool,
+    ) -> tuple[Position, Position, tuple[Position, ...]] | None:
+        doors = tuple(
+            position
+            for position, cell in self._grid.items()
+            if cell[0] == self._objects["door"]
+        )
+        candidates: list[
+            tuple[int, Position, Position, tuple[Position, ...]]
+        ] = []
+        for drop_position, cell in self._grid.items():
+            if cell[0] not in {
+                self._objects["empty"],
+                self._objects["floor"],
+            }:
+                continue
+            if prefer_away_from_doors and any(
+                max(
+                    abs(drop_position[0] - door[0]),
+                    abs(drop_position[1] - door[1]),
+                )
+                <= 1
+                for door in doors
+            ):
+                continue
+            for _, approach in _neighbors(drop_position):
+                if not self._traversable(approach):
+                    continue
+                path = self._shortest_path(approach)
+                if path is not None:
+                    candidates.append(
+                        (
+                            len(path),
+                            approach,
+                            drop_position,
+                            path,
+                        )
+                    )
+        if not candidates:
+            return None
+        _, approach, drop_position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        return approach, drop_position, path
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(
+            frontiers,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        if turn is not None:
+            return turn
+        return _RIGHT
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        if cell is None:
+            return False
+        return bool(
+            cell[0]
+            in {
+                self._objects["empty"],
+                self._objects["floor"],
+                self._objects["goal"],
+            }
+            or (
+                cell[0] == self._objects["door"]
+                and cell[2] == self._states["open"]
+            )
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_colors = parameters.get("color_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_colors) is not dict
+        or set(raw_colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in raw_colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in raw_colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/tests/test_blocked_unlock_pickup.py
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/tests/test_blocked_unlock_pickup.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_blocked_unlock_pickup import (
+    BlockedUnlockPickupBenchmark,
+    baseline_program,
+)
+
+
+class BlockedUnlockPickupTests(unittest.TestCase):
+    def test_spec_and_split_planning(self) -> None:
+        benchmark = BlockedUnlockPickupBenchmark()
+        self.assertEqual(
+            benchmark.spec.id,
+            "minigrid/BlockedUnlockPickup-v0/success-rate-v1",
+        )
+        self.assertEqual(benchmark.spec.max_episode_steps, 576)
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertEqual(train, repeated)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+
+    def test_environment_contract_and_invalid_actions(self) -> None:
+        benchmark = BlockedUnlockPickupBenchmark()
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 5, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertIsInstance(observation["image"], TensorValue)
+            self.assertTrue(
+                str(observation["mission"]).startswith("pick up the ")
+            )
+            with self.assertRaises(InvalidAction):
+                environment.step(7)
+        finally:
+            environment.close()
+            environment.close()
+
+    def test_scenario_override_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            BlockedUnlockPickupBenchmark().make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"room_size": 8})
+            )
+
+    def test_feedback_keeps_identity_private(self) -> None:
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        feedback = BlockedUnlockPickupBenchmark().feedback((failed,))
+        trace = feedback.artifacts[0].read_bytes()
+        self.assertEqual(feedback.score, 0.0)
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+        self.assertNotIn(b'"scenario"', trace)
+
+    def test_baseline_completes_public_progress_ladder(self) -> None:
+        result = evaluate(
+            baseline_program(),
+            BlockedUnlockPickupBenchmark(),
+            execution=ProcessExecution.unsafe(),
+            config=EvaluationConfig(
+                split="validation",
+                episodes=12,
+                seed=5,
+                episode_timeout_seconds=10,
+            ),
+        )
+        self.assertEqual(result.feedback.score, 1.0)
+        self.assertIsInstance(result.feedback.content, dict)
+        assert isinstance(result.feedback.content, dict)
+        for field in (
+            "blocker_moved_rate",
+            "key_picked_up_rate",
+            "door_opened_rate",
+            "target_found_rate",
+        ):
+            self.assertEqual(result.feedback.content[field], 1.0)
+        self.assertEqual(
+            result.feedback.artifacts[0].name,
+            "trace.jsonl",
+        )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "pick up the purple box",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/uv.lock
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-blocked-unlock-pickup"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/crossing/.gitignore
+++ b/environments/minigrid/minigrid/crossing/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/crossing/README.md
+++ b/environments/minigrid/minigrid/crossing/README.md
@@ -1,0 +1,18 @@
+# MiniGrid Crossing Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the MiniGrid
+`LavaCrossing` and `SimpleCrossing` registrations. All eight upstream
+size/crossing/obstacle combinations are explicit profiles.
+
+```python
+from minigrid_crossing import CrossingBenchmark, CrossingConfig
+
+benchmark = CrossingBenchmark(CrossingConfig(profile="lava-S9-N3"))
+```
+
+The Policy must safely discover openings through generated rivers and reach
+the opposite-corner goal. Feedback reports goal discovery and hazard entry;
+the bounded semantic trace contains no seeds, private identity, or Host paths.
+The packaged baseline never moves into an unknown or observed obstacle cell.
+Trusted baseline tests use `ProcessExecution.unsafe()`, which is not a sandbox.
+

--- a/environments/minigrid/minigrid/crossing/pyproject.toml
+++ b/environments/minigrid/minigrid/crossing/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-crossing"
+version = "0.1.0"
+description = "The MiniGrid Crossing Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_crossing"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/crossing/src/minigrid_crossing/__init__.py
+++ b/environments/minigrid/minigrid/crossing/src/minigrid_crossing/__init__.py
@@ -1,0 +1,8 @@
+"""The public MiniGrid Crossing Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import CrossingBenchmark
+from .config import CrossingConfig
+
+__all__ = ["CrossingBenchmark", "CrossingConfig", "baseline_program"]
+

--- a/environments/minigrid/minigrid/crossing/src/minigrid_crossing/baseline.py
+++ b/environments/minigrid/minigrid/crossing/src/minigrid_crossing/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid Crossing Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_crossing").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/crossing/src/minigrid_crossing/benchmark.py
+++ b/environments/minigrid/minigrid/crossing/src/minigrid_crossing/benchmark.py
@@ -1,0 +1,331 @@
+"""MiniGrid Crossing with deterministic plans and safety traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import CrossingConfig
+from .environment import CrossingEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-minigrid-crossing/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_OBJECTS = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATES = ("open", "closed", "locked")
+_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTIONS: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRICS = {"goal_found", "hazard_entered", "success"}
+
+
+class CrossingBenchmark:
+    """Safe-navigation success rate across wall or lava rivers."""
+
+    def __init__(self, config: CrossingConfig | None = None) -> None:
+        if config is None:
+            config = CrossingConfig()
+        if type(config) is not CrossingConfig:
+            raise TypeError("config must be CrossingConfig")
+        self._config = config
+        self._spec = _spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return CrossingEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successes = sum(_success(record) for record in records)
+        score = successes / len(records)
+        goal_found = sum(_reached(r, "goal_found") for r in records)
+        hazards = sum(_reached(r, "hazard_entered") for r in records)
+        traced = records[:4]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the goal in {successes}/{len(records)} Episodes "
+                    f"({score:.3f} success rate); {hazards} entered a hazard."
+                ),
+                "success_rate": score,
+                "goal_found_rate": goal_found / len(records),
+                "hazard_rate": hazards / len(records),
+                "mean_return": statistics.fmean(
+                    r.total_reward if r.policy_failure is None else 0.0
+                    for r in records
+                ),
+                "mean_steps": statistics.fmean(r.steps for r in records),
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "hazard_episodes": hazards,
+                "truncated_episodes": sum(_truncated(r) for r in records),
+                "policy_failures": sum(
+                    r.policy_failure is not None for r in records
+                ),
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+            },
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec(config: CrossingConfig) -> BenchmarkSpec:
+    mission = (
+        "avoid the lava and get to the green goal square"
+        if config.obstacle_type == "lava"
+        else "find the opening and get to the green goal square"
+    )
+    return BenchmarkSpec(
+        id="minigrid/Crossing-v0/success-rate-v1",
+        description=(
+            "Discover the openings through a generated sequence of wall or "
+            "lava rivers and safely reach the opposite-corner goal."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "constant": mission},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTIONS,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "size": config.size,
+            "crossings": config.crossings,
+            "obstacle_type": config.obstacle_type,
+            "start_position": [1, 1],
+            "goal_position": [config.size - 2, config.size - 2],
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": mission,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECTS)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLORS)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATES)
+            },
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _success(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _reached(record: EpisodeRecord, name: str) -> bool:
+    return any(
+        type(item.step.metrics) is dict
+        and item.step.metrics.get(name) is True
+        for item in record.transitions
+    )
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _success(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                }
+            )
+        )
+        indices = (
+            tuple(range(record.steps))
+            if record.steps <= 160
+            else (*range(128), *range(record.steps - 32, record.steps))
+        )
+        for index in indices:
+            item = record.transitions[index]
+            if type(item.action) is not int or not 0 <= item.action <= 6:
+                raise ValueError("MiniGrid Crossing trace Action is invalid")
+            if (
+                type(item.step.metrics) is not dict
+                or set(item.step.metrics) != _METRICS
+            ):
+                raise ValueError("MiniGrid Crossing trace metrics are invalid")
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": index,
+                        "action": item.action,
+                        "action_meaning": _ACTIONS[str(item.action)],
+                        "reward": item.step.reward,
+                        "next_observation": _trace_observation(
+                            item.step.observation
+                        ),
+                        "terminated": item.step.terminated,
+                        "truncated": item.step.truncated,
+                        "metrics": item.step.metrics,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_observation(value: PolicyValue) -> dict[str, PolicyValue]:
+    if type(value) is not dict:
+        raise ValueError("MiniGrid Crossing trace observation is invalid")
+    image = value.get("image")
+    direction = value.get("direction")
+    mission = value.get("mission")
+    if (
+        type(image) is not TensorValue
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+        or type(direction) is not int
+        or type(mission) is not str
+    ):
+        raise ValueError("MiniGrid Crossing trace observation is invalid")
+    rows: list[PolicyValue] = []
+    for y in range(7):
+        rows.append(
+            "".join(
+                _SYMBOLS[image.data[(x * 7 + y) * 3]]
+                for x in range(7)
+            )
+        )
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+    }
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
+__all__ = ["CrossingBenchmark"]

--- a/environments/minigrid/minigrid/crossing/src/minigrid_crossing/config.py
+++ b/environments/minigrid/minigrid/crossing/src/minigrid_crossing/config.py
@@ -1,0 +1,52 @@
+"""Typed, public MiniGrid Crossing environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int, int, str]] = {
+    "lava-S9-N1": ("MiniGrid-LavaCrossingS9N1-v0", 9, 1, "lava"),
+    "lava-S9-N2": ("MiniGrid-LavaCrossingS9N2-v0", 9, 2, "lava"),
+    "lava-S9-N3": ("MiniGrid-LavaCrossingS9N3-v0", 9, 3, "lava"),
+    "lava-S11-N5": ("MiniGrid-LavaCrossingS11N5-v0", 11, 5, "lava"),
+    "wall-S9-N1": ("MiniGrid-SimpleCrossingS9N1-v0", 9, 1, "wall"),
+    "wall-S9-N2": ("MiniGrid-SimpleCrossingS9N2-v0", 9, 2, "wall"),
+    "wall-S9-N3": ("MiniGrid-SimpleCrossingS9N3-v0", 9, 3, "wall"),
+    "wall-S11-N5": ("MiniGrid-SimpleCrossingS11N5-v0", 11, 5, "wall"),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CrossingConfig:
+    """Parameters defining one Crossing Benchmark identity."""
+
+    profile: str = "lava-S9-N3"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        return _PROFILES[self.profile][0]
+
+    @property
+    def size(self) -> int:
+        return _PROFILES[self.profile][1]
+
+    @property
+    def crossings(self) -> int:
+        return _PROFILES[self.profile][2]
+
+    @property
+    def obstacle_type(self) -> str:
+        return _PROFILES[self.profile][3]
+
+    @property
+    def max_episode_steps(self) -> int:
+        return 4 * self.size**2
+
+
+__all__ = ["CrossingConfig"]
+

--- a/environments/minigrid/minigrid/crossing/src/minigrid_crossing/environment.py
+++ b/environments/minigrid/minigrid/crossing/src/minigrid_crossing/environment.py
@@ -1,0 +1,151 @@
+"""One fresh MiniGrid Crossing Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import CrossingConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_GOAL = 8
+
+
+@dataclass(frozen=True, slots=True)
+class _Facts:
+    goal_visible: bool
+
+
+class CrossingEnvironment:
+    """Strict seeded adapter around a configured Crossing registration."""
+
+    def __init__(self, episode: EpisodeSpec, *, config: CrossingConfig) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not CrossingConfig:
+            raise TypeError("config must be CrossingConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "Crossing configuration belongs in CrossingConfig"
+            )
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._goal_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._goal_found = facts.goal_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid Crossing returned invalid flags")
+        number = _number(reward)
+        public, facts = _observation(observation)
+        self._goal_found = self._goal_found or facts.goal_visible
+        success = bool(terminated and number > 0.0)
+        hazard = bool(terminated and action == 2 and not success)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "goal_found": self._goal_found,
+                "hazard_entered": hazard,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(value: object) -> tuple[dict[str, PolicyValue], _Facts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid Crossing returned invalid observation")
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid Crossing returned invalid image")
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid Crossing returned invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid Crossing returned invalid direction")
+    mission = value["mission"]
+    if type(mission) is not str or mission not in {
+        "avoid the lava and get to the green goal square",
+        "find the opening and get to the green goal square",
+    }:
+        raise RuntimeError("MiniGrid Crossing returned invalid mission")
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _Facts(goal_visible=bool(numpy.any(image[:, :, 0] == _GOAL))),
+    )
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("MiniGrid Crossing returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("MiniGrid Crossing returned non-finite reward")
+    return number
+
+
+__all__ = ["CrossingEnvironment"]

--- a/environments/minigrid/minigrid/crossing/src/minigrid_crossing/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/crossing/src/minigrid_crossing/programs/baseline/policy.py
@@ -1,0 +1,275 @@
+"""A public-observation safe exploration baseline for Crossing."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Reveal unknown cells without entering them and plan through openings."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+        size: int,
+    ) -> None:
+        self._objects = object_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._goal = (size - 3, size - 3)
+        self._grid: dict[Position, Cell] = {
+            self._position: (self._objects["empty"], self._states["open"]),
+            self._goal: (self._objects["goal"], self._states["open"]),
+        }
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+        self._integrate(image, direction)
+        action = self._navigate(self._goal, direction)
+        if action is not None:
+            return action
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        image = observation.get("image")
+        direction = observation.get("direction")
+        if (
+            type(image) is not TensorValue
+            or image.shape != (self._view_size, self._view_size, 3)
+            or image.dtype != "uint8"
+            or type(direction) is not int
+            or not 0 <= direction <= 3
+        ):
+            raise ValueError("observation is invalid")
+        return image, direction
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _VECTORS[direction]
+        right_x, right_y = _VECTORS[(direction + 1) % 4]
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                offset = (view_x * self._view_size + view_y) * 3
+                object_code = image.data[offset]
+                state_code = image.data[offset + 2]
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (object_code, state_code)
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        return None if not path else self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        turn = _turn_toward(
+            direction,
+            _direction_between(self._position, next_position),
+        )
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers = [
+            (distance, position, frontier_direction)
+            for position, distance in distances.items()
+            for frontier_direction, neighbor in _neighbors(position)
+            if neighbor not in self._grid
+        ]
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(frontiers)
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        return _RIGHT if turn is None else turn
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        return bool(
+            cell is not None
+            and cell[0]
+            in {
+                self._objects["empty"],
+                self._objects["floor"],
+                self._objects["goal"],
+            }
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    values = context.environment_parameters
+    objects = values.get("object_encoding")
+    states = values.get("state_encoding")
+    view_size = values.get("view_size")
+    agent_position = values.get("agent_view_position")
+    size = values.get("size")
+    names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(objects) is not dict
+        or set(objects) != names
+        or any(type(value) is not int for value in objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(states) is not dict
+        or set(states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(view_size) is not int or view_size != 7:
+        raise ValueError("view_size is invalid")
+    if type(agent_position) is not list or agent_position != [3, 6]:
+        raise ValueError("agent_view_position is invalid")
+    if type(size) is not int or size not in {9, 11}:
+        raise ValueError("size is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in objects.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in states.items()
+        },
+        view_size=view_size,
+        agent_view_position=(3, 6),
+        size=size,
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        path.append(current)
+        current = previous[current]
+    path.reverse()
+    return tuple(path[1:])

--- a/environments/minigrid/minigrid/crossing/tests/test_crossing.py
+++ b/environments/minigrid/minigrid/crossing/tests/test_crossing.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import EpisodeRecord, EpisodeSpec
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_crossing import (
+    CrossingBenchmark,
+    CrossingConfig,
+    baseline_program,
+)
+
+
+class CrossingTests(unittest.TestCase):
+    def test_profiles_define_identity(self) -> None:
+        default = CrossingBenchmark()
+        wall = CrossingBenchmark(CrossingConfig(profile="wall-S9-N3"))
+        large = CrossingBenchmark(
+            CrossingConfig(profile="lava-S11-N5")
+        )
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/Crossing-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 324)
+        self.assertEqual(large.spec.max_episode_steps, 484)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            wall.spec.environment_digest,
+        )
+        with self.assertRaises(ValueError):
+            CrossingConfig(profile="S9-N3")
+
+    def test_split_planning_and_scenario_rejection(self) -> None:
+        benchmark = CrossingBenchmark()
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"size": 11})
+            )
+
+    def test_feedback_privacy(self) -> None:
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        trace = (
+            CrossingBenchmark().feedback((failed,)).artifacts[0].read_bytes()
+        )
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+
+    def test_baseline_solves_all_profiles_without_hazard(self) -> None:
+        profiles = (
+            "lava-S9-N1",
+            "lava-S9-N2",
+            "lava-S9-N3",
+            "lava-S11-N5",
+            "wall-S9-N1",
+            "wall-S9-N2",
+            "wall-S9-N3",
+            "wall-S11-N5",
+        )
+        for profile in profiles:
+            with self.subTest(profile=profile):
+                benchmark = CrossingBenchmark(
+                    CrossingConfig(profile=profile)
+                )
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=6,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["hazard_rate"],
+                    0.0,
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "avoid the lava and get to the green goal square",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/crossing/uv.lock
+++ b/environments/minigrid/minigrid/crossing/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-crossing"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/dist_shift/.gitignore
+++ b/environments/minigrid/minigrid/dist_shift/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/dist_shift/README.md
+++ b/environments/minigrid/minigrid/dist_shift/README.md
@@ -1,0 +1,16 @@
+# MiniGrid DistShift Benchmark
+
+An independently installable EvoPolicyGym Benchmark for both MiniGrid
+`DistShift` registrations.
+
+```python
+from minigrid_dist_shift import DistShiftBenchmark, DistShiftConfig
+
+benchmark = DistShiftBenchmark(DistShiftConfig(profile="shift1"))
+```
+
+The Policy must reach the goal without entering lava under the selected
+distribution-shift layout. Feedback reports goal discovery and hazard entry;
+the bounded semantic trace contains no seeds, private identity, or Host paths.
+The packaged baseline never moves into an unknown or observed obstacle cell.
+Trusted baseline tests use `ProcessExecution.unsafe()`, which is not a sandbox.

--- a/environments/minigrid/minigrid/dist_shift/pyproject.toml
+++ b/environments/minigrid/minigrid/dist_shift/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-dist-shift"
+version = "0.1.0"
+description = "The MiniGrid DistShift Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_dist_shift"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/__init__.py
+++ b/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/__init__.py
@@ -1,0 +1,8 @@
+"""The public MiniGrid DistShift Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import DistShiftBenchmark
+from .config import DistShiftConfig
+
+__all__ = ["DistShiftBenchmark", "DistShiftConfig", "baseline_program"]
+

--- a/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/baseline.py
+++ b/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid DistShift Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_dist_shift").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/benchmark.py
+++ b/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/benchmark.py
@@ -1,0 +1,328 @@
+"""MiniGrid DistShift with deterministic plans and safety traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import DistShiftConfig
+from .environment import DistShiftEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-minigrid-dist_shift/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_OBJECTS = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATES = ("open", "closed", "locked")
+_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTIONS: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRICS = {"goal_found", "hazard_entered", "success"}
+
+
+class DistShiftBenchmark:
+    """Safe-navigation success rate under one selected lava-strip layout."""
+
+    def __init__(self, config: DistShiftConfig | None = None) -> None:
+        if config is None:
+            config = DistShiftConfig()
+        if type(config) is not DistShiftConfig:
+            raise TypeError("config must be DistShiftConfig")
+        self._config = config
+        self._spec = _spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return DistShiftEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successes = sum(_success(record) for record in records)
+        score = successes / len(records)
+        goal_found = sum(_reached(r, "goal_found") for r in records)
+        hazards = sum(_reached(r, "hazard_entered") for r in records)
+        traced = records[:4]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the goal in {successes}/{len(records)} Episodes "
+                    f"({score:.3f} success rate); {hazards} entered a hazard."
+                ),
+                "success_rate": score,
+                "goal_found_rate": goal_found / len(records),
+                "hazard_rate": hazards / len(records),
+                "mean_return": statistics.fmean(
+                    r.total_reward if r.policy_failure is None else 0.0
+                    for r in records
+                ),
+                "mean_steps": statistics.fmean(r.steps for r in records),
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "hazard_episodes": hazards,
+                "truncated_episodes": sum(_truncated(r) for r in records),
+                "policy_failures": sum(
+                    r.policy_failure is not None for r in records
+                ),
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+            },
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec(config: DistShiftConfig) -> BenchmarkSpec:
+    mission = "get to the green goal square"
+    return BenchmarkSpec(
+        id="minigrid/DistShift-v0/success-rate-v1",
+        description=(
+            "Reach a fixed goal while avoiding one of two distribution-shift "
+            "lava layouts."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "constant": mission},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTIONS,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "width": 9,
+            "height": 7,
+            "strip2_row": config.strip2_row,
+            "start_position": [1, 1],
+            "goal_position": [7, 1],
+            "goal_relative": [6, 0],
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": mission,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECTS)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLORS)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATES)
+            },
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _success(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _reached(record: EpisodeRecord, name: str) -> bool:
+    return any(
+        type(item.step.metrics) is dict
+        and item.step.metrics.get(name) is True
+        for item in record.transitions
+    )
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _success(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                }
+            )
+        )
+        indices = (
+            tuple(range(record.steps))
+            if record.steps <= 160
+            else (*range(128), *range(record.steps - 32, record.steps))
+        )
+        for index in indices:
+            item = record.transitions[index]
+            if type(item.action) is not int or not 0 <= item.action <= 6:
+                raise ValueError("MiniGrid DistShift trace Action is invalid")
+            if (
+                type(item.step.metrics) is not dict
+                or set(item.step.metrics) != _METRICS
+            ):
+                raise ValueError("MiniGrid DistShift trace metrics are invalid")
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": index,
+                        "action": item.action,
+                        "action_meaning": _ACTIONS[str(item.action)],
+                        "reward": item.step.reward,
+                        "next_observation": _trace_observation(
+                            item.step.observation
+                        ),
+                        "terminated": item.step.terminated,
+                        "truncated": item.step.truncated,
+                        "metrics": item.step.metrics,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_observation(value: PolicyValue) -> dict[str, PolicyValue]:
+    if type(value) is not dict:
+        raise ValueError("MiniGrid DistShift trace observation is invalid")
+    image = value.get("image")
+    direction = value.get("direction")
+    mission = value.get("mission")
+    if (
+        type(image) is not TensorValue
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+        or type(direction) is not int
+        or type(mission) is not str
+    ):
+        raise ValueError("MiniGrid DistShift trace observation is invalid")
+    rows: list[PolicyValue] = []
+    for y in range(7):
+        rows.append(
+            "".join(
+                _SYMBOLS[image.data[(x * 7 + y) * 3]]
+                for x in range(7)
+            )
+        )
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+    }
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
+__all__ = ["DistShiftBenchmark"]

--- a/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/config.py
+++ b/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/config.py
@@ -1,0 +1,37 @@
+"""Typed, public MiniGrid DistShift environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int]] = {
+    "shift1": ("MiniGrid-DistShift1-v0", 2),
+    "shift2": ("MiniGrid-DistShift2-v0", 5),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DistShiftConfig:
+    """Parameters defining one DistShift Benchmark identity."""
+
+    profile: str = "shift1"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        return _PROFILES[self.profile][0]
+
+    @property
+    def strip2_row(self) -> int:
+        return _PROFILES[self.profile][1]
+
+    @property
+    def max_episode_steps(self) -> int:
+        return 4 * 9 * 7
+
+
+__all__ = ["DistShiftConfig"]

--- a/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/environment.py
+++ b/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/environment.py
@@ -1,0 +1,151 @@
+"""One fresh MiniGrid DistShift Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import DistShiftConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_GOAL = 8
+
+
+@dataclass(frozen=True, slots=True)
+class _Facts:
+    goal_visible: bool
+
+
+class DistShiftEnvironment:
+    """Strict seeded adapter around a configured DistShift registration."""
+
+    def __init__(self, episode: EpisodeSpec, *, config: DistShiftConfig) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not DistShiftConfig:
+            raise TypeError("config must be DistShiftConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "DistShift configuration belongs in DistShiftConfig"
+            )
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._goal_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._goal_found = facts.goal_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid DistShift returned invalid flags")
+        number = _number(reward)
+        public, facts = _observation(observation)
+        self._goal_found = self._goal_found or facts.goal_visible
+        success = bool(terminated and number > 0.0)
+        hazard = bool(terminated and action == 2 and not success)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "goal_found": self._goal_found,
+                "hazard_entered": hazard,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(value: object) -> tuple[dict[str, PolicyValue], _Facts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid DistShift returned invalid observation")
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid DistShift returned invalid image")
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid DistShift returned invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid DistShift returned invalid direction")
+    mission = value["mission"]
+    if (
+        type(mission) is not str
+        or mission != "get to the green goal square"
+    ):
+        raise RuntimeError("MiniGrid DistShift returned invalid mission")
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _Facts(goal_visible=bool(numpy.any(image[:, :, 0] == _GOAL))),
+    )
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("MiniGrid DistShift returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("MiniGrid DistShift returned non-finite reward")
+    return number
+
+
+__all__ = ["DistShiftEnvironment"]

--- a/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/programs/baseline/policy.py
@@ -1,0 +1,275 @@
+"""A public-observation safe exploration baseline for DistShift."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Reveal unknown cells without entering them and plan through openings."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+        goal_relative: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._goal = goal_relative
+        self._grid: dict[Position, Cell] = {
+            self._position: (self._objects["empty"], self._states["open"]),
+            self._goal: (self._objects["goal"], self._states["open"]),
+        }
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+        self._integrate(image, direction)
+        action = self._navigate(self._goal, direction)
+        if action is not None:
+            return action
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        image = observation.get("image")
+        direction = observation.get("direction")
+        if (
+            type(image) is not TensorValue
+            or image.shape != (self._view_size, self._view_size, 3)
+            or image.dtype != "uint8"
+            or type(direction) is not int
+            or not 0 <= direction <= 3
+        ):
+            raise ValueError("observation is invalid")
+        return image, direction
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _VECTORS[direction]
+        right_x, right_y = _VECTORS[(direction + 1) % 4]
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                offset = (view_x * self._view_size + view_y) * 3
+                object_code = image.data[offset]
+                state_code = image.data[offset + 2]
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (object_code, state_code)
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        return None if not path else self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        turn = _turn_toward(
+            direction,
+            _direction_between(self._position, next_position),
+        )
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers = [
+            (distance, position, frontier_direction)
+            for position, distance in distances.items()
+            for frontier_direction, neighbor in _neighbors(position)
+            if neighbor not in self._grid
+        ]
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(frontiers)
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        return _RIGHT if turn is None else turn
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        return bool(
+            cell is not None
+            and cell[0]
+            in {
+                self._objects["empty"],
+                self._objects["floor"],
+                self._objects["goal"],
+            }
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    values = context.environment_parameters
+    objects = values.get("object_encoding")
+    states = values.get("state_encoding")
+    view_size = values.get("view_size")
+    agent_position = values.get("agent_view_position")
+    goal_relative = values.get("goal_relative")
+    names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(objects) is not dict
+        or set(objects) != names
+        or any(type(value) is not int for value in objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(states) is not dict
+        or set(states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(view_size) is not int or view_size != 7:
+        raise ValueError("view_size is invalid")
+    if type(agent_position) is not list or agent_position != [3, 6]:
+        raise ValueError("agent_view_position is invalid")
+    if type(goal_relative) is not list or goal_relative != [6, 0]:
+        raise ValueError("goal_relative is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in objects.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in states.items()
+        },
+        view_size=view_size,
+        agent_view_position=(3, 6),
+        goal_relative=(6, 0),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        path.append(current)
+        current = previous[current]
+    path.reverse()
+    return tuple(path[1:])

--- a/environments/minigrid/minigrid/dist_shift/tests/test_dist_shift.py
+++ b/environments/minigrid/minigrid/dist_shift/tests/test_dist_shift.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import EpisodeRecord, EpisodeSpec
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_dist_shift import (
+    DistShiftBenchmark,
+    DistShiftConfig,
+    baseline_program,
+)
+
+
+class DistShiftTests(unittest.TestCase):
+    def test_profiles_define_identity(self) -> None:
+        default = DistShiftBenchmark()
+        shifted = DistShiftBenchmark(DistShiftConfig(profile="shift2"))
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/DistShift-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 252)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            shifted.spec.environment_digest,
+        )
+        with self.assertRaises(ValueError):
+            DistShiftConfig(profile="shift3")
+
+    def test_split_planning_and_scenario_rejection(self) -> None:
+        benchmark = DistShiftBenchmark()
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"strip2_row": 5})
+            )
+
+    def test_feedback_privacy(self) -> None:
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        trace = (
+            DistShiftBenchmark().feedback((failed,)).artifacts[0].read_bytes()
+        )
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+
+    def test_baseline_solves_all_profiles_without_hazard(self) -> None:
+        profiles = ("shift1", "shift2")
+        for profile in profiles:
+            with self.subTest(profile=profile):
+                benchmark = DistShiftBenchmark(
+                    DistShiftConfig(profile=profile)
+                )
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=6,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["hazard_rate"],
+                    0.0,
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "get to the green goal square",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/dist_shift/uv.lock
+++ b/environments/minigrid/minigrid/dist_shift/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-dist-shift"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/doorkey/.gitignore
+++ b/environments/minigrid/minigrid/doorkey/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+dist/
+build/
+*.egg-info/
+__pycache__/
+*.py[cod]

--- a/environments/minigrid/minigrid/doorkey/README.md
+++ b/environments/minigrid/minigrid/doorkey/README.md
@@ -1,0 +1,52 @@
+# MiniGrid DoorKey Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid DoorKey](https://minigrid.farama.org/environments/minigrid/DoorKeyEnv/)
+partially observable navigation task.
+
+The Policy sees the upstream `7 × 7 × 3` egocentric symbolic image, compass
+direction, and mission text. It must explore the room, pick up the yellow key,
+unlock the yellow door, and reach the green goal. The primary score is Episode
+success rate.
+
+## Install and test
+
+From the EvoPolicyGym repository root:
+
+```console
+uv sync --project environments/minigrid/minigrid/doorkey --extra dev
+uv run --project environments/minigrid/minigrid/doorkey \
+  python -m unittest discover \
+  -s environments/minigrid/minigrid/doorkey/tests
+uv build environments/minigrid/minigrid/doorkey
+```
+
+## Public API
+
+```python
+from minigrid_doorkey import (
+    DoorKeyBenchmark,
+    DoorKeyConfig,
+    baseline_program,
+)
+
+benchmark = DoorKeyBenchmark(DoorKeyConfig(profile="8x8"))
+program = baseline_program()
+```
+
+Available profiles are `5x5`, `6x6`, `8x8`, and `16x16`.
+
+Feedback includes success, key-pickup and door-opening rates, aggregate return
+and step statistics, truncations, and Policy failures. `trace.jsonl` contains
+a bounded semantic trace for at most four Episodes; long traces retain the
+first 128 and last 32 transitions. Milestones are derived from the same
+Policy-visible symbolic observations and actions. Feedback contains no Episode
+seed, private Case identity, or Host path.
+
+The packaged baseline constructs a relative map from its egocentric
+observations and uses shortest-path planning between the key, door, and goal.
+It consumes no private environment state.
+
+Tests that use `ProcessExecution.unsafe()` run trusted packaged code only.
+That backend is a local process mechanism, not a sandbox and not suitable for
+hostile Programs.

--- a/environments/minigrid/minigrid/doorkey/pyproject.toml
+++ b/environments/minigrid/minigrid/doorkey/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-doorkey"
+version = "0.1.0"
+description = "The MiniGrid DoorKey Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = [
+    "mypy==2.3.0",
+    "ruff>=0.12.0",
+]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_doorkey"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/README.md",
+    "/pyproject.toml",
+    "/src",
+    "/tests",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/__init__.py
+++ b/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/__init__.py
@@ -1,0 +1,11 @@
+"""The public MiniGrid DoorKey Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import DoorKeyBenchmark
+from .config import DoorKeyConfig
+
+__all__ = [
+    "DoorKeyBenchmark",
+    "DoorKeyConfig",
+    "baseline_program",
+]

--- a/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/baseline.py
+++ b/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/baseline.py
@@ -1,0 +1,18 @@
+"""Packaged initial Program for MiniGrid DoorKey development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the mapping and planning baseline."""
+
+    resource = files("minigrid_doorkey").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]

--- a/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/benchmark.py
+++ b/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/benchmark.py
@@ -1,0 +1,428 @@
+"""MiniGrid DoorKey with deterministic plans and semantic milestone traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import DoorKeyConfig
+from .environment import DoorKeyEnvironment
+
+_EPISODE_SEED_DOMAIN = b"evopolicygym-minigrid-doorkey/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_MISSION = "use the key to open the door and then get to the goal"
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRIC_FIELDS = {
+    "carrying_key",
+    "picked_up_key",
+    "opened_door",
+    "success",
+}
+
+
+class DoorKeyBenchmark:
+    """Success rate on a partially observable key-door navigation task."""
+
+    def __init__(self, config: DoorKeyConfig | None = None) -> None:
+        if config is None:
+            config = DoorKeyConfig()
+        if type(config) is not DoorKeyConfig:
+            raise TypeError("config must be DoorKeyConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return DoorKeyEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        picked_up_keys = sum(
+            _reached_milestone(record, "picked_up_key")
+            for record in records
+        )
+        opened_doors = sum(
+            _reached_milestone(record, "opened_door")
+            for record in records
+        )
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        mean_success_steps: PolicyValue = (
+            statistics.fmean(record.steps for record in successful)
+            if successful
+            else None
+        )
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the goal in {successes}/{len(records)} Episodes "
+                    f"({score:.3f} success rate); {picked_up_keys} picked up "
+                    f"the key and {opened_doors} opened the door."
+                ),
+                "success_rate": score,
+                "key_pickup_rate": picked_up_keys / len(records),
+                "door_open_rate": opened_doors / len(records),
+                "mean_return": mean_return,
+                "mean_steps": mean_steps,
+                "mean_steps_on_success": mean_success_steps,
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "key_pickup_episodes": picked_up_keys,
+                "door_open_episodes": opened_doors,
+                "truncated_episodes": truncations,
+                "policy_failures": failures,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+                "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+                "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+            },
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: DoorKeyConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/DoorKey-v0/success-rate-v1",
+        description=(
+            "Explore a partially observable room, pick up the yellow key, "
+            "unlock the yellow door, and reach the green goal. Maximize "
+            "success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "meaning": {
+                        "0": "east",
+                        "1": "south",
+                        "2": "west",
+                        "3": "north",
+                    },
+                },
+                "mission": {
+                    "type": "string",
+                    "constant": _MISSION,
+                },
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "size": config.size,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": _MISSION,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for reaching the goal; zero for "
+                "timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _reached_milestone(record: EpisodeRecord, name: str) -> bool:
+    for transition in record.transitions:
+        metrics = transition.step.metrics
+        if type(metrics) is dict and metrics.get(name) is True:
+            return True
+    return False
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "picked_up_key": _reached_milestone(
+                        record,
+                        "picked_up_key",
+                    ),
+                    "opened_door": _reached_milestone(
+                        record,
+                        "opened_door",
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError("MiniGrid DoorKey trace Action is invalid")
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if (
+        type(metrics) is not dict
+        or set(metrics) != _METRIC_FIELDS
+        or any(type(value) is not bool for value in metrics.values())
+    ):
+        raise ValueError("MiniGrid DoorKey trace metrics are invalid")
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError("MiniGrid DoorKey trace observation is invalid")
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("MiniGrid DoorKey trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("MiniGrid DoorKey trace direction is invalid")
+    if type(mission) is not str or mission != _MISSION:
+        raise ValueError("MiniGrid DoorKey trace mission is invalid")
+
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError("MiniGrid DoorKey trace image codes are invalid")
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["DoorKeyBenchmark"]

--- a/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/config.py
+++ b/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/config.py
@@ -1,0 +1,45 @@
+"""Typed, public MiniGrid DoorKey environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int]] = {
+    "5x5": ("MiniGrid-DoorKey-5x5-v0", 5),
+    "6x6": ("MiniGrid-DoorKey-6x6-v0", 6),
+    "8x8": ("MiniGrid-DoorKey-8x8-v0", 8),
+    "16x16": ("MiniGrid-DoorKey-16x16-v0", 16),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DoorKeyConfig:
+    """Parameters that define one MiniGrid DoorKey Benchmark identity."""
+
+    profile: str = "8x8"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        """Return the upstream Gymnasium registration."""
+
+        return _PROFILES[self.profile][0]
+
+    @property
+    def size(self) -> int:
+        """Return the square grid size."""
+
+        return _PROFILES[self.profile][1]
+
+    @property
+    def max_episode_steps(self) -> int:
+        """Return the upstream horizon."""
+
+        return 10 * self.size**2
+
+
+__all__ = ["DoorKeyConfig"]

--- a/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/environment.py
+++ b/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/environment.py
@@ -1,0 +1,172 @@
+"""One fresh MiniGrid DoorKey Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401  # Import registers MiniGrid environments.
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import DoorKeyConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_MISSION = "use the key to open the door and then get to the goal"
+_DOOR = 4
+_KEY = 5
+_OPEN = 0
+
+
+class DoorKeyEnvironment:
+    """The seeded strict adapter around a configured MiniGrid DoorKey task."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: DoorKeyConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not DoorKeyConfig:
+            raise TypeError("config must be DoorKeyConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "DoorKey configuration belongs in DoorKeyConfig, "
+                "not EpisodeSpec.scenario"
+            )
+
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._picked_up_key = False
+        self._opened_door = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, _, _ = _observation(observation)
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid DoorKey returned invalid termination flags")
+        number = _number(reward, name="reward")
+        public, carrying_key, open_door_visible = _observation(observation)
+        self._picked_up_key = self._picked_up_key or carrying_key
+        self._opened_door = self._opened_door or open_door_visible
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "carrying_key": carrying_key,
+                "picked_up_key": self._picked_up_key,
+                "opened_door": self._opened_door,
+                "success": bool(terminated and number > 0.0),
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(
+    value: object,
+) -> tuple[dict[str, PolicyValue], bool, bool]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid DoorKey returned an invalid observation")
+
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid DoorKey returned an invalid image")
+    if (
+        numpy.any(image[:, :, 0] > 10)
+        or numpy.any(image[:, :, 1] > 5)
+        or numpy.any(image[:, :, 2] > 2)
+    ):
+        raise RuntimeError("MiniGrid DoorKey returned out-of-range image codes")
+
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid DoorKey returned an invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid DoorKey returned an invalid direction")
+
+    mission = value["mission"]
+    if type(mission) is not str or mission != _MISSION:
+        raise RuntimeError("MiniGrid DoorKey returned an invalid mission")
+
+    carrying_key = bool(image[3, 6, 0] == _KEY)
+    open_door_visible = bool(
+        numpy.any(
+            (image[:, :, 0] == _DOOR) & (image[:, :, 2] == _OPEN)
+        )
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        carrying_key,
+        open_door_visible,
+    )
+
+
+def _number(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(f"MiniGrid DoorKey returned an invalid {name}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(f"MiniGrid DoorKey returned a non-finite {name}")
+    return number
+
+
+__all__ = ["DoorKeyEnvironment"]

--- a/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/programs/baseline/policy.py
@@ -1,0 +1,409 @@
+"""A public-observation mapping and shortest-path DoorKey baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_PICKUP = 3
+_TOGGLE = 5
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Build a relative map, then plan between task milestones."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (self._objects["empty"], self._states["open"])
+        }
+        self._has_key = False
+        self._door_open = False
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+        self._integrate(image, direction)
+
+        if not self._has_key:
+            key = self._known_object("key")
+            if key is not None:
+                return self._interact(
+                    key,
+                    action=_PICKUP,
+                    direction=direction,
+                )
+            return self._explore(direction)
+
+        if not self._door_open:
+            door = self._known_object("door")
+            if door is not None:
+                if self._grid[door][1] == self._states["open"]:
+                    self._door_open = True
+                else:
+                    return self._interact(
+                        door,
+                        action=_TOGGLE,
+                        direction=direction,
+                    )
+            else:
+                return self._explore(direction)
+
+        goal = self._known_object("goal")
+        if goal is not None:
+            action = self._navigate(goal, direction)
+            if action is not None:
+                return action
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        return image, direction
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, _, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    if object_code == self._objects["key"]:
+                        self._has_key = True
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (object_code, state_code)
+                if (
+                    object_code == self._objects["door"]
+                    and state_code == self._states["open"]
+                ):
+                    self._door_open = True
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> tuple[int, int, int]:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_object(self, name: str) -> Position | None:
+        code = self._objects[name]
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == code
+            ),
+            None,
+        )
+
+    def _interact(
+        self,
+        target: Position,
+        *,
+        action: int,
+        direction: int,
+    ) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+
+        target_direction = _direction_between(approach_position, target)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+
+        if action == _PICKUP:
+            self._has_key = True
+            self._grid[target] = (
+                self._objects["empty"],
+                self._states["open"],
+            )
+        elif action == _TOGGLE:
+            self._door_open = True
+            self._grid[target] = (
+                self._objects["door"],
+                self._states["open"],
+            )
+        return action
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if not frontiers:
+            return _RIGHT
+
+        _, frontier, frontier_direction = min(
+            frontiers,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+
+        turn = _turn_toward(direction, frontier_direction)
+        if turn is not None:
+            return turn
+        return _RIGHT
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        if cell is None:
+            return False
+        object_code, state_code = cell
+        return bool(
+            object_code
+            in {
+                self._objects["empty"],
+                self._objects["floor"],
+                self._objects["goal"],
+            }
+            or (
+                object_code == self._objects["door"]
+                and state_code == self._states["open"]
+            )
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/doorkey/tests/test_doorkey.py
+++ b/environments/minigrid/minigrid/doorkey/tests/test_doorkey.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_doorkey import (
+    DoorKeyBenchmark,
+    DoorKeyConfig,
+    baseline_program,
+)
+
+
+class DoorKeyBenchmarkTests(unittest.TestCase):
+    def test_config_profiles_define_distinct_environment_identity(self) -> None:
+        default = DoorKeyBenchmark()
+        small = DoorKeyBenchmark(DoorKeyConfig(profile="5x5"))
+        large = DoorKeyBenchmark(DoorKeyConfig(profile="16x16"))
+
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/DoorKey-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 640)
+        self.assertEqual(small.spec.max_episode_steps, 250)
+        self.assertEqual(large.spec.max_episode_steps, 2_560)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            small.spec.environment_digest,
+        )
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            large.spec.environment_digest,
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["profile"],
+            "8x8",
+        )
+
+        exposed = default.spec.environment_parameters["state_encoding"]
+        self.assertIsInstance(exposed, dict)
+        assert isinstance(exposed, dict)
+        exposed["locked"] = 100
+        fresh = default.spec.environment_parameters["state_encoding"]
+        self.assertIsInstance(fresh, dict)
+        assert isinstance(fresh, dict)
+        self.assertEqual(fresh["locked"], 2)
+
+    def test_config_rejects_unsupported_or_ambiguous_profiles(self) -> None:
+        with self.assertRaises(ValueError):
+            DoorKeyConfig(profile="10x10")
+        with self.assertRaises(ValueError):
+            DoorKeyConfig(profile=8)  # type: ignore[arg-type]
+
+    def test_episode_planning_is_reproducible_and_split_scoped(self) -> None:
+        benchmark = DoorKeyBenchmark()
+
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        validation = tuple(
+            benchmark.episodes("validation", seed=7, count=10)
+        )
+
+        self.assertEqual(train, repeated)
+        self.assertEqual(len({item.environment_seed for item in train}), 10)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in validation
+            )
+        )
+        self.assertTrue(all(item.scenario is None for item in train))
+
+    def test_environment_is_conformant_and_rejects_invalid_actions(
+        self,
+    ) -> None:
+        benchmark = DoorKeyBenchmark(DoorKeyConfig(profile="5x5"))
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertEqual(
+                set(observation),
+                {"image", "direction", "mission"},
+            )
+            image = observation["image"]
+            self.assertIsInstance(image, TensorValue)
+            assert isinstance(image, TensorValue)
+            self.assertEqual(image.dtype, "uint8")
+            self.assertEqual(image.shape, (7, 7, 3))
+            self.assertEqual(len(image.data), 147)
+            self.assertIn(observation["direction"], {0, 1, 2, 3})
+        finally:
+            environment.close()
+            environment.close()
+
+        invalid_actions: tuple[PolicyValue, ...] = (
+            -1,
+            7,
+            True,
+            2.0,
+            [2],
+        )
+        for invalid in invalid_actions:
+            environment = benchmark.make_environment(
+                EpisodeSpec(environment_seed=123)
+            )
+            try:
+                environment.reset()
+                with self.assertRaises(InvalidAction):
+                    environment.step(invalid)
+            finally:
+                environment.close()
+
+    def test_episode_scenario_cannot_override_benchmark_configuration(
+        self,
+    ) -> None:
+        benchmark = DoorKeyBenchmark()
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(
+                    environment_seed=1,
+                    scenario={"profile": "5x5"},
+                )
+            )
+
+    def test_feedback_penalizes_failure_and_keeps_identity_private(self) -> None:
+        benchmark = DoorKeyBenchmark()
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+
+        feedback = benchmark.feedback((failed,))
+
+        self.assertEqual(feedback.score, 0.0)
+        self.assertEqual(len(feedback.artifacts), 1)
+        trace = feedback.artifacts[0]
+        self.assertEqual(trace.name, "trace.jsonl")
+        self.assertNotIn(b"environment_seed", trace.read_bytes())
+        self.assertNotIn(b"policy_seed", trace.read_bytes())
+        self.assertNotIn(b'"profile"', trace.read_bytes())
+        self.assertIsInstance(feedback.content, dict)
+        assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["policy_failures"], 1)
+        self.assertEqual(feedback.content["key_pickup_episodes"], 0)
+        self.assertEqual(feedback.content["door_open_episodes"], 0)
+
+    def test_baseline_solves_every_public_profile_and_publishes_trace(
+        self,
+    ) -> None:
+        for profile in ("5x5", "6x6", "8x8", "16x16"):
+            with self.subTest(profile=profile):
+                benchmark = DoorKeyBenchmark(DoorKeyConfig(profile=profile))
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=8,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+
+                self.assertEqual(
+                    result.benchmark_id,
+                    "minigrid/DoorKey-v0/success-rate-v1",
+                )
+                self.assertEqual(
+                    result.environment_digest,
+                    benchmark.spec.environment_digest,
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["key_pickup_rate"],
+                    1.0,
+                )
+                self.assertEqual(
+                    result.feedback.content["door_open_rate"],
+                    1.0,
+                )
+                trace = result.feedback.artifacts[0]
+                documents = tuple(
+                    json.loads(line)
+                    for line in trace.read_bytes().splitlines()
+                )
+                transitions = tuple(
+                    document
+                    for document in documents
+                    if document["type"] == "transition"
+                )
+                self.assertEqual(trace.name, "trace.jsonl")
+                self.assertEqual(
+                    trace.media_type,
+                    "application/x-ndjson",
+                )
+                self.assertTrue(transitions)
+                self.assertTrue(
+                    all(
+                        "grid_rows" in item["next_observation"]
+                        for item in transitions
+                    )
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "use the key to open the door and then get to the goal",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/doorkey/uv.lock
+++ b/environments/minigrid/minigrid/doorkey/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-doorkey"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/dynamic_obstacles/.gitignore
+++ b/environments/minigrid/minigrid/dynamic_obstacles/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/dynamic_obstacles/README.md
+++ b/environments/minigrid/minigrid/dynamic_obstacles/README.md
@@ -1,0 +1,58 @@
+# MiniGrid DynamicObstacles Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid DynamicObstacles](https://minigrid.farama.org/environments/minigrid/DynamicObstaclesEnv/)
+navigation task.
+
+The Policy receives the upstream `7 × 7 × 3` egocentric symbolic image,
+compass direction, and fixed mission. It must reach the green goal while grey
+balls move locally before every action. The only valid actions are left,
+right, and forward; collisions end the Episode with reward `-1`. The primary
+score is collision-free Episode success rate.
+
+## Install and test
+
+From the EvoPolicyGym repository root:
+
+```console
+uv sync --project environments/minigrid/minigrid/dynamic_obstacles --extra dev
+uv run --project environments/minigrid/minigrid/dynamic_obstacles \
+  python -m unittest discover \
+  -s environments/minigrid/minigrid/dynamic_obstacles/tests
+uv build environments/minigrid/minigrid/dynamic_obstacles
+```
+
+## Public API
+
+```python
+from minigrid_dynamic_obstacles import (
+    DynamicObstaclesBenchmark,
+    DynamicObstaclesConfig,
+    baseline_program,
+)
+
+benchmark = DynamicObstaclesBenchmark(
+    DynamicObstaclesConfig(profile="8x8-N4"),
+)
+program = baseline_program()
+```
+
+Available profiles are `5x5-N2`, `5x5-N2-random`, `6x6-N3`,
+`6x6-N3-random`, `8x8-N4`, and `16x16-N8`. A profile is selected by the Host
+before a Run and contributes to the environment digest.
+
+Feedback reports success, goal discovery, and collision rate, together with
+return, step, truncation, and Policy-failure statistics. `trace.jsonl`
+contains a bounded semantic trace for at most four Episodes, retaining the
+first 128 and last 32 transitions of long Episodes. It contains no Episode
+seed, private Case identity, or Host path.
+
+The packaged baseline builds a relative map from public observations and
+replans each step. It moves forward only when no currently visible obstacle
+can enter the destination in one upstream motion update. It consumes no
+private environment state.
+
+Tests that use `ProcessExecution.unsafe()` run trusted packaged code only.
+That backend is a local process mechanism, not a sandbox and not suitable for
+hostile Programs.
+

--- a/environments/minigrid/minigrid/dynamic_obstacles/pyproject.toml
+++ b/environments/minigrid/minigrid/dynamic_obstacles/pyproject.toml
@@ -1,0 +1,69 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-dynamic-obstacles"
+version = "0.1.0"
+description = "The MiniGrid DynamicObstacles Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = [
+    "mypy==2.3.0",
+    "ruff>=0.12.0",
+]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_dynamic_obstacles"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/README.md",
+    "/pyproject.toml",
+    "/src",
+    "/tests",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/__init__.py
+++ b/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/__init__.py
@@ -1,0 +1,12 @@
+"""The public MiniGrid DynamicObstacles Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import DynamicObstaclesBenchmark
+from .config import DynamicObstaclesConfig
+
+__all__ = [
+    "DynamicObstaclesBenchmark",
+    "DynamicObstaclesConfig",
+    "baseline_program",
+]
+

--- a/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/baseline.py
+++ b/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/baseline.py
@@ -1,0 +1,22 @@
+"""Packaged initial Program for DynamicObstacles development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_dynamic_obstacles").joinpath(
+        "programs",
+        "baseline",
+    )
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/benchmark.py
+++ b/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/benchmark.py
@@ -1,0 +1,448 @@
+"""DynamicObstacles with deterministic plans and collision traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import DynamicObstaclesConfig
+from .environment import DynamicObstaclesEnvironment
+
+_EPISODE_SEED_DOMAIN = (
+    b"evopolicygym-minigrid-dynamic-obstacles/episode-seed/v1\0"
+)
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_MISSION = "get to the green goal square"
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+}
+_METRIC_FIELDS = {"goal_found", "collision", "success"}
+
+
+class DynamicObstaclesBenchmark:
+    """Success rate while avoiding moving obstacles."""
+
+    def __init__(
+        self,
+        config: DynamicObstaclesConfig | None = None,
+    ) -> None:
+        if config is None:
+            config = DynamicObstaclesConfig()
+        if type(config) is not DynamicObstaclesConfig:
+            raise TypeError("config must be DynamicObstaclesConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return DynamicObstaclesEnvironment(
+            episode,
+            config=self._config,
+        )
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        found_goals = _milestone_count(records, "goal_found")
+        collisions = _milestone_count(records, "collision")
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        mean_success_steps: PolicyValue = (
+            statistics.fmean(record.steps for record in successful)
+            if successful
+            else None
+        )
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the goal without collision in {successes}/"
+                    f"{len(records)} Episodes ({score:.3f} success rate); "
+                    f"{collisions} Episodes collided with an obstacle."
+                ),
+                "success_rate": score,
+                "goal_found_rate": found_goals / len(records),
+                "collision_rate": collisions / len(records),
+                "mean_return": mean_return,
+                "mean_steps": mean_steps,
+                "mean_steps_on_success": mean_success_steps,
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "goal_found_episodes": found_goals,
+                "collision_episodes": collisions,
+                "truncated_episodes": truncations,
+                "policy_failures": failures,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+                "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+                "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+            },
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: DynamicObstaclesConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/DynamicObstacles-v0/success-rate-v1",
+        description=(
+            "Reach the green goal in a partially observable room while grey "
+            "balls move locally before every action. Avoid collision and "
+            "maximize success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "meaning": {
+                        "0": "east",
+                        "1": "south",
+                        "2": "west",
+                        "3": "north",
+                    },
+                },
+                "mission": {
+                    "type": "string",
+                    "constant": _MISSION,
+                },
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(3)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "size": config.size,
+            "obstacle_count": config.obstacle_count,
+            "random_start": config.random_start,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": _MISSION,
+            "obstacle_object": "grey ball",
+            "obstacle_motion": (
+                "before every agent action, each ball attempts to move to a "
+                "free cell within its local 3x3 neighborhood"
+            ),
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for reaching the goal, -1 for "
+                "attempting to move into an occupied non-goal cell, zero for "
+                "timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _milestone_count(
+    records: Sequence[EpisodeRecord],
+    name: str,
+) -> int:
+    return sum(_reached_milestone(record, name) for record in records)
+
+
+def _reached_milestone(record: EpisodeRecord, name: str) -> bool:
+    for transition in record.transitions:
+        metrics = transition.step.metrics
+        if type(metrics) is dict and metrics.get(name) is True:
+            return True
+    return False
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "goal_found": _reached_milestone(
+                        record,
+                        "goal_found",
+                    ),
+                    "collision": _reached_milestone(
+                        record,
+                        "collision",
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 2:
+                raise ValueError(
+                    "MiniGrid DynamicObstacles trace Action is invalid"
+                )
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if (
+        type(metrics) is not dict
+        or set(metrics) != _METRIC_FIELDS
+        or any(type(value) is not bool for value in metrics.values())
+    ):
+        raise ValueError(
+            "MiniGrid DynamicObstacles trace metrics are invalid"
+        )
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError(
+            "MiniGrid DynamicObstacles trace observation is invalid"
+        )
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("MiniGrid DynamicObstacles trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError(
+            "MiniGrid DynamicObstacles trace direction is invalid"
+        )
+    if type(mission) is not str or mission != _MISSION:
+        raise ValueError(
+            "MiniGrid DynamicObstacles trace mission is invalid"
+        )
+
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError(
+                    "MiniGrid DynamicObstacles trace image codes are invalid"
+                )
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["DynamicObstaclesBenchmark"]

--- a/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/config.py
+++ b/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/config.py
@@ -1,0 +1,70 @@
+"""Typed, public MiniGrid DynamicObstacles environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int, int, bool]] = {
+    "5x5-N2": ("MiniGrid-Dynamic-Obstacles-5x5-v0", 5, 2, False),
+    "5x5-N2-random": (
+        "MiniGrid-Dynamic-Obstacles-Random-5x5-v0",
+        5,
+        2,
+        True,
+    ),
+    "6x6-N3": ("MiniGrid-Dynamic-Obstacles-6x6-v0", 6, 3, False),
+    "6x6-N3-random": (
+        "MiniGrid-Dynamic-Obstacles-Random-6x6-v0",
+        6,
+        3,
+        True,
+    ),
+    "8x8-N4": ("MiniGrid-Dynamic-Obstacles-8x8-v0", 8, 4, False),
+    "16x16-N8": ("MiniGrid-Dynamic-Obstacles-16x16-v0", 16, 8, False),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DynamicObstaclesConfig:
+    """Parameters defining one DynamicObstacles Benchmark identity."""
+
+    profile: str = "8x8-N4"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        """Return the upstream Gymnasium registration."""
+
+        return _PROFILES[self.profile][0]
+
+    @property
+    def size(self) -> int:
+        """Return the square grid size."""
+
+        return _PROFILES[self.profile][1]
+
+    @property
+    def obstacle_count(self) -> int:
+        """Return the moving obstacle count."""
+
+        return _PROFILES[self.profile][2]
+
+    @property
+    def random_start(self) -> bool:
+        """Return whether the upstream agent start is randomized."""
+
+        return _PROFILES[self.profile][3]
+
+    @property
+    def max_episode_steps(self) -> int:
+        """Return the upstream horizon."""
+
+        return 4 * self.size**2
+
+
+__all__ = ["DynamicObstaclesConfig"]
+

--- a/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/environment.py
+++ b/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/environment.py
@@ -1,0 +1,187 @@
+"""One fresh MiniGrid DynamicObstacles Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401  # Import registers MiniGrid environments.
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import DynamicObstaclesConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(3))
+_MISSION = "get to the green goal square"
+_GOAL = 8
+
+
+@dataclass(frozen=True, slots=True)
+class _ObservationFacts:
+    goal_visible: bool
+
+
+class DynamicObstaclesEnvironment:
+    """Strict seeded adapter around MiniGrid DynamicObstacles."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: DynamicObstaclesConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not DynamicObstaclesConfig:
+            raise TypeError("config must be DynamicObstaclesConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "DynamicObstacles configuration belongs in "
+                "DynamicObstaclesConfig, not EpisodeSpec.scenario"
+            )
+
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._goal_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._goal_found = facts.goal_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError(
+                "MiniGrid DynamicObstacles returned invalid termination flags"
+            )
+        number = _number(reward, name="reward")
+        public, facts = _observation(observation)
+        self._goal_found = self._goal_found or facts.goal_visible
+        collided = bool(terminated and number < 0.0)
+        success = bool(terminated and number > 0.0)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "goal_found": self._goal_found,
+                "collision": collided,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(
+    value: object,
+) -> tuple[dict[str, PolicyValue], _ObservationFacts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError(
+            "MiniGrid DynamicObstacles returned an invalid observation"
+        )
+
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError(
+            "MiniGrid DynamicObstacles returned an invalid image"
+        )
+    if (
+        numpy.any(image[:, :, 0] > 10)
+        or numpy.any(image[:, :, 1] > 5)
+        or numpy.any(image[:, :, 2] > 2)
+    ):
+        raise RuntimeError(
+            "MiniGrid DynamicObstacles returned out-of-range image codes"
+        )
+
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid DynamicObstacles returned an invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError(
+            "MiniGrid DynamicObstacles returned an invalid direction"
+        )
+
+    mission = value["mission"]
+    if type(mission) is not str or mission != _MISSION:
+        raise RuntimeError(
+            "MiniGrid DynamicObstacles returned an invalid mission"
+        )
+
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _ObservationFacts(
+            goal_visible=bool(numpy.any(image[:, :, 0] == _GOAL)),
+        ),
+    )
+
+
+def _number(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(
+            f"MiniGrid DynamicObstacles returned an invalid {name}"
+        )
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(
+            f"MiniGrid DynamicObstacles returned a non-finite {name}"
+        )
+    return number
+
+
+__all__ = ["DynamicObstaclesEnvironment"]

--- a/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/programs/baseline/policy.py
@@ -1,0 +1,439 @@
+"""A public-observation replanning DynamicObstacles baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Map the room and replan around moving obstacle observations."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+        size: int,
+        random_start: bool,
+    ) -> None:
+        self._objects = object_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (self._objects["empty"], self._states["open"])
+        }
+        self._static_grid: dict[Position, Cell] = dict(self._grid)
+        self._pending_position: Position | None = None
+        self._conservative_motion = size >= 16 and not random_start
+        if not random_start:
+            self._initialize_known_room(size)
+
+    def _initialize_known_room(self, size: int) -> None:
+        empty = (self._objects["empty"], self._states["open"])
+        wall = (self._objects["wall"], self._states["open"])
+        last_interior = size - 3
+        for x in range(last_interior + 1):
+            for y in range(last_interior + 1):
+                self._grid[(x, y)] = empty
+                self._static_grid[(x, y)] = empty
+        goal = (self._objects["goal"], self._states["open"])
+        self._grid[(last_interior, last_interior)] = goal
+        self._static_grid[(last_interior, last_interior)] = goal
+        for coordinate in range(-1, size - 1):
+            for position in (
+                (-1, coordinate),
+                (size - 2, coordinate),
+                (coordinate, -1),
+                (coordinate, size - 2),
+            ):
+                self._grid[position] = wall
+                self._static_grid[position] = wall
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+        self._reconcile_position(image, direction)
+        self._integrate(image, direction)
+
+        goal = self._known_object("goal")
+        if goal is not None:
+            action = self._navigate(goal, direction)
+            if action is not None:
+                return action
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        return image, direction
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, _, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    cell = (
+                        self._objects["empty"],
+                        self._states["open"],
+                    )
+                    self._grid[self._position] = cell
+                    self._static_grid[self._position] = cell
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (object_code, state_code)
+                if object_code != self._objects["ball"]:
+                    self._static_grid[world] = (object_code, state_code)
+
+    def _reconcile_position(
+        self,
+        image: TensorValue,
+        direction: int,
+    ) -> None:
+        pending = self._pending_position
+        if pending is None:
+            return
+        old_score = self._alignment_score(
+            image,
+            direction,
+            self._position,
+        )
+        pending_score = self._alignment_score(
+            image,
+            direction,
+            pending,
+        )
+        if pending_score >= old_score:
+            self._position = pending
+        self._pending_position = None
+
+    def _alignment_score(
+        self,
+        image: TensorValue,
+        direction: int,
+        candidate: Position,
+    ) -> int:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+        score = 0
+        ignored = {
+            self._objects["unseen"],
+            self._objects["ball"],
+            self._objects["agent"],
+        }
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                if (view_x, view_y) == self._agent_view_position:
+                    continue
+                object_code, _, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if object_code in ignored:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    candidate[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    candidate[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                known = self._static_grid.get(world)
+                if known is None:
+                    continue
+                score += 2 if known == (object_code, state_code) else -3
+        return score
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> tuple[int, int, int]:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_object(self, name: str) -> Position | None:
+        code = self._objects[name]
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == code
+            ),
+            None,
+        )
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        if (
+            self._conservative_motion
+            and not self._safe_after_obstacle_motion(next_position)
+        ):
+            return _RIGHT
+        if self._conservative_motion:
+            self._position = next_position
+            return _FORWARD
+        self._pending_position = next_position
+        return _FORWARD
+
+    def _safe_after_obstacle_motion(self, destination: Position) -> bool:
+        obstacle = self._objects["ball"]
+        return all(
+            cell[0] != obstacle
+            or max(
+                abs(position[0] - destination[0]),
+                abs(position[1] - destination[1]),
+            )
+            > 1
+            for position, cell in self._grid.items()
+        )
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if not frontiers:
+            return _RIGHT
+
+        _, frontier, frontier_direction = min(
+            frontiers,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+
+        turn = _turn_toward(direction, frontier_direction)
+        if turn is not None:
+            return turn
+        return _RIGHT
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        if cell is None:
+            return False
+        return cell[0] in {
+            self._objects["empty"],
+            self._objects["floor"],
+            self._objects["goal"],
+        }
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    raw_size = parameters.get("size")
+    raw_random_start = parameters.get("random_start")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+    if type(raw_size) is not int or raw_size < 5:
+        raise ValueError("size is invalid")
+    if type(raw_random_start) is not bool:
+        raise ValueError("random_start is invalid")
+
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+        size=raw_size,
+        random_start=raw_random_start,
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/dynamic_obstacles/tests/test_dynamic_obstacles.py
+++ b/environments/minigrid/minigrid/dynamic_obstacles/tests/test_dynamic_obstacles.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_dynamic_obstacles import (
+    DynamicObstaclesBenchmark,
+    DynamicObstaclesConfig,
+    baseline_program,
+)
+
+
+class DynamicObstaclesBenchmarkTests(unittest.TestCase):
+    def test_config_profiles_define_distinct_environment_identity(self) -> None:
+        default = DynamicObstaclesBenchmark()
+        small = DynamicObstaclesBenchmark(
+            DynamicObstaclesConfig(profile="5x5-N2")
+        )
+        random = DynamicObstaclesBenchmark(
+            DynamicObstaclesConfig(profile="5x5-N2-random")
+        )
+        large = DynamicObstaclesBenchmark(
+            DynamicObstaclesConfig(profile="16x16-N8")
+        )
+
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/DynamicObstacles-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 256)
+        self.assertEqual(small.spec.max_episode_steps, 100)
+        self.assertEqual(large.spec.max_episode_steps, 1_024)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            small.spec.environment_digest,
+        )
+        self.assertNotEqual(
+            small.spec.environment_digest,
+            random.spec.environment_digest,
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["profile"],
+            "8x8-N4",
+        )
+        self.assertEqual(
+            large.spec.environment_parameters["obstacle_count"],
+            8,
+        )
+
+    def test_config_rejects_unsupported_or_ambiguous_profiles(self) -> None:
+        with self.assertRaises(ValueError):
+            DynamicObstaclesConfig(profile="8x8")
+        with self.assertRaises(ValueError):
+            DynamicObstaclesConfig(profile=8)  # type: ignore[arg-type]
+
+    def test_episode_planning_is_reproducible_and_split_scoped(self) -> None:
+        benchmark = DynamicObstaclesBenchmark()
+
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        validation = tuple(
+            benchmark.episodes("validation", seed=7, count=10)
+        )
+
+        self.assertEqual(train, repeated)
+        self.assertEqual(len({item.environment_seed for item in train}), 10)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in validation
+            )
+        )
+        self.assertTrue(all(item.scenario is None for item in train))
+
+    def test_environment_is_conformant_and_rejects_invalid_actions(
+        self,
+    ) -> None:
+        benchmark = DynamicObstaclesBenchmark(
+            DynamicObstaclesConfig(profile="5x5-N2")
+        )
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertEqual(
+                set(observation),
+                {"image", "direction", "mission"},
+            )
+            image = observation["image"]
+            self.assertIsInstance(image, TensorValue)
+            assert isinstance(image, TensorValue)
+            self.assertEqual(image.dtype, "uint8")
+            self.assertEqual(image.shape, (7, 7, 3))
+            self.assertEqual(len(image.data), 147)
+            self.assertEqual(
+                observation["mission"],
+                "get to the green goal square",
+            )
+        finally:
+            environment.close()
+            environment.close()
+
+        invalid_actions: tuple[PolicyValue, ...] = (
+            -1,
+            3,
+            6,
+            True,
+            2.0,
+            [2],
+        )
+        for invalid in invalid_actions:
+            environment = benchmark.make_environment(
+                EpisodeSpec(environment_seed=123)
+            )
+            try:
+                environment.reset()
+                with self.assertRaises(InvalidAction):
+                    environment.step(invalid)
+            finally:
+                environment.close()
+
+    def test_episode_scenario_cannot_override_benchmark_configuration(
+        self,
+    ) -> None:
+        benchmark = DynamicObstaclesBenchmark()
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(
+                    environment_seed=1,
+                    scenario={"profile": "5x5-N2"},
+                )
+            )
+
+    def test_feedback_penalizes_failure_and_keeps_identity_private(self) -> None:
+        benchmark = DynamicObstaclesBenchmark()
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+
+        feedback = benchmark.feedback((failed,))
+
+        self.assertEqual(feedback.score, 0.0)
+        self.assertEqual(len(feedback.artifacts), 1)
+        trace = feedback.artifacts[0]
+        self.assertEqual(trace.name, "trace.jsonl")
+        self.assertNotIn(b"environment_seed", trace.read_bytes())
+        self.assertNotIn(b"policy_seed", trace.read_bytes())
+        self.assertNotIn(b'"profile"', trace.read_bytes())
+        self.assertIsInstance(feedback.content, dict)
+        assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["policy_failures"], 1)
+        self.assertEqual(feedback.content["goal_found_episodes"], 0)
+        self.assertEqual(feedback.content["collision_episodes"], 0)
+
+    def test_baseline_solves_every_public_profile_and_publishes_trace(
+        self,
+    ) -> None:
+        profiles = (
+            "5x5-N2",
+            "5x5-N2-random",
+            "6x6-N3",
+            "6x6-N3-random",
+            "8x8-N4",
+            "16x16-N8",
+        )
+        for profile in profiles:
+            with self.subTest(profile=profile):
+                benchmark = DynamicObstaclesBenchmark(
+                    DynamicObstaclesConfig(profile=profile)
+                )
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=6,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+
+                self.assertEqual(
+                    result.benchmark_id,
+                    "minigrid/DynamicObstacles-v0/success-rate-v1",
+                )
+                self.assertEqual(
+                    result.environment_digest,
+                    benchmark.spec.environment_digest,
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["collision_rate"],
+                    0.0,
+                )
+                trace = result.feedback.artifacts[0]
+                documents = tuple(
+                    json.loads(line)
+                    for line in trace.read_bytes().splitlines()
+                )
+                transitions = tuple(
+                    document
+                    for document in documents
+                    if document["type"] == "transition"
+                )
+                self.assertEqual(trace.name, "trace.jsonl")
+                self.assertEqual(
+                    trace.media_type,
+                    "application/x-ndjson",
+                )
+                self.assertTrue(transitions)
+                self.assertTrue(
+                    all(
+                        "visible_objects" in item["next_observation"]
+                        for item in transitions
+                    )
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "get to the green goal square",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/dynamic_obstacles/uv.lock
+++ b/environments/minigrid/minigrid/dynamic_obstacles/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-dynamic-obstacles"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/empty/.gitignore
+++ b/environments/minigrid/minigrid/empty/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/empty/README.md
+++ b/environments/minigrid/minigrid/empty/README.md
@@ -1,0 +1,16 @@
+# MiniGrid Empty Benchmark
+
+An independently installable EvoPolicyGym Benchmark for all six MiniGrid
+`Empty` fixed- and random-start registrations.
+
+```python
+from minigrid_empty import EmptyBenchmark, EmptyConfig
+
+benchmark = EmptyBenchmark(EmptyConfig(profile="16x16"))
+```
+
+The Policy must navigate an empty room and reach the opposite-corner goal.
+Feedback reports goal discovery and success;
+the bounded semantic trace contains no seeds, private identity, or Host paths.
+The packaged baseline never moves into an unknown or observed obstacle cell.
+Trusted baseline tests use `ProcessExecution.unsafe()`, which is not a sandbox.

--- a/environments/minigrid/minigrid/empty/pyproject.toml
+++ b/environments/minigrid/minigrid/empty/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-empty"
+version = "0.1.0"
+description = "The MiniGrid Empty Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_empty"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/empty/src/minigrid_empty/__init__.py
+++ b/environments/minigrid/minigrid/empty/src/minigrid_empty/__init__.py
@@ -1,0 +1,7 @@
+"""The public MiniGrid Empty Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import EmptyBenchmark
+from .config import EmptyConfig
+
+__all__ = ["EmptyBenchmark", "EmptyConfig", "baseline_program"]

--- a/environments/minigrid/minigrid/empty/src/minigrid_empty/baseline.py
+++ b/environments/minigrid/minigrid/empty/src/minigrid_empty/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid Empty Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_empty").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/empty/src/minigrid_empty/benchmark.py
+++ b/environments/minigrid/minigrid/empty/src/minigrid_empty/benchmark.py
@@ -1,0 +1,322 @@
+"""MiniGrid Empty with deterministic plans and safety traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import EmptyConfig
+from .environment import EmptyEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-minigrid-empty/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_OBJECTS = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATES = ("open", "closed", "locked")
+_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTIONS: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRICS = {"goal_found", "success"}
+
+
+class EmptyBenchmark:
+    """Navigation success rate in an empty room."""
+
+    def __init__(self, config: EmptyConfig | None = None) -> None:
+        if config is None:
+            config = EmptyConfig()
+        if type(config) is not EmptyConfig:
+            raise TypeError("config must be EmptyConfig")
+        self._config = config
+        self._spec = _spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return EmptyEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successes = sum(_success(record) for record in records)
+        score = successes / len(records)
+        goal_found = sum(_reached(r, "goal_found") for r in records)
+        traced = records[:4]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the goal in {successes}/{len(records)} Episodes "
+                    f"({score:.3f} success rate)."
+                ),
+                "success_rate": score,
+                "goal_found_rate": goal_found / len(records),
+                "mean_return": statistics.fmean(
+                    r.total_reward if r.policy_failure is None else 0.0
+                    for r in records
+                ),
+                "mean_steps": statistics.fmean(r.steps for r in records),
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "truncated_episodes": sum(_truncated(r) for r in records),
+                "policy_failures": sum(
+                    r.policy_failure is not None for r in records
+                ),
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+            },
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec(config: EmptyConfig) -> BenchmarkSpec:
+    mission = "get to the green goal square"
+    return BenchmarkSpec(
+        id="minigrid/Empty-v0/success-rate-v1",
+        description=(
+            "Reach the opposite-corner goal from a fixed or random start in "
+            "an otherwise empty room."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "constant": mission},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTIONS,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "size": config.size,
+            "random_start": config.random_start,
+            "goal_position": [config.size - 2, config.size - 2],
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": mission,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECTS)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLORS)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATES)
+            },
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _success(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _reached(record: EpisodeRecord, name: str) -> bool:
+    return any(
+        type(item.step.metrics) is dict
+        and item.step.metrics.get(name) is True
+        for item in record.transitions
+    )
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _success(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                }
+            )
+        )
+        indices = (
+            tuple(range(record.steps))
+            if record.steps <= 160
+            else (*range(128), *range(record.steps - 32, record.steps))
+        )
+        for index in indices:
+            item = record.transitions[index]
+            if type(item.action) is not int or not 0 <= item.action <= 6:
+                raise ValueError("MiniGrid Empty trace Action is invalid")
+            if (
+                type(item.step.metrics) is not dict
+                or set(item.step.metrics) != _METRICS
+            ):
+                raise ValueError("MiniGrid Empty trace metrics are invalid")
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": index,
+                        "action": item.action,
+                        "action_meaning": _ACTIONS[str(item.action)],
+                        "reward": item.step.reward,
+                        "next_observation": _trace_observation(
+                            item.step.observation
+                        ),
+                        "terminated": item.step.terminated,
+                        "truncated": item.step.truncated,
+                        "metrics": item.step.metrics,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_observation(value: PolicyValue) -> dict[str, PolicyValue]:
+    if type(value) is not dict:
+        raise ValueError("MiniGrid Empty trace observation is invalid")
+    image = value.get("image")
+    direction = value.get("direction")
+    mission = value.get("mission")
+    if (
+        type(image) is not TensorValue
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+        or type(direction) is not int
+        or type(mission) is not str
+    ):
+        raise ValueError("MiniGrid Empty trace observation is invalid")
+    rows: list[PolicyValue] = []
+    for y in range(7):
+        rows.append(
+            "".join(
+                _SYMBOLS[image.data[(x * 7 + y) * 3]]
+                for x in range(7)
+            )
+        )
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+    }
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
+__all__ = ["EmptyBenchmark"]

--- a/environments/minigrid/minigrid/empty/src/minigrid_empty/config.py
+++ b/environments/minigrid/minigrid/empty/src/minigrid_empty/config.py
@@ -1,0 +1,45 @@
+"""Typed, public MiniGrid Empty environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int, bool]] = {
+    "5x5": ("MiniGrid-Empty-5x5-v0", 5, False),
+    "5x5-random": ("MiniGrid-Empty-Random-5x5-v0", 5, True),
+    "6x6": ("MiniGrid-Empty-6x6-v0", 6, False),
+    "6x6-random": ("MiniGrid-Empty-Random-6x6-v0", 6, True),
+    "8x8": ("MiniGrid-Empty-8x8-v0", 8, False),
+    "16x16": ("MiniGrid-Empty-16x16-v0", 16, False),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class EmptyConfig:
+    """Parameters defining one MiniGrid Empty Benchmark identity."""
+
+    profile: str = "8x8"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        return _PROFILES[self.profile][0]
+
+    @property
+    def size(self) -> int:
+        return _PROFILES[self.profile][1]
+
+    @property
+    def random_start(self) -> bool:
+        return _PROFILES[self.profile][2]
+
+    @property
+    def max_episode_steps(self) -> int:
+        return 4 * self.size**2
+
+
+__all__ = ["EmptyConfig"]

--- a/environments/minigrid/minigrid/empty/src/minigrid_empty/environment.py
+++ b/environments/minigrid/minigrid/empty/src/minigrid_empty/environment.py
@@ -1,0 +1,149 @@
+"""One fresh MiniGrid Empty Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import EmptyConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_GOAL = 8
+
+
+@dataclass(frozen=True, slots=True)
+class _Facts:
+    goal_visible: bool
+
+
+class EmptyEnvironment:
+    """Strict seeded adapter around a configured Empty registration."""
+
+    def __init__(self, episode: EpisodeSpec, *, config: EmptyConfig) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not EmptyConfig:
+            raise TypeError("config must be EmptyConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "Empty configuration belongs in EmptyConfig"
+            )
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._goal_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._goal_found = facts.goal_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid Empty returned invalid flags")
+        number = _number(reward)
+        public, facts = _observation(observation)
+        self._goal_found = self._goal_found or facts.goal_visible
+        success = bool(terminated and number > 0.0)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "goal_found": self._goal_found,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(value: object) -> tuple[dict[str, PolicyValue], _Facts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid Empty returned invalid observation")
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid Empty returned invalid image")
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid Empty returned invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid Empty returned invalid direction")
+    mission = value["mission"]
+    if (
+        type(mission) is not str
+        or mission != "get to the green goal square"
+    ):
+        raise RuntimeError("MiniGrid Empty returned invalid mission")
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _Facts(goal_visible=bool(numpy.any(image[:, :, 0] == _GOAL))),
+    )
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("MiniGrid Empty returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("MiniGrid Empty returned non-finite reward")
+    return number
+
+
+__all__ = ["EmptyEnvironment"]

--- a/environments/minigrid/minigrid/empty/src/minigrid_empty/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/empty/src/minigrid_empty/programs/baseline/policy.py
@@ -1,0 +1,272 @@
+"""A public-observation safe exploration baseline for Empty."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Reveal unknown cells without entering them and plan through openings."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._goal: Position | None = None
+        self._grid: dict[Position, Cell] = {
+            self._position: (self._objects["empty"], self._states["open"]),
+        }
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+        self._integrate(image, direction)
+        if self._goal is not None:
+            action = self._navigate(self._goal, direction)
+            if action is not None:
+                return action
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        image = observation.get("image")
+        direction = observation.get("direction")
+        if (
+            type(image) is not TensorValue
+            or image.shape != (self._view_size, self._view_size, 3)
+            or image.dtype != "uint8"
+            or type(direction) is not int
+            or not 0 <= direction <= 3
+        ):
+            raise ValueError("observation is invalid")
+        return image, direction
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _VECTORS[direction]
+        right_x, right_y = _VECTORS[(direction + 1) % 4]
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                offset = (view_x * self._view_size + view_y) * 3
+                object_code = image.data[offset]
+                state_code = image.data[offset + 2]
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (object_code, state_code)
+                if object_code == self._objects["goal"]:
+                    self._goal = world
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        return None if not path else self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        turn = _turn_toward(
+            direction,
+            _direction_between(self._position, next_position),
+        )
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers = [
+            (distance, position, frontier_direction)
+            for position, distance in distances.items()
+            for frontier_direction, neighbor in _neighbors(position)
+            if neighbor not in self._grid
+        ]
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(frontiers)
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        return _RIGHT if turn is None else turn
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        return bool(
+            cell is not None
+            and cell[0]
+            in {
+                self._objects["empty"],
+                self._objects["floor"],
+                self._objects["goal"],
+            }
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    values = context.environment_parameters
+    objects = values.get("object_encoding")
+    states = values.get("state_encoding")
+    view_size = values.get("view_size")
+    agent_position = values.get("agent_view_position")
+    names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(objects) is not dict
+        or set(objects) != names
+        or any(type(value) is not int for value in objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(states) is not dict
+        or set(states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(view_size) is not int or view_size != 7:
+        raise ValueError("view_size is invalid")
+    if type(agent_position) is not list or agent_position != [3, 6]:
+        raise ValueError("agent_view_position is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in objects.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in states.items()
+        },
+        view_size=view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        path.append(current)
+        current = previous[current]
+    path.reverse()
+    return tuple(path[1:])

--- a/environments/minigrid/minigrid/empty/tests/test_empty.py
+++ b/environments/minigrid/minigrid/empty/tests/test_empty.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import EpisodeRecord, EpisodeSpec
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_empty import (
+    EmptyBenchmark,
+    EmptyConfig,
+    baseline_program,
+)
+
+
+class EmptyTests(unittest.TestCase):
+    def test_profiles_define_upstream_identity(self) -> None:
+        default = EmptyBenchmark()
+        random = EmptyBenchmark(EmptyConfig(profile="6x6-random"))
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/Empty-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 256)
+        self.assertEqual(
+            default.spec.metadata["environment"],
+            "MiniGrid-Empty-8x8-v0",
+        )
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            random.spec.environment_digest,
+        )
+
+    def test_split_planning_and_scenario_rejection(self) -> None:
+        benchmark = EmptyBenchmark()
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"size": 11})
+            )
+
+    def test_feedback_privacy(self) -> None:
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        trace = (
+            EmptyBenchmark().feedback((failed,)).artifacts[0].read_bytes()
+        )
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+
+    def test_baseline_solves_all_profiles(self) -> None:
+        profiles = (
+            "5x5",
+            "5x5-random",
+            "6x6",
+            "6x6-random",
+            "8x8",
+            "16x16",
+        )
+        for profile in profiles:
+            with self.subTest(profile=profile):
+                benchmark = EmptyBenchmark(EmptyConfig(profile=profile))
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=6,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "get to the green goal square",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/empty/uv.lock
+++ b/environments/minigrid/minigrid/empty/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-empty"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/fetch/.gitignore
+++ b/environments/minigrid/minigrid/fetch/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/fetch/README.md
+++ b/environments/minigrid/minigrid/fetch/README.md
@@ -1,0 +1,53 @@
+# MiniGrid Fetch Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid Fetch](https://minigrid.farama.org/environments/minigrid/FetchEnv/)
+instruction-following task.
+
+The Policy receives the upstream `7 × 7 × 3` egocentric symbolic image,
+compass direction, and a natural-language mission identifying a colored key or
+ball. It must explore the room and pick up exactly the requested object;
+choosing a distractor ends the Episode with zero reward. The primary score is
+Episode success rate.
+
+## Install and test
+
+From the EvoPolicyGym repository root:
+
+```console
+uv sync --project environments/minigrid/minigrid/fetch --extra dev
+uv run --project environments/minigrid/minigrid/fetch \
+  python -m unittest discover \
+  -s environments/minigrid/minigrid/fetch/tests
+uv build environments/minigrid/minigrid/fetch
+```
+
+## Public API
+
+```python
+from minigrid_fetch import FetchBenchmark, FetchConfig, baseline_program
+
+benchmark = FetchBenchmark(
+    FetchConfig(profile="8x8-N3"),
+)
+program = baseline_program()
+```
+
+Available profiles are `5x5-N2`, `6x6-N2`, and `8x8-N3`. A profile is selected
+by the Benchmark Host before a Run, is included in the environment digest, and
+cannot be selected or changed by the Policy.
+
+Feedback reports success, whether the target was observed, and wrong-object
+pickups, together with return, step, truncation, and Policy-failure statistics.
+`trace.jsonl` contains a bounded semantic trace for at most four Episodes,
+retaining the first 128 and last 32 transitions of long Episodes. It contains
+no Episode seed, private Case identity, or Host path.
+
+The packaged baseline builds a relative map from public egocentric
+observations, parses the public mission, and shortest-path plans to the matching
+object. It consumes no private environment state.
+
+Tests that use `ProcessExecution.unsafe()` run trusted packaged code only.
+That backend is a local process mechanism, not a sandbox and not suitable for
+hostile Programs.
+

--- a/environments/minigrid/minigrid/fetch/pyproject.toml
+++ b/environments/minigrid/minigrid/fetch/pyproject.toml
@@ -1,0 +1,69 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-fetch"
+version = "0.1.0"
+description = "The MiniGrid Fetch Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = [
+    "mypy==2.3.0",
+    "ruff>=0.12.0",
+]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_fetch"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/README.md",
+    "/pyproject.toml",
+    "/src",
+    "/tests",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/fetch/src/minigrid_fetch/__init__.py
+++ b/environments/minigrid/minigrid/fetch/src/minigrid_fetch/__init__.py
@@ -1,0 +1,12 @@
+"""The public MiniGrid Fetch Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import FetchBenchmark
+from .config import FetchConfig
+
+__all__ = [
+    "FetchBenchmark",
+    "FetchConfig",
+    "baseline_program",
+]
+

--- a/environments/minigrid/minigrid/fetch/src/minigrid_fetch/baseline.py
+++ b/environments/minigrid/minigrid/fetch/src/minigrid_fetch/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid Fetch development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_fetch").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/fetch/src/minigrid_fetch/benchmark.py
+++ b/environments/minigrid/minigrid/fetch/src/minigrid_fetch/benchmark.py
@@ -1,0 +1,463 @@
+"""MiniGrid Fetch with deterministic plans and bounded semantic traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import FetchConfig
+from .environment import FetchEnvironment
+
+_EPISODE_SEED_DOMAIN = b"evopolicygym-minigrid-fetch/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_MISSION_PREFIXES = (
+    "get a ",
+    "go get a ",
+    "fetch a ",
+    "go fetch a ",
+    "you must fetch a ",
+)
+_MISSIONS = tuple(
+    f"{prefix}{color} {kind}"
+    for prefix in _MISSION_PREFIXES
+    for color in _COLOR_NAMES
+    for kind in ("key", "ball")
+)
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRIC_FIELDS = {
+    "target_found",
+    "picked_up_object",
+    "wrong_object",
+    "success",
+}
+
+
+class FetchBenchmark:
+    """Success rate on a partially observable instruction-following task."""
+
+    def __init__(self, config: FetchConfig | None = None) -> None:
+        if config is None:
+            config = FetchConfig()
+        if type(config) is not FetchConfig:
+            raise TypeError("config must be FetchConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return FetchEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        found_targets = _milestone_count(records, "target_found")
+        wrong_objects = _milestone_count(records, "wrong_object")
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        mean_success_steps: PolicyValue = (
+            statistics.fmean(record.steps for record in successful)
+            if successful
+            else None
+        )
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Fetched the mission-matching object in {successes}/"
+                    f"{len(records)} Episodes ({score:.3f} success rate); "
+                    f"{wrong_objects} picked up a wrong object."
+                ),
+                "success_rate": score,
+                "target_found_rate": found_targets / len(records),
+                "wrong_object_rate": wrong_objects / len(records),
+                "mean_return": mean_return,
+                "mean_steps": mean_steps,
+                "mean_steps_on_success": mean_success_steps,
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "target_found_episodes": found_targets,
+                "wrong_object_episodes": wrong_objects,
+                "truncated_episodes": truncations,
+                "policy_failures": failures,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+                "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+                "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+            },
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: FetchConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/Fetch-v0/success-rate-v1",
+        description=(
+            "Read the natural-language mission, explore the partially "
+            "observable room, and pick up the matching colored key or ball "
+            "without picking up a distractor. Maximize success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "meaning": {
+                        "0": "east",
+                        "1": "south",
+                        "2": "west",
+                        "3": "north",
+                    },
+                },
+                "mission": {
+                    "type": "string",
+                    "values": list(_MISSIONS),
+                },
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "size": config.size,
+            "object_count": config.object_count,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission_syntax": list(_MISSION_PREFIXES),
+            "target_types": ["key", "ball"],
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for picking up the requested "
+                "object; zero for a distractor or timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _milestone_count(
+    records: Sequence[EpisodeRecord],
+    name: str,
+) -> int:
+    return sum(_reached_milestone(record, name) for record in records)
+
+
+def _reached_milestone(record: EpisodeRecord, name: str) -> bool:
+    for transition in record.transitions:
+        metrics = transition.step.metrics
+        if type(metrics) is dict and metrics.get(name) is True:
+            return True
+    return False
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "target_found": _reached_milestone(
+                        record,
+                        "target_found",
+                    ),
+                    "wrong_object": _reached_milestone(
+                        record,
+                        "wrong_object",
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError("MiniGrid Fetch trace Action is invalid")
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if (
+        type(metrics) is not dict
+        or set(metrics) != _METRIC_FIELDS
+        or any(type(value) is not bool for value in metrics.values())
+    ):
+        raise ValueError("MiniGrid Fetch trace metrics are invalid")
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError("MiniGrid Fetch trace observation is invalid")
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("MiniGrid Fetch trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("MiniGrid Fetch trace direction is invalid")
+    if type(mission) is not str or mission not in _MISSIONS:
+        raise ValueError("MiniGrid Fetch trace mission is invalid")
+
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError("MiniGrid Fetch trace image codes are invalid")
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    target_color, target_type = _target(mission)
+    return {
+        "direction": direction,
+        "mission": mission,
+        "target_color": target_color,
+        "target_type": target_type,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _target(mission: str) -> tuple[str, str]:
+    remainder = next(
+        (
+            mission.removeprefix(prefix)
+            for prefix in _MISSION_PREFIXES
+            if mission.startswith(prefix)
+        ),
+        None,
+    )
+    if remainder is None:
+        raise ValueError("MiniGrid Fetch trace mission is invalid")
+    parts = remainder.split(" ")
+    if len(parts) != 2 or parts[0] not in _COLOR_NAMES or parts[1] not in {"key", "ball"}:
+        raise ValueError("MiniGrid Fetch trace mission is invalid")
+    return parts[0], parts[1]
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["FetchBenchmark"]

--- a/environments/minigrid/minigrid/fetch/src/minigrid_fetch/config.py
+++ b/environments/minigrid/minigrid/fetch/src/minigrid_fetch/config.py
@@ -1,0 +1,51 @@
+"""Typed, public MiniGrid Fetch environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int, int]] = {
+    "5x5-N2": ("MiniGrid-Fetch-5x5-N2-v0", 5, 2),
+    "6x6-N2": ("MiniGrid-Fetch-6x6-N2-v0", 6, 2),
+    "8x8-N3": ("MiniGrid-Fetch-8x8-N3-v0", 8, 3),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class FetchConfig:
+    """Parameters that define one MiniGrid Fetch Benchmark identity."""
+
+    profile: str = "8x8-N3"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        """Return the upstream Gymnasium registration."""
+
+        return _PROFILES[self.profile][0]
+
+    @property
+    def size(self) -> int:
+        """Return the square grid size."""
+
+        return _PROFILES[self.profile][1]
+
+    @property
+    def object_count(self) -> int:
+        """Return the number of generated candidate objects."""
+
+        return _PROFILES[self.profile][2]
+
+    @property
+    def max_episode_steps(self) -> int:
+        """Return the upstream horizon."""
+
+        return 5 * self.size**2
+
+
+__all__ = ["FetchConfig"]
+

--- a/environments/minigrid/minigrid/fetch/src/minigrid_fetch/environment.py
+++ b/environments/minigrid/minigrid/fetch/src/minigrid_fetch/environment.py
@@ -1,0 +1,228 @@
+"""One fresh MiniGrid Fetch Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401  # Import registers MiniGrid environments.
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import FetchConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_OBJECT_CODES = {"key": 5, "ball": 6}
+_MISSION_PREFIXES = (
+    "get a ",
+    "go get a ",
+    "fetch a ",
+    "go fetch a ",
+    "you must fetch a ",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ObservationFacts:
+    target_color: int
+    target_type: str
+    target_visible: bool
+    carried_color: int | None
+    carried_type: str | None
+
+
+class FetchEnvironment:
+    """The seeded strict adapter around configured MiniGrid Fetch."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: FetchConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not FetchConfig:
+            raise TypeError("config must be FetchConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "Fetch configuration belongs in FetchConfig, "
+                "not EpisodeSpec.scenario"
+            )
+
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._target: tuple[int, str] | None = None
+        self._target_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._target = (facts.target_color, facts.target_type)
+        self._target_found = facts.target_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid Fetch returned invalid termination flags")
+        number = _number(reward, name="reward")
+        public, facts = _observation(observation)
+        if (facts.target_color, facts.target_type) != self._target:
+            raise RuntimeError(
+                "MiniGrid Fetch changed target during an Episode"
+            )
+        self._target_found = self._target_found or facts.target_visible
+        picked_up_object = facts.carried_type is not None
+        success = bool(terminated and number > 0.0)
+        wrong_object = bool(terminated and picked_up_object and not success)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "target_found": self._target_found,
+                "picked_up_object": picked_up_object,
+                "wrong_object": wrong_object,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(
+    value: object,
+) -> tuple[dict[str, PolicyValue], _ObservationFacts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid Fetch returned an invalid observation")
+
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid Fetch returned an invalid image")
+    if (
+        numpy.any(image[:, :, 0] > 10)
+        or numpy.any(image[:, :, 1] > 5)
+        or numpy.any(image[:, :, 2] > 2)
+    ):
+        raise RuntimeError("MiniGrid Fetch returned out-of-range image codes")
+
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid Fetch returned an invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid Fetch returned an invalid direction")
+
+    mission = value["mission"]
+    if type(mission) is not str:
+        raise RuntimeError("MiniGrid Fetch returned an invalid mission")
+    target_color, target_type = _target(mission)
+    target_code = _OBJECT_CODES[target_type]
+    target_visible = bool(
+        numpy.any(
+            (image[:, :, 0] == target_code)
+            & (image[:, :, 1] == target_color)
+        )
+    )
+    carried_code = int(image[3, 6, 0])
+    carried_type = next(
+        (
+            name
+            for name, code in _OBJECT_CODES.items()
+            if code == carried_code
+        ),
+        None,
+    )
+    carried_color = int(image[3, 6, 1]) if carried_type is not None else None
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _ObservationFacts(
+            target_color=target_color,
+            target_type=target_type,
+            target_visible=target_visible,
+            carried_color=carried_color,
+            carried_type=carried_type,
+        ),
+    )
+
+
+def _target(mission: str) -> tuple[int, str]:
+    remainder = next(
+        (
+            mission.removeprefix(prefix)
+            for prefix in _MISSION_PREFIXES
+            if mission.startswith(prefix)
+        ),
+        None,
+    )
+    if remainder is None:
+        raise RuntimeError("MiniGrid Fetch returned an invalid mission")
+    parts = remainder.split(" ")
+    if len(parts) != 2 or parts[0] not in _COLORS or parts[1] not in _OBJECT_CODES:
+        raise RuntimeError("MiniGrid Fetch returned an invalid mission")
+    return _COLORS.index(parts[0]), parts[1]
+
+
+def _number(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(f"MiniGrid Fetch returned an invalid {name}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(f"MiniGrid Fetch returned a non-finite {name}")
+    return number
+
+
+__all__ = ["FetchEnvironment"]

--- a/environments/minigrid/minigrid/fetch/src/minigrid_fetch/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/fetch/src/minigrid_fetch/programs/baseline/policy.py
@@ -1,0 +1,406 @@
+"""A public-observation mapping and planning MiniGrid Fetch baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_PICKUP = 3
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+_MISSION_PREFIXES = (
+    "get a ",
+    "go get a ",
+    "fetch a ",
+    "go fetch a ",
+    "you must fetch a ",
+)
+
+
+class BaselinePolicy:
+    """Build a relative map and pick up only the requested object."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._target: tuple[int, int] | None = None
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction, mission = self._read_observation(observation)
+        target = self._read_target(mission)
+        if self._target is None:
+            self._target = target
+        elif self._target != target:
+            raise ValueError("mission changed during the Episode")
+        self._integrate(image, direction)
+
+        target_position = self._known_target()
+        if target_position is not None:
+            return self._interact(target_position, direction)
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int, str]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        mission = observation["mission"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        if type(mission) is not str:
+            raise ValueError("observation mission is invalid")
+        return image, direction, mission
+
+    def _read_target(self, mission: str) -> tuple[int, int]:
+        remainder = next(
+            (
+                mission.removeprefix(prefix)
+                for prefix in _MISSION_PREFIXES
+                if mission.startswith(prefix)
+            ),
+            None,
+        )
+        if remainder is None:
+            raise ValueError("observation mission is invalid")
+        parts = remainder.split(" ")
+        if (
+            len(parts) != 2
+            or parts[0] not in self._colors
+            or parts[1] not in {"key", "ball"}
+        ):
+            raise ValueError("observation mission is invalid")
+        return self._objects[parts[1]], self._colors[parts[0]]
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_target(self) -> Position | None:
+        if self._target is None:
+            return None
+        target_object, target_color = self._target
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == target_object and cell[1] == target_color
+            ),
+            None,
+        )
+
+    def _interact(self, target: Position, direction: int) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+
+        target_direction = _direction_between(approach_position, target)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        return _PICKUP
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if not frontiers:
+            return _RIGHT
+
+        _, frontier, frontier_direction = min(
+            frontiers,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+
+        turn = _turn_toward(direction, frontier_direction)
+        if turn is not None:
+            return turn
+        return _RIGHT
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        if cell is None:
+            return False
+        return cell[0] in {
+            self._objects["empty"],
+            self._objects["floor"],
+            self._objects["goal"],
+        }
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_colors = parameters.get("color_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_colors) is not dict
+        or set(raw_colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in raw_colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in raw_colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/fetch/tests/test_fetch.py
+++ b/environments/minigrid/minigrid/fetch/tests/test_fetch.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_fetch import FetchBenchmark, FetchConfig, baseline_program
+
+
+class FetchBenchmarkTests(unittest.TestCase):
+    def test_config_profiles_define_distinct_environment_identity(self) -> None:
+        default = FetchBenchmark()
+        small = FetchBenchmark(FetchConfig(profile="5x5-N2"))
+        medium = FetchBenchmark(FetchConfig(profile="6x6-N2"))
+
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/Fetch-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 320)
+        self.assertEqual(small.spec.max_episode_steps, 125)
+        self.assertEqual(medium.spec.max_episode_steps, 180)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            small.spec.environment_digest,
+        )
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            medium.spec.environment_digest,
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["profile"],
+            "8x8-N3",
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["object_count"],
+            3,
+        )
+
+        exposed = default.spec.environment_parameters["color_encoding"]
+        self.assertIsInstance(exposed, dict)
+        assert isinstance(exposed, dict)
+        exposed["purple"] = 100
+        fresh = default.spec.environment_parameters["color_encoding"]
+        self.assertIsInstance(fresh, dict)
+        assert isinstance(fresh, dict)
+        self.assertEqual(fresh["purple"], 3)
+
+    def test_config_rejects_unsupported_or_ambiguous_profiles(self) -> None:
+        with self.assertRaises(ValueError):
+            FetchConfig(profile="8x8")
+        with self.assertRaises(ValueError):
+            FetchConfig(profile=8)  # type: ignore[arg-type]
+
+    def test_episode_planning_is_reproducible_and_split_scoped(self) -> None:
+        benchmark = FetchBenchmark()
+
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        validation = tuple(
+            benchmark.episodes("validation", seed=7, count=10)
+        )
+
+        self.assertEqual(train, repeated)
+        self.assertEqual(len({item.environment_seed for item in train}), 10)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in validation
+            )
+        )
+        self.assertTrue(all(item.scenario is None for item in train))
+
+    def test_environment_is_conformant_and_rejects_invalid_actions(
+        self,
+    ) -> None:
+        benchmark = FetchBenchmark(FetchConfig(profile="5x5-N2"))
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertEqual(
+                set(observation),
+                {"image", "direction", "mission"},
+            )
+            image = observation["image"]
+            self.assertIsInstance(image, TensorValue)
+            assert isinstance(image, TensorValue)
+            self.assertEqual(image.dtype, "uint8")
+            self.assertEqual(image.shape, (7, 7, 3))
+            self.assertEqual(len(image.data), 147)
+            mission = observation["mission"]
+            self.assertIsInstance(mission, str)
+            assert isinstance(mission, str)
+            self.assertTrue(mission.endswith((" key", " ball")))
+        finally:
+            environment.close()
+            environment.close()
+
+        invalid_actions: tuple[PolicyValue, ...] = (
+            -1,
+            7,
+            True,
+            2.0,
+            [2],
+        )
+        for invalid in invalid_actions:
+            environment = benchmark.make_environment(
+                EpisodeSpec(environment_seed=123)
+            )
+            try:
+                environment.reset()
+                with self.assertRaises(InvalidAction):
+                    environment.step(invalid)
+            finally:
+                environment.close()
+
+    def test_episode_scenario_cannot_override_benchmark_configuration(
+        self,
+    ) -> None:
+        benchmark = FetchBenchmark()
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(
+                    environment_seed=1,
+                    scenario={"profile": "5x5-N2"},
+                )
+            )
+
+    def test_feedback_penalizes_failure_and_keeps_identity_private(self) -> None:
+        benchmark = FetchBenchmark()
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+
+        feedback = benchmark.feedback((failed,))
+
+        self.assertEqual(feedback.score, 0.0)
+        self.assertEqual(len(feedback.artifacts), 1)
+        trace = feedback.artifacts[0]
+        self.assertEqual(trace.name, "trace.jsonl")
+        self.assertNotIn(b"environment_seed", trace.read_bytes())
+        self.assertNotIn(b"policy_seed", trace.read_bytes())
+        self.assertNotIn(b'"profile"', trace.read_bytes())
+        self.assertIsInstance(feedback.content, dict)
+        assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["policy_failures"], 1)
+        self.assertEqual(feedback.content["target_found_episodes"], 0)
+        self.assertEqual(feedback.content["wrong_object_episodes"], 0)
+
+    def test_baseline_solves_every_public_profile_and_publishes_trace(
+        self,
+    ) -> None:
+        for profile in ("5x5-N2", "6x6-N2", "8x8-N3"):
+            with self.subTest(profile=profile):
+                benchmark = FetchBenchmark(FetchConfig(profile=profile))
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=8,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+
+                self.assertEqual(
+                    result.benchmark_id,
+                    "minigrid/Fetch-v0/success-rate-v1",
+                )
+                self.assertEqual(
+                    result.environment_digest,
+                    benchmark.spec.environment_digest,
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["target_found_rate"],
+                    1.0,
+                )
+                self.assertEqual(
+                    result.feedback.content["wrong_object_rate"],
+                    0.0,
+                )
+                trace = result.feedback.artifacts[0]
+                documents = tuple(
+                    json.loads(line)
+                    for line in trace.read_bytes().splitlines()
+                )
+                transitions = tuple(
+                    document
+                    for document in documents
+                    if document["type"] == "transition"
+                )
+                self.assertEqual(trace.name, "trace.jsonl")
+                self.assertEqual(
+                    trace.media_type,
+                    "application/x-ndjson",
+                )
+                self.assertTrue(transitions)
+                self.assertTrue(
+                    all(
+                        "target_color" in item["next_observation"]
+                        and "target_type" in item["next_observation"]
+                        for item in transitions
+                    )
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "fetch a purple ball",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/fetch/uv.lock
+++ b/environments/minigrid/minigrid/fetch/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-fetch"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/four_rooms/.gitignore
+++ b/environments/minigrid/minigrid/four_rooms/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/four_rooms/README.md
+++ b/environments/minigrid/minigrid/four_rooms/README.md
@@ -1,0 +1,17 @@
+# MiniGrid FourRooms Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the MiniGrid
+`FourRooms` registration.
+
+```python
+from minigrid_four_rooms import FourRoomsBenchmark
+
+benchmark = FourRoomsBenchmark()
+```
+
+The Policy must explore generated openings between four rooms and reach the
+randomly placed goal. Feedback reports goal discovery and success;
+the bounded semantic trace contains no seeds, private identity, or Host paths.
+The packaged baseline never moves into an unknown or observed obstacle cell.
+The fixed public horizon is 256 steps (the upstream default is 100).
+Trusted baseline tests use `ProcessExecution.unsafe()`, which is not a sandbox.

--- a/environments/minigrid/minigrid/four_rooms/pyproject.toml
+++ b/environments/minigrid/minigrid/four_rooms/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-four-rooms"
+version = "0.1.0"
+description = "The MiniGrid FourRooms Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_four_rooms"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/__init__.py
+++ b/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/__init__.py
@@ -1,0 +1,6 @@
+"""The public MiniGrid FourRooms Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import FourRoomsBenchmark
+
+__all__ = ["FourRoomsBenchmark", "baseline_program"]

--- a/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/baseline.py
+++ b/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid FourRooms Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_four_rooms").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/benchmark.py
+++ b/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/benchmark.py
@@ -1,0 +1,316 @@
+"""MiniGrid FourRooms with deterministic plans and safety traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .environment import FourRoomsEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-minigrid-four_rooms/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_EPISODE_STEPS = 256
+_OBJECTS = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATES = ("open", "closed", "locked")
+_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTIONS: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRICS = {"goal_found", "success"}
+
+
+class FourRoomsBenchmark:
+    """Navigation success rate in the generated four-room maze."""
+
+    def __init__(self) -> None:
+        self._spec = _spec()
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return FourRoomsEnvironment(episode)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successes = sum(_success(record) for record in records)
+        score = successes / len(records)
+        goal_found = sum(_reached(r, "goal_found") for r in records)
+        traced = records[:4]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the goal in {successes}/{len(records)} Episodes "
+                    f"({score:.3f} success rate)."
+                ),
+                "success_rate": score,
+                "goal_found_rate": goal_found / len(records),
+                "mean_return": statistics.fmean(
+                    r.total_reward if r.policy_failure is None else 0.0
+                    for r in records
+                ),
+                "mean_steps": statistics.fmean(r.steps for r in records),
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "truncated_episodes": sum(_truncated(r) for r in records),
+                "policy_failures": sum(
+                    r.policy_failure is not None for r in records
+                ),
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+            },
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec() -> BenchmarkSpec:
+    mission = "reach the goal"
+    return BenchmarkSpec(
+        id="minigrid/FourRooms-v0/success-rate-v1",
+        description=(
+            "Explore four rooms connected by generated openings and reach a "
+            "randomly placed goal."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "constant": mission},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTIONS,
+        },
+        metadata={
+            "environment": "MiniGrid-FourRooms-v0",
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "size": 19,
+            "rooms": 4,
+            "upstream_default_max_episode_steps": 100,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": mission,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECTS)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLORS)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATES)
+            },
+        },
+        max_episode_steps=_MAX_EPISODE_STEPS,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _success(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _reached(record: EpisodeRecord, name: str) -> bool:
+    return any(
+        type(item.step.metrics) is dict
+        and item.step.metrics.get(name) is True
+        for item in record.transitions
+    )
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _success(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                }
+            )
+        )
+        indices = (
+            tuple(range(record.steps))
+            if record.steps <= 160
+            else (*range(128), *range(record.steps - 32, record.steps))
+        )
+        for index in indices:
+            item = record.transitions[index]
+            if type(item.action) is not int or not 0 <= item.action <= 6:
+                raise ValueError("MiniGrid FourRooms trace Action is invalid")
+            if (
+                type(item.step.metrics) is not dict
+                or set(item.step.metrics) != _METRICS
+            ):
+                raise ValueError("MiniGrid FourRooms trace metrics are invalid")
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": index,
+                        "action": item.action,
+                        "action_meaning": _ACTIONS[str(item.action)],
+                        "reward": item.step.reward,
+                        "next_observation": _trace_observation(
+                            item.step.observation
+                        ),
+                        "terminated": item.step.terminated,
+                        "truncated": item.step.truncated,
+                        "metrics": item.step.metrics,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_observation(value: PolicyValue) -> dict[str, PolicyValue]:
+    if type(value) is not dict:
+        raise ValueError("MiniGrid FourRooms trace observation is invalid")
+    image = value.get("image")
+    direction = value.get("direction")
+    mission = value.get("mission")
+    if (
+        type(image) is not TensorValue
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+        or type(direction) is not int
+        or type(mission) is not str
+    ):
+        raise ValueError("MiniGrid FourRooms trace observation is invalid")
+    rows: list[PolicyValue] = []
+    for y in range(7):
+        rows.append(
+            "".join(
+                _SYMBOLS[image.data[(x * 7 + y) * 3]]
+                for x in range(7)
+            )
+        )
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+    }
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
+__all__ = ["FourRoomsBenchmark"]

--- a/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/environment.py
+++ b/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/environment.py
@@ -1,0 +1,144 @@
+"""One fresh MiniGrid FourRooms Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_GOAL = 8
+_MAX_EPISODE_STEPS = 256
+
+
+@dataclass(frozen=True, slots=True)
+class _Facts:
+    goal_visible: bool
+
+
+class FourRoomsEnvironment:
+    """Strict seeded adapter around a configured FourRooms registration."""
+
+    def __init__(self, episode: EpisodeSpec) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if episode.scenario is not None:
+            raise ValueError("FourRooms has no Episode scenario overrides")
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(
+                "MiniGrid-FourRooms-v0",
+                max_steps=_MAX_EPISODE_STEPS,
+            ),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._goal_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._goal_found = facts.goal_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid FourRooms returned invalid flags")
+        number = _number(reward)
+        public, facts = _observation(observation)
+        self._goal_found = self._goal_found or facts.goal_visible
+        success = bool(terminated and number > 0.0)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "goal_found": self._goal_found,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(value: object) -> tuple[dict[str, PolicyValue], _Facts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid FourRooms returned invalid observation")
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid FourRooms returned invalid image")
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid FourRooms returned invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid FourRooms returned invalid direction")
+    mission = value["mission"]
+    if type(mission) is not str or mission != "reach the goal":
+        raise RuntimeError("MiniGrid FourRooms returned invalid mission")
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _Facts(goal_visible=bool(numpy.any(image[:, :, 0] == _GOAL))),
+    )
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("MiniGrid FourRooms returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("MiniGrid FourRooms returned non-finite reward")
+    return number
+
+
+__all__ = ["FourRoomsEnvironment"]

--- a/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/programs/baseline/policy.py
@@ -1,0 +1,272 @@
+"""A public-observation safe exploration baseline for FourRooms."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Reveal unknown cells without entering them and plan through openings."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._goal: Position | None = None
+        self._grid: dict[Position, Cell] = {
+            self._position: (self._objects["empty"], self._states["open"]),
+        }
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+        self._integrate(image, direction)
+        if self._goal is not None:
+            action = self._navigate(self._goal, direction)
+            if action is not None:
+                return action
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        image = observation.get("image")
+        direction = observation.get("direction")
+        if (
+            type(image) is not TensorValue
+            or image.shape != (self._view_size, self._view_size, 3)
+            or image.dtype != "uint8"
+            or type(direction) is not int
+            or not 0 <= direction <= 3
+        ):
+            raise ValueError("observation is invalid")
+        return image, direction
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _VECTORS[direction]
+        right_x, right_y = _VECTORS[(direction + 1) % 4]
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                offset = (view_x * self._view_size + view_y) * 3
+                object_code = image.data[offset]
+                state_code = image.data[offset + 2]
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (object_code, state_code)
+                if object_code == self._objects["goal"]:
+                    self._goal = world
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        return None if not path else self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        turn = _turn_toward(
+            direction,
+            _direction_between(self._position, next_position),
+        )
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers = [
+            (distance, position, frontier_direction)
+            for position, distance in distances.items()
+            for frontier_direction, neighbor in _neighbors(position)
+            if neighbor not in self._grid
+        ]
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(frontiers)
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        return _RIGHT if turn is None else turn
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        return bool(
+            cell is not None
+            and cell[0]
+            in {
+                self._objects["empty"],
+                self._objects["floor"],
+                self._objects["goal"],
+            }
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    values = context.environment_parameters
+    objects = values.get("object_encoding")
+    states = values.get("state_encoding")
+    view_size = values.get("view_size")
+    agent_position = values.get("agent_view_position")
+    names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(objects) is not dict
+        or set(objects) != names
+        or any(type(value) is not int for value in objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(states) is not dict
+        or set(states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(view_size) is not int or view_size != 7:
+        raise ValueError("view_size is invalid")
+    if type(agent_position) is not list or agent_position != [3, 6]:
+        raise ValueError("agent_view_position is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in objects.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in states.items()
+        },
+        view_size=view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        path.append(current)
+        current = previous[current]
+    path.reverse()
+    return tuple(path[1:])

--- a/environments/minigrid/minigrid/four_rooms/tests/test_four_rooms.py
+++ b/environments/minigrid/minigrid/four_rooms/tests/test_four_rooms.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import EpisodeRecord, EpisodeSpec
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_four_rooms import (
+    FourRoomsBenchmark,
+    baseline_program,
+)
+
+
+class FourRoomsTests(unittest.TestCase):
+    def test_spec_defines_upstream_identity(self) -> None:
+        default = FourRoomsBenchmark()
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/FourRooms-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 256)
+        self.assertEqual(
+            default.spec.metadata["environment"],
+            "MiniGrid-FourRooms-v0",
+        )
+
+    def test_split_planning_and_scenario_rejection(self) -> None:
+        benchmark = FourRoomsBenchmark()
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"size": 11})
+            )
+
+    def test_feedback_privacy(self) -> None:
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        trace = (
+            FourRoomsBenchmark().feedback((failed,)).artifacts[0].read_bytes()
+        )
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+
+    def test_baseline_solves_seeded_episodes(self) -> None:
+        benchmark = FourRoomsBenchmark()
+        result = evaluate(
+            baseline_program(),
+            benchmark,
+            execution=ProcessExecution.unsafe(),
+            config=EvaluationConfig(
+                split="validation",
+                episodes=6,
+                seed=5,
+                episode_timeout_seconds=10,
+            ),
+        )
+        self.assertEqual(result.feedback.score, 1.0)
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "reach the goal",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/four_rooms/uv.lock
+++ b/environments/minigrid/minigrid/four_rooms/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-four-rooms"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/go_to_door/.gitignore
+++ b/environments/minigrid/minigrid/go_to_door/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/go_to_door/README.md
+++ b/environments/minigrid/minigrid/go_to_door/README.md
@@ -1,0 +1,51 @@
+# MiniGrid GoToDoor Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid GoToDoor](https://minigrid.farama.org/environments/minigrid/GoToDoorEnv/)
+instruction-following task.
+
+The Policy receives the upstream `7 × 7 × 3` egocentric symbolic image,
+compass direction, and a natural-language mission identifying a colored door.
+It must explore the room, stand next to that door, and issue `done`; an
+incorrect completion ends the Episode with zero reward.
+
+## Install and test
+
+From the EvoPolicyGym repository root:
+
+```console
+uv sync --project environments/minigrid/minigrid/go_to_door --extra dev
+uv run --project environments/minigrid/minigrid/go_to_door \
+  python -m unittest discover \
+  -s environments/minigrid/minigrid/go_to_door/tests
+uv build environments/minigrid/minigrid/go_to_door
+```
+
+## Public API
+
+```python
+from minigrid_go_to_door import GoToDoorBenchmark, GoToDoorConfig, baseline_program
+
+benchmark = GoToDoorBenchmark(
+    GoToDoorConfig(profile="8x8"),
+)
+program = baseline_program()
+```
+
+Available profiles are `5x5`, `6x6`, and `8x8`. A profile is selected
+by the Benchmark Host before a Run, is included in the environment digest, and
+cannot be selected or changed by the Policy.
+
+Feedback reports success, whether the target was observed, and incorrect
+completions, together with return, step, truncation, and Policy-failure statistics.
+`trace.jsonl` contains a bounded semantic trace for at most four Episodes,
+retaining the first 128 and last 32 transitions of long Episodes. It contains
+no Episode seed, private Case identity, or Host path.
+
+The packaged baseline builds a relative map from public egocentric
+observations, parses the public mission, and shortest-path plans to the matching
+object. It consumes no private environment state.
+
+Tests that use `ProcessExecution.unsafe()` run trusted packaged code only.
+That backend is a local process mechanism, not a sandbox and not suitable for
+hostile Programs.

--- a/environments/minigrid/minigrid/go_to_door/pyproject.toml
+++ b/environments/minigrid/minigrid/go_to_door/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-go-to-door"
+version = "0.1.0"
+description = "The MiniGrid GoToDoor Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = [
+    "mypy==2.3.0",
+    "ruff>=0.12.0",
+]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_go_to_door"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/README.md",
+    "/pyproject.toml",
+    "/src",
+    "/tests",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/__init__.py
+++ b/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/__init__.py
@@ -1,0 +1,12 @@
+"""The public MiniGrid GoToDoor Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import GoToDoorBenchmark
+from .config import GoToDoorConfig
+
+__all__ = [
+    "GoToDoorBenchmark",
+    "GoToDoorConfig",
+    "baseline_program",
+]
+

--- a/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/baseline.py
+++ b/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid GoToDoor development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_go_to_door").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/benchmark.py
+++ b/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/benchmark.py
@@ -1,0 +1,451 @@
+"""MiniGrid GoToDoor with deterministic plans and bounded semantic traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import GoToDoorConfig
+from .environment import GoToDoorEnvironment
+
+_EPISODE_SEED_DOMAIN = b"evopolicygym-minigrid-go_to_door/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_MISSIONS = tuple(
+    f"go to the {color} door"
+    for color in _COLOR_NAMES
+)
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRIC_FIELDS = {
+    "target_found",
+    "wrong_completion",
+    "success",
+}
+
+
+class GoToDoorBenchmark:
+    """Success rate on a partially observable instruction-following task."""
+
+    def __init__(self, config: GoToDoorConfig | None = None) -> None:
+        if config is None:
+            config = GoToDoorConfig()
+        if type(config) is not GoToDoorConfig:
+            raise TypeError("config must be GoToDoorConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return GoToDoorEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        found_targets = _milestone_count(records, "target_found")
+        wrong_completions = _milestone_count(records, "wrong_completion")
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        mean_success_steps: PolicyValue = (
+            statistics.fmean(record.steps for record in successful)
+            if successful
+            else None
+        )
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the mission-matching object in {successes}/"
+                    f"{len(records)} Episodes ({score:.3f} success rate); "
+                    f"{wrong_completions} incorrect completions."
+                ),
+                "success_rate": score,
+                "target_found_rate": found_targets / len(records),
+                "wrong_completion_rate": wrong_completions / len(records),
+                "mean_return": mean_return,
+                "mean_steps": mean_steps,
+                "mean_steps_on_success": mean_success_steps,
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "target_found_episodes": found_targets,
+                "wrong_completion_episodes": wrong_completions,
+                "truncated_episodes": truncations,
+                "policy_failures": failures,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+                "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+                "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+            },
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: GoToDoorConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/GoToDoor-v0/success-rate-v1",
+        description=(
+            "Read the natural-language mission, explore the partially "
+            "observable room, stand next to the matching colored door, and "
+            "declare completion. Maximize success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "meaning": {
+                        "0": "east",
+                        "1": "south",
+                        "2": "west",
+                        "3": "north",
+                    },
+                },
+                "mission": {
+                    "type": "string",
+                    "values": list(_MISSIONS),
+                },
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "size": config.size,
+            "object_count": config.object_count,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission_syntax": "go to the {color} door",
+            "target_types": ["door"],
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for picking up the requested "
+                "object; zero for a distractor or timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _milestone_count(
+    records: Sequence[EpisodeRecord],
+    name: str,
+) -> int:
+    return sum(_reached_milestone(record, name) for record in records)
+
+
+def _reached_milestone(record: EpisodeRecord, name: str) -> bool:
+    for transition in record.transitions:
+        metrics = transition.step.metrics
+        if type(metrics) is dict and metrics.get(name) is True:
+            return True
+    return False
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "target_found": _reached_milestone(
+                        record,
+                        "target_found",
+                    ),
+                    "wrong_completion": _reached_milestone(
+                        record,
+                        "wrong_completion",
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError("MiniGrid GoToDoor trace Action is invalid")
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if (
+        type(metrics) is not dict
+        or set(metrics) != _METRIC_FIELDS
+        or any(type(value) is not bool for value in metrics.values())
+    ):
+        raise ValueError("MiniGrid GoToDoor trace metrics are invalid")
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError("MiniGrid GoToDoor trace observation is invalid")
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("MiniGrid GoToDoor trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("MiniGrid GoToDoor trace direction is invalid")
+    if type(mission) is not str or mission not in _MISSIONS:
+        raise ValueError("MiniGrid GoToDoor trace mission is invalid")
+
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError("MiniGrid GoToDoor trace image codes are invalid")
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    target_color, target_type = _target(mission)
+    return {
+        "direction": direction,
+        "mission": mission,
+        "target_color": target_color,
+        "target_type": target_type,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _target(mission: str) -> tuple[str, str]:
+    prefix = "go to the "
+    if not mission.startswith(prefix):
+        raise ValueError("MiniGrid GoToDoor trace mission is invalid")
+    remainder = mission.removeprefix(prefix)
+    parts = remainder.split(" ")
+    if (
+        len(parts) != 2
+        or parts[0] not in _COLOR_NAMES
+        or parts[1] != "door"
+    ):
+        raise ValueError("MiniGrid GoToDoor trace mission is invalid")
+    return parts[0], parts[1]
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["GoToDoorBenchmark"]

--- a/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/config.py
+++ b/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/config.py
@@ -1,0 +1,50 @@
+"""Typed, public MiniGrid GoToDoor environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int, int]] = {
+    "5x5": ("MiniGrid-GoToDoor-5x5-v0", 5, 4),
+    "6x6": ("MiniGrid-GoToDoor-6x6-v0", 6, 4),
+    "8x8": ("MiniGrid-GoToDoor-8x8-v0", 8, 4),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class GoToDoorConfig:
+    """Parameters that define one MiniGrid GoToDoor Benchmark identity."""
+
+    profile: str = "8x8"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        """Return the upstream Gymnasium registration."""
+
+        return _PROFILES[self.profile][0]
+
+    @property
+    def size(self) -> int:
+        """Return the square grid size."""
+
+        return _PROFILES[self.profile][1]
+
+    @property
+    def object_count(self) -> int:
+        """Return the number of generated candidate doors."""
+
+        return _PROFILES[self.profile][2]
+
+    @property
+    def max_episode_steps(self) -> int:
+        """Return the upstream horizon."""
+
+        return 4 * self.size**2
+
+
+__all__ = ["GoToDoorConfig"]

--- a/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/environment.py
+++ b/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/environment.py
@@ -1,0 +1,201 @@
+"""One fresh MiniGrid GoToDoor Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401  # Import registers MiniGrid environments.
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import GoToDoorConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_OBJECT_CODES = {"door": 4}
+
+
+@dataclass(frozen=True, slots=True)
+class _ObservationFacts:
+    target_color: int
+    target_type: str
+    target_visible: bool
+
+
+class GoToDoorEnvironment:
+    """The seeded strict adapter around configured MiniGrid GoToDoor."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: GoToDoorConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not GoToDoorConfig:
+            raise TypeError("config must be GoToDoorConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "GoToDoor configuration belongs in GoToDoorConfig, "
+                "not EpisodeSpec.scenario"
+            )
+
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._target: tuple[int, str] | None = None
+        self._target_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._target = (facts.target_color, facts.target_type)
+        self._target_found = facts.target_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid GoToDoor returned invalid termination flags")
+        number = _number(reward, name="reward")
+        public, facts = _observation(observation)
+        if (facts.target_color, facts.target_type) != self._target:
+            raise RuntimeError(
+                "MiniGrid GoToDoor changed target during an Episode"
+            )
+        self._target_found = self._target_found or facts.target_visible
+        success = bool(terminated and number > 0.0)
+        wrong_completion = bool(
+            terminated and action in {5, 6} and not success
+        )
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "target_found": self._target_found,
+                "wrong_completion": wrong_completion,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(
+    value: object,
+) -> tuple[dict[str, PolicyValue], _ObservationFacts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid GoToDoor returned an invalid observation")
+
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid GoToDoor returned an invalid image")
+    if (
+        numpy.any(image[:, :, 0] > 10)
+        or numpy.any(image[:, :, 1] > 5)
+        or numpy.any(image[:, :, 2] > 2)
+    ):
+        raise RuntimeError("MiniGrid GoToDoor returned out-of-range image codes")
+
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid GoToDoor returned an invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid GoToDoor returned an invalid direction")
+
+    mission = value["mission"]
+    if type(mission) is not str:
+        raise RuntimeError("MiniGrid GoToDoor returned an invalid mission")
+    target_color, target_type = _target(mission)
+    target_code = _OBJECT_CODES[target_type]
+    target_visible = bool(
+        numpy.any(
+            (image[:, :, 0] == target_code)
+            & (image[:, :, 1] == target_color)
+        )
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _ObservationFacts(
+            target_color=target_color,
+            target_type=target_type,
+            target_visible=target_visible,
+        ),
+    )
+
+
+def _target(mission: str) -> tuple[int, str]:
+    prefix = "go to the "
+    if not mission.startswith(prefix):
+        raise RuntimeError("MiniGrid GoToDoor returned an invalid mission")
+    remainder = mission.removeprefix(prefix)
+    parts = remainder.split(" ")
+    if len(parts) != 2 or parts[0] not in _COLORS or parts[1] not in _OBJECT_CODES:
+        raise RuntimeError("MiniGrid GoToDoor returned an invalid mission")
+    return _COLORS.index(parts[0]), parts[1]
+
+
+def _number(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(f"MiniGrid GoToDoor returned an invalid {name}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(f"MiniGrid GoToDoor returned a non-finite {name}")
+    return number
+
+
+__all__ = ["GoToDoorEnvironment"]

--- a/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/programs/baseline/policy.py
@@ -1,0 +1,387 @@
+"""A public-observation mapping and planning MiniGrid GoToDoor baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_DONE = 6
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+class BaselinePolicy:
+    """Build a relative map and stop next to the requested object."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._target: tuple[int, int] | None = None
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction, mission = self._read_observation(observation)
+        target = self._read_target(mission)
+        if self._target is None:
+            self._target = target
+        elif self._target != target:
+            raise ValueError("mission changed during the Episode")
+        self._integrate(image, direction)
+
+        target_position = self._known_target()
+        if target_position is not None:
+            return self._interact(target_position, direction)
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int, str]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        mission = observation["mission"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        if type(mission) is not str:
+            raise ValueError("observation mission is invalid")
+        return image, direction, mission
+
+    def _read_target(self, mission: str) -> tuple[int, int]:
+        prefix = "go to the "
+        if not mission.startswith(prefix):
+            raise ValueError("observation mission is invalid")
+        remainder = mission.removeprefix(prefix)
+        parts = remainder.split(" ")
+        if (
+            len(parts) != 2
+            or parts[0] not in self._colors
+            or parts[1] != "door"
+        ):
+            raise ValueError("observation mission is invalid")
+        return self._objects[parts[1]], self._colors[parts[0]]
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_target(self) -> Position | None:
+        if self._target is None:
+            return None
+        target_object, target_color = self._target
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == target_object and cell[1] == target_color
+            ),
+            None,
+        )
+
+    def _interact(self, target: Position, direction: int) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+
+        return _DONE
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if not frontiers:
+            return _RIGHT
+
+        _, frontier, frontier_direction = min(
+            frontiers,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+
+        turn = _turn_toward(direction, frontier_direction)
+        if turn is not None:
+            return turn
+        return _RIGHT
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        if cell is None:
+            return False
+        return cell[0] in {
+            self._objects["empty"],
+            self._objects["floor"],
+            self._objects["goal"],
+        }
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_colors = parameters.get("color_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_colors) is not dict
+        or set(raw_colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in raw_colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in raw_colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/go_to_door/tests/test_go_to_door.py
+++ b/environments/minigrid/minigrid/go_to_door/tests/test_go_to_door.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_go_to_door import GoToDoorBenchmark, GoToDoorConfig, baseline_program
+
+
+class GoToDoorBenchmarkTests(unittest.TestCase):
+    def test_config_profiles_define_distinct_environment_identity(self) -> None:
+        default = GoToDoorBenchmark()
+        small = GoToDoorBenchmark(GoToDoorConfig(profile="5x5"))
+
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/GoToDoor-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 256)
+        self.assertEqual(small.spec.max_episode_steps, 100)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            small.spec.environment_digest,
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["profile"],
+            "8x8",
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["object_count"],
+            4,
+        )
+
+        exposed = default.spec.environment_parameters["color_encoding"]
+        self.assertIsInstance(exposed, dict)
+        assert isinstance(exposed, dict)
+        exposed["purple"] = 100
+        fresh = default.spec.environment_parameters["color_encoding"]
+        self.assertIsInstance(fresh, dict)
+        assert isinstance(fresh, dict)
+        self.assertEqual(fresh["purple"], 3)
+
+    def test_config_rejects_unsupported_or_ambiguous_profiles(self) -> None:
+        with self.assertRaises(ValueError):
+            GoToDoorConfig(profile="7x7")
+        with self.assertRaises(ValueError):
+            GoToDoorConfig(profile=8)  # type: ignore[arg-type]
+
+    def test_episode_planning_is_reproducible_and_split_scoped(self) -> None:
+        benchmark = GoToDoorBenchmark()
+
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        validation = tuple(
+            benchmark.episodes("validation", seed=7, count=10)
+        )
+
+        self.assertEqual(train, repeated)
+        self.assertEqual(len({item.environment_seed for item in train}), 10)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in validation
+            )
+        )
+        self.assertTrue(all(item.scenario is None for item in train))
+
+    def test_environment_is_conformant_and_rejects_invalid_actions(
+        self,
+    ) -> None:
+        benchmark = GoToDoorBenchmark(GoToDoorConfig(profile="5x5"))
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertEqual(
+                set(observation),
+                {"image", "direction", "mission"},
+            )
+            image = observation["image"]
+            self.assertIsInstance(image, TensorValue)
+            assert isinstance(image, TensorValue)
+            self.assertEqual(image.dtype, "uint8")
+            self.assertEqual(image.shape, (7, 7, 3))
+            self.assertEqual(len(image.data), 147)
+            mission = observation["mission"]
+            self.assertIsInstance(mission, str)
+            assert isinstance(mission, str)
+            self.assertTrue(mission.endswith(" door"))
+        finally:
+            environment.close()
+            environment.close()
+
+        invalid_actions: tuple[PolicyValue, ...] = (
+            -1,
+            7,
+            True,
+            2.0,
+            [2],
+        )
+        for invalid in invalid_actions:
+            environment = benchmark.make_environment(
+                EpisodeSpec(environment_seed=123)
+            )
+            try:
+                environment.reset()
+                with self.assertRaises(InvalidAction):
+                    environment.step(invalid)
+            finally:
+                environment.close()
+
+    def test_episode_scenario_cannot_override_benchmark_configuration(
+        self,
+    ) -> None:
+        benchmark = GoToDoorBenchmark()
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(
+                    environment_seed=1,
+                    scenario={"profile": "5x5"},
+                )
+            )
+
+    def test_feedback_penalizes_failure_and_keeps_identity_private(self) -> None:
+        benchmark = GoToDoorBenchmark()
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+
+        feedback = benchmark.feedback((failed,))
+
+        self.assertEqual(feedback.score, 0.0)
+        self.assertEqual(len(feedback.artifacts), 1)
+        trace = feedback.artifacts[0]
+        self.assertEqual(trace.name, "trace.jsonl")
+        self.assertNotIn(b"environment_seed", trace.read_bytes())
+        self.assertNotIn(b"policy_seed", trace.read_bytes())
+        self.assertNotIn(b'"profile"', trace.read_bytes())
+        self.assertIsInstance(feedback.content, dict)
+        assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["policy_failures"], 1)
+        self.assertEqual(feedback.content["target_found_episodes"], 0)
+        self.assertEqual(feedback.content["wrong_completion_episodes"], 0)
+
+    def test_baseline_solves_every_public_profile_and_publishes_trace(
+        self,
+    ) -> None:
+        for profile in ("5x5", "6x6", "8x8"):
+            with self.subTest(profile=profile):
+                benchmark = GoToDoorBenchmark(GoToDoorConfig(profile=profile))
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=8,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+
+                self.assertEqual(
+                    result.benchmark_id,
+                    "minigrid/GoToDoor-v0/success-rate-v1",
+                )
+                self.assertEqual(
+                    result.environment_digest,
+                    benchmark.spec.environment_digest,
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["target_found_rate"],
+                    1.0,
+                )
+                self.assertEqual(
+                    result.feedback.content["wrong_completion_rate"],
+                    0.0,
+                )
+                trace = result.feedback.artifacts[0]
+                documents = tuple(
+                    json.loads(line)
+                    for line in trace.read_bytes().splitlines()
+                )
+                transitions = tuple(
+                    document
+                    for document in documents
+                    if document["type"] == "transition"
+                )
+                self.assertEqual(trace.name, "trace.jsonl")
+                self.assertEqual(
+                    trace.media_type,
+                    "application/x-ndjson",
+                )
+                self.assertTrue(transitions)
+                self.assertTrue(
+                    all(
+                        "target_color" in item["next_observation"]
+                        and "target_type" in item["next_observation"]
+                        for item in transitions
+                    )
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "go to the purple door",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/go_to_door/uv.lock
+++ b/environments/minigrid/minigrid/go_to_door/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-go-to-door"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/go_to_object/.gitignore
+++ b/environments/minigrid/minigrid/go_to_object/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/go_to_object/README.md
+++ b/environments/minigrid/minigrid/go_to_object/README.md
@@ -1,0 +1,51 @@
+# MiniGrid GoToObject Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid GoToObject](https://minigrid.farama.org/environments/minigrid/GoToObjectEnv/)
+instruction-following task.
+
+The Policy receives the upstream `7 × 7 × 3` egocentric symbolic image,
+compass direction, and a natural-language mission identifying a colored key,
+ball, or box. It must explore the room, stand next to the requested object, and
+issue `done`; an incorrect completion ends the Episode with zero reward.
+
+## Install and test
+
+From the EvoPolicyGym repository root:
+
+```console
+uv sync --project environments/minigrid/minigrid/go_to_object --extra dev
+uv run --project environments/minigrid/minigrid/go_to_object \
+  python -m unittest discover \
+  -s environments/minigrid/minigrid/go_to_object/tests
+uv build environments/minigrid/minigrid/go_to_object
+```
+
+## Public API
+
+```python
+from minigrid_go_to_object import GoToObjectBenchmark, GoToObjectConfig, baseline_program
+
+benchmark = GoToObjectBenchmark(
+    GoToObjectConfig(profile="8x8-N2"),
+)
+program = baseline_program()
+```
+
+Available profiles are `6x6-N2` and `8x8-N2`. A profile is selected
+by the Benchmark Host before a Run, is included in the environment digest, and
+cannot be selected or changed by the Policy.
+
+Feedback reports success, whether the target was observed, and incorrect
+completions, together with return, step, truncation, and Policy-failure statistics.
+`trace.jsonl` contains a bounded semantic trace for at most four Episodes,
+retaining the first 128 and last 32 transitions of long Episodes. It contains
+no Episode seed, private Case identity, or Host path.
+
+The packaged baseline builds a relative map from public egocentric
+observations, parses the public mission, and shortest-path plans to the matching
+object. It consumes no private environment state.
+
+Tests that use `ProcessExecution.unsafe()` run trusted packaged code only.
+That backend is a local process mechanism, not a sandbox and not suitable for
+hostile Programs.

--- a/environments/minigrid/minigrid/go_to_object/pyproject.toml
+++ b/environments/minigrid/minigrid/go_to_object/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-go-to-object"
+version = "0.1.0"
+description = "The MiniGrid GoToObject Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = [
+    "mypy==2.3.0",
+    "ruff>=0.12.0",
+]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_go_to_object"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/README.md",
+    "/pyproject.toml",
+    "/src",
+    "/tests",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/__init__.py
+++ b/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/__init__.py
@@ -1,0 +1,12 @@
+"""The public MiniGrid GoToObject Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import GoToObjectBenchmark
+from .config import GoToObjectConfig
+
+__all__ = [
+    "GoToObjectBenchmark",
+    "GoToObjectConfig",
+    "baseline_program",
+]
+

--- a/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/baseline.py
+++ b/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid GoToObject development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_go_to_object").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/benchmark.py
+++ b/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/benchmark.py
@@ -1,0 +1,452 @@
+"""MiniGrid GoToObject with deterministic plans and bounded semantic traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import GoToObjectConfig
+from .environment import GoToObjectEnvironment
+
+_EPISODE_SEED_DOMAIN = b"evopolicygym-minigrid-go_to_object/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_MISSIONS = tuple(
+    f"go to the {color} {kind}"
+    for color in _COLOR_NAMES
+    for kind in ("key", "ball", "box")
+)
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRIC_FIELDS = {
+    "target_found",
+    "wrong_completion",
+    "success",
+}
+
+
+class GoToObjectBenchmark:
+    """Success rate on a partially observable instruction-following task."""
+
+    def __init__(self, config: GoToObjectConfig | None = None) -> None:
+        if config is None:
+            config = GoToObjectConfig()
+        if type(config) is not GoToObjectConfig:
+            raise TypeError("config must be GoToObjectConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return GoToObjectEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        found_targets = _milestone_count(records, "target_found")
+        wrong_completions = _milestone_count(records, "wrong_completion")
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        mean_success_steps: PolicyValue = (
+            statistics.fmean(record.steps for record in successful)
+            if successful
+            else None
+        )
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the mission-matching object in {successes}/"
+                    f"{len(records)} Episodes ({score:.3f} success rate); "
+                    f"{wrong_completions} incorrect completions."
+                ),
+                "success_rate": score,
+                "target_found_rate": found_targets / len(records),
+                "wrong_completion_rate": wrong_completions / len(records),
+                "mean_return": mean_return,
+                "mean_steps": mean_steps,
+                "mean_steps_on_success": mean_success_steps,
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "target_found_episodes": found_targets,
+                "wrong_completion_episodes": wrong_completions,
+                "truncated_episodes": truncations,
+                "policy_failures": failures,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+                "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+                "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+            },
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: GoToObjectConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/GoToObject-v0/success-rate-v1",
+        description=(
+            "Read the natural-language mission, explore the partially "
+            "observable room, stand next to the matching colored key, ball, "
+            "or box, and declare completion. Maximize success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "meaning": {
+                        "0": "east",
+                        "1": "south",
+                        "2": "west",
+                        "3": "north",
+                    },
+                },
+                "mission": {
+                    "type": "string",
+                    "values": list(_MISSIONS),
+                },
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "size": config.size,
+            "object_count": config.object_count,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission_syntax": "go to the {color} {object}",
+            "target_types": ["key", "ball", "box"],
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for picking up the requested "
+                "object; zero for a distractor or timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _milestone_count(
+    records: Sequence[EpisodeRecord],
+    name: str,
+) -> int:
+    return sum(_reached_milestone(record, name) for record in records)
+
+
+def _reached_milestone(record: EpisodeRecord, name: str) -> bool:
+    for transition in record.transitions:
+        metrics = transition.step.metrics
+        if type(metrics) is dict and metrics.get(name) is True:
+            return True
+    return False
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "target_found": _reached_milestone(
+                        record,
+                        "target_found",
+                    ),
+                    "wrong_completion": _reached_milestone(
+                        record,
+                        "wrong_completion",
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError("MiniGrid GoToObject trace Action is invalid")
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if (
+        type(metrics) is not dict
+        or set(metrics) != _METRIC_FIELDS
+        or any(type(value) is not bool for value in metrics.values())
+    ):
+        raise ValueError("MiniGrid GoToObject trace metrics are invalid")
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError("MiniGrid GoToObject trace observation is invalid")
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("MiniGrid GoToObject trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("MiniGrid GoToObject trace direction is invalid")
+    if type(mission) is not str or mission not in _MISSIONS:
+        raise ValueError("MiniGrid GoToObject trace mission is invalid")
+
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError("MiniGrid GoToObject trace image codes are invalid")
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    target_color, target_type = _target(mission)
+    return {
+        "direction": direction,
+        "mission": mission,
+        "target_color": target_color,
+        "target_type": target_type,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _target(mission: str) -> tuple[str, str]:
+    prefix = "go to the "
+    if not mission.startswith(prefix):
+        raise ValueError("MiniGrid GoToObject trace mission is invalid")
+    remainder = mission.removeprefix(prefix)
+    parts = remainder.split(" ")
+    if (
+        len(parts) != 2
+        or parts[0] not in _COLOR_NAMES
+        or parts[1] not in {"key", "ball", "box"}
+    ):
+        raise ValueError("MiniGrid GoToObject trace mission is invalid")
+    return parts[0], parts[1]
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["GoToObjectBenchmark"]

--- a/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/config.py
+++ b/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/config.py
@@ -1,0 +1,49 @@
+"""Typed, public MiniGrid GoToObject environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int, int]] = {
+    "6x6-N2": ("MiniGrid-GoToObject-6x6-N2-v0", 6, 2),
+    "8x8-N2": ("MiniGrid-GoToObject-8x8-N2-v0", 8, 2),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class GoToObjectConfig:
+    """Parameters that define one MiniGrid GoToObject Benchmark identity."""
+
+    profile: str = "8x8-N2"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        """Return the upstream Gymnasium registration."""
+
+        return _PROFILES[self.profile][0]
+
+    @property
+    def size(self) -> int:
+        """Return the square grid size."""
+
+        return _PROFILES[self.profile][1]
+
+    @property
+    def object_count(self) -> int:
+        """Return the number of generated candidate objects."""
+
+        return _PROFILES[self.profile][2]
+
+    @property
+    def max_episode_steps(self) -> int:
+        """Return the upstream horizon."""
+
+        return 5 * self.size**2
+
+
+__all__ = ["GoToObjectConfig"]

--- a/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/environment.py
+++ b/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/environment.py
@@ -1,0 +1,201 @@
+"""One fresh MiniGrid GoToObject Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401  # Import registers MiniGrid environments.
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import GoToObjectConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_OBJECT_CODES = {"key": 5, "ball": 6, "box": 7}
+
+
+@dataclass(frozen=True, slots=True)
+class _ObservationFacts:
+    target_color: int
+    target_type: str
+    target_visible: bool
+
+
+class GoToObjectEnvironment:
+    """The seeded strict adapter around configured MiniGrid GoToObject."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: GoToObjectConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not GoToObjectConfig:
+            raise TypeError("config must be GoToObjectConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "GoToObject configuration belongs in GoToObjectConfig, "
+                "not EpisodeSpec.scenario"
+            )
+
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._target: tuple[int, str] | None = None
+        self._target_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._target = (facts.target_color, facts.target_type)
+        self._target_found = facts.target_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid GoToObject returned invalid termination flags")
+        number = _number(reward, name="reward")
+        public, facts = _observation(observation)
+        if (facts.target_color, facts.target_type) != self._target:
+            raise RuntimeError(
+                "MiniGrid GoToObject changed target during an Episode"
+            )
+        self._target_found = self._target_found or facts.target_visible
+        success = bool(terminated and number > 0.0)
+        wrong_completion = bool(
+            terminated and action in {5, 6} and not success
+        )
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "target_found": self._target_found,
+                "wrong_completion": wrong_completion,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(
+    value: object,
+) -> tuple[dict[str, PolicyValue], _ObservationFacts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid GoToObject returned an invalid observation")
+
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid GoToObject returned an invalid image")
+    if (
+        numpy.any(image[:, :, 0] > 10)
+        or numpy.any(image[:, :, 1] > 5)
+        or numpy.any(image[:, :, 2] > 2)
+    ):
+        raise RuntimeError("MiniGrid GoToObject returned out-of-range image codes")
+
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid GoToObject returned an invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid GoToObject returned an invalid direction")
+
+    mission = value["mission"]
+    if type(mission) is not str:
+        raise RuntimeError("MiniGrid GoToObject returned an invalid mission")
+    target_color, target_type = _target(mission)
+    target_code = _OBJECT_CODES[target_type]
+    target_visible = bool(
+        numpy.any(
+            (image[:, :, 0] == target_code)
+            & (image[:, :, 1] == target_color)
+        )
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _ObservationFacts(
+            target_color=target_color,
+            target_type=target_type,
+            target_visible=target_visible,
+        ),
+    )
+
+
+def _target(mission: str) -> tuple[int, str]:
+    prefix = "go to the "
+    if not mission.startswith(prefix):
+        raise RuntimeError("MiniGrid GoToObject returned an invalid mission")
+    remainder = mission.removeprefix(prefix)
+    parts = remainder.split(" ")
+    if len(parts) != 2 or parts[0] not in _COLORS or parts[1] not in _OBJECT_CODES:
+        raise RuntimeError("MiniGrid GoToObject returned an invalid mission")
+    return _COLORS.index(parts[0]), parts[1]
+
+
+def _number(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(f"MiniGrid GoToObject returned an invalid {name}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(f"MiniGrid GoToObject returned a non-finite {name}")
+    return number
+
+
+__all__ = ["GoToObjectEnvironment"]

--- a/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/programs/baseline/policy.py
@@ -1,0 +1,387 @@
+"""A public-observation mapping and planning MiniGrid GoToObject baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_DONE = 6
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+class BaselinePolicy:
+    """Build a relative map and stop next to the requested object."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._target: tuple[int, int] | None = None
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction, mission = self._read_observation(observation)
+        target = self._read_target(mission)
+        if self._target is None:
+            self._target = target
+        elif self._target != target:
+            raise ValueError("mission changed during the Episode")
+        self._integrate(image, direction)
+
+        target_position = self._known_target()
+        if target_position is not None:
+            return self._interact(target_position, direction)
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int, str]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        mission = observation["mission"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        if type(mission) is not str:
+            raise ValueError("observation mission is invalid")
+        return image, direction, mission
+
+    def _read_target(self, mission: str) -> tuple[int, int]:
+        prefix = "go to the "
+        if not mission.startswith(prefix):
+            raise ValueError("observation mission is invalid")
+        remainder = mission.removeprefix(prefix)
+        parts = remainder.split(" ")
+        if (
+            len(parts) != 2
+            or parts[0] not in self._colors
+            or parts[1] not in {"key", "ball", "box"}
+        ):
+            raise ValueError("observation mission is invalid")
+        return self._objects[parts[1]], self._colors[parts[0]]
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_target(self) -> Position | None:
+        if self._target is None:
+            return None
+        target_object, target_color = self._target
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == target_object and cell[1] == target_color
+            ),
+            None,
+        )
+
+    def _interact(self, target: Position, direction: int) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+
+        return _DONE
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if not frontiers:
+            return _RIGHT
+
+        _, frontier, frontier_direction = min(
+            frontiers,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+
+        turn = _turn_toward(direction, frontier_direction)
+        if turn is not None:
+            return turn
+        return _RIGHT
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        if cell is None:
+            return False
+        return cell[0] in {
+            self._objects["empty"],
+            self._objects["floor"],
+            self._objects["goal"],
+        }
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_colors = parameters.get("color_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_colors) is not dict
+        or set(raw_colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in raw_colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in raw_colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/go_to_object/tests/test_go_to_object.py
+++ b/environments/minigrid/minigrid/go_to_object/tests/test_go_to_object.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_go_to_object import GoToObjectBenchmark, GoToObjectConfig, baseline_program
+
+
+class GoToObjectBenchmarkTests(unittest.TestCase):
+    def test_config_profiles_define_distinct_environment_identity(self) -> None:
+        default = GoToObjectBenchmark()
+        small = GoToObjectBenchmark(GoToObjectConfig(profile="6x6-N2"))
+
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/GoToObject-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 320)
+        self.assertEqual(small.spec.max_episode_steps, 180)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            small.spec.environment_digest,
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["profile"],
+            "8x8-N2",
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["object_count"],
+            2,
+        )
+
+        exposed = default.spec.environment_parameters["color_encoding"]
+        self.assertIsInstance(exposed, dict)
+        assert isinstance(exposed, dict)
+        exposed["purple"] = 100
+        fresh = default.spec.environment_parameters["color_encoding"]
+        self.assertIsInstance(fresh, dict)
+        assert isinstance(fresh, dict)
+        self.assertEqual(fresh["purple"], 3)
+
+    def test_config_rejects_unsupported_or_ambiguous_profiles(self) -> None:
+        with self.assertRaises(ValueError):
+            GoToObjectConfig(profile="8x8-N3")
+        with self.assertRaises(ValueError):
+            GoToObjectConfig(profile=8)  # type: ignore[arg-type]
+
+    def test_episode_planning_is_reproducible_and_split_scoped(self) -> None:
+        benchmark = GoToObjectBenchmark()
+
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        validation = tuple(
+            benchmark.episodes("validation", seed=7, count=10)
+        )
+
+        self.assertEqual(train, repeated)
+        self.assertEqual(len({item.environment_seed for item in train}), 10)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in validation
+            )
+        )
+        self.assertTrue(all(item.scenario is None for item in train))
+
+    def test_environment_is_conformant_and_rejects_invalid_actions(
+        self,
+    ) -> None:
+        benchmark = GoToObjectBenchmark(GoToObjectConfig(profile="6x6-N2"))
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertEqual(
+                set(observation),
+                {"image", "direction", "mission"},
+            )
+            image = observation["image"]
+            self.assertIsInstance(image, TensorValue)
+            assert isinstance(image, TensorValue)
+            self.assertEqual(image.dtype, "uint8")
+            self.assertEqual(image.shape, (7, 7, 3))
+            self.assertEqual(len(image.data), 147)
+            mission = observation["mission"]
+            self.assertIsInstance(mission, str)
+            assert isinstance(mission, str)
+            self.assertTrue(mission.endswith((" key", " ball", " box")))
+        finally:
+            environment.close()
+            environment.close()
+
+        invalid_actions: tuple[PolicyValue, ...] = (
+            -1,
+            7,
+            True,
+            2.0,
+            [2],
+        )
+        for invalid in invalid_actions:
+            environment = benchmark.make_environment(
+                EpisodeSpec(environment_seed=123)
+            )
+            try:
+                environment.reset()
+                with self.assertRaises(InvalidAction):
+                    environment.step(invalid)
+            finally:
+                environment.close()
+
+    def test_episode_scenario_cannot_override_benchmark_configuration(
+        self,
+    ) -> None:
+        benchmark = GoToObjectBenchmark()
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(
+                    environment_seed=1,
+                    scenario={"profile": "6x6-N2"},
+                )
+            )
+
+    def test_feedback_penalizes_failure_and_keeps_identity_private(self) -> None:
+        benchmark = GoToObjectBenchmark()
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+
+        feedback = benchmark.feedback((failed,))
+
+        self.assertEqual(feedback.score, 0.0)
+        self.assertEqual(len(feedback.artifacts), 1)
+        trace = feedback.artifacts[0]
+        self.assertEqual(trace.name, "trace.jsonl")
+        self.assertNotIn(b"environment_seed", trace.read_bytes())
+        self.assertNotIn(b"policy_seed", trace.read_bytes())
+        self.assertNotIn(b'"profile"', trace.read_bytes())
+        self.assertIsInstance(feedback.content, dict)
+        assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["policy_failures"], 1)
+        self.assertEqual(feedback.content["target_found_episodes"], 0)
+        self.assertEqual(feedback.content["wrong_completion_episodes"], 0)
+
+    def test_baseline_solves_every_public_profile_and_publishes_trace(
+        self,
+    ) -> None:
+        for profile in ("6x6-N2", "8x8-N2"):
+            with self.subTest(profile=profile):
+                benchmark = GoToObjectBenchmark(GoToObjectConfig(profile=profile))
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=8,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+
+                self.assertEqual(
+                    result.benchmark_id,
+                    "minigrid/GoToObject-v0/success-rate-v1",
+                )
+                self.assertEqual(
+                    result.environment_digest,
+                    benchmark.spec.environment_digest,
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["target_found_rate"],
+                    1.0,
+                )
+                self.assertEqual(
+                    result.feedback.content["wrong_completion_rate"],
+                    0.0,
+                )
+                trace = result.feedback.artifacts[0]
+                documents = tuple(
+                    json.loads(line)
+                    for line in trace.read_bytes().splitlines()
+                )
+                transitions = tuple(
+                    document
+                    for document in documents
+                    if document["type"] == "transition"
+                )
+                self.assertEqual(trace.name, "trace.jsonl")
+                self.assertEqual(
+                    trace.media_type,
+                    "application/x-ndjson",
+                )
+                self.assertTrue(transitions)
+                self.assertTrue(
+                    all(
+                        "target_color" in item["next_observation"]
+                        and "target_type" in item["next_observation"]
+                        for item in transitions
+                    )
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "go to the purple ball",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/go_to_object/uv.lock
+++ b/environments/minigrid/minigrid/go_to_object/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-go-to-object"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/keycorridor/.gitignore
+++ b/environments/minigrid/minigrid/keycorridor/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+dist/
+build/
+*.egg-info/
+__pycache__/
+*.py[cod]

--- a/environments/minigrid/minigrid/keycorridor/README.md
+++ b/environments/minigrid/minigrid/keycorridor/README.md
@@ -1,0 +1,58 @@
+# MiniGrid KeyCorridor Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid KeyCorridor](https://minigrid.farama.org/environments/minigrid/KeyCorridorEnv/)
+multi-room task.
+
+The Policy receives the upstream `7 × 7 × 3` egocentric symbolic image,
+compass direction, and a mission naming the target ball color. It must explore
+multiple rooms, acquire the key matching the locked door, unlock the target
+room, and pick up the mission-matching ball. The primary score is Episode
+success rate.
+
+## Install and test
+
+From the EvoPolicyGym repository root:
+
+```console
+uv sync --project environments/minigrid/minigrid/keycorridor --extra dev
+uv run --project environments/minigrid/minigrid/keycorridor \
+  python -m unittest discover \
+  -s environments/minigrid/minigrid/keycorridor/tests
+uv build environments/minigrid/minigrid/keycorridor
+```
+
+## Public API
+
+```python
+from minigrid_keycorridor import (
+    KeyCorridorBenchmark,
+    KeyCorridorConfig,
+    baseline_program,
+)
+
+benchmark = KeyCorridorBenchmark(
+    KeyCorridorConfig(profile="S4R3"),
+)
+program = baseline_program()
+```
+
+Available profiles are `S3R1`, `S3R2`, `S3R3`, `S4R3`, `S5R3`, and `S6R3`.
+`S` is the upstream room-size parameter and `R` is the number of room rows;
+every profile has three room columns.
+
+Feedback reports success and the public progress ladder: finding and picking
+up the matching key, opening the target locked door, and finding the target
+object. It also includes return, step, truncation, and Policy-failure
+statistics. `trace.jsonl` contains a bounded semantic trace for at most four
+Episodes, retaining the first 128 and last 32 transitions of long Episodes.
+It contains no Episode seed, private Case identity, or Host path.
+
+The packaged baseline builds a relative multi-room map from egocentric
+observations, opens accessible doors during exploration, and uses shortest-path
+planning between the matching key, locked door, and ball. It consumes no
+private environment state.
+
+Tests that use `ProcessExecution.unsafe()` run trusted packaged code only.
+That backend is a local process mechanism, not a sandbox and not suitable for
+hostile Programs.

--- a/environments/minigrid/minigrid/keycorridor/pyproject.toml
+++ b/environments/minigrid/minigrid/keycorridor/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-keycorridor"
+version = "0.1.0"
+description = "The MiniGrid KeyCorridor Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = [
+    "mypy==2.3.0",
+    "ruff>=0.12.0",
+]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_keycorridor"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/README.md",
+    "/pyproject.toml",
+    "/src",
+    "/tests",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/__init__.py
+++ b/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/__init__.py
@@ -1,0 +1,11 @@
+"""The public MiniGrid KeyCorridor Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import KeyCorridorBenchmark
+from .config import KeyCorridorConfig
+
+__all__ = [
+    "KeyCorridorBenchmark",
+    "KeyCorridorConfig",
+    "baseline_program",
+]

--- a/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/baseline.py
+++ b/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/baseline.py
@@ -1,0 +1,21 @@
+"""Packaged initial Program for MiniGrid KeyCorridor development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the mapping and planning baseline."""
+
+    resource = files("minigrid_keycorridor").joinpath(
+        "programs",
+        "baseline",
+    )
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]

--- a/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/benchmark.py
+++ b/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/benchmark.py
@@ -1,0 +1,460 @@
+"""MiniGrid KeyCorridor with deterministic plans and milestone traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import KeyCorridorConfig
+from .environment import KeyCorridorEnvironment
+
+_EPISODE_SEED_DOMAIN = b"evopolicygym-minigrid-keycorridor/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_MISSIONS = tuple(
+    f"pick up the {color} ball" for color in _COLOR_NAMES
+)
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRIC_FIELDS = {
+    "found_key",
+    "carrying_key",
+    "picked_up_key",
+    "opened_target_door",
+    "found_target_object",
+    "success",
+}
+
+
+class KeyCorridorBenchmark:
+    """Success rate on a multi-room matching-key search task."""
+
+    def __init__(self, config: KeyCorridorConfig | None = None) -> None:
+        if config is None:
+            config = KeyCorridorConfig()
+        if type(config) is not KeyCorridorConfig:
+            raise TypeError("config must be KeyCorridorConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return KeyCorridorEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        found_keys = _milestone_count(records, "found_key")
+        picked_up_keys = _milestone_count(records, "picked_up_key")
+        opened_doors = _milestone_count(records, "opened_target_door")
+        found_targets = _milestone_count(records, "found_target_object")
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        mean_success_steps: PolicyValue = (
+            statistics.fmean(record.steps for record in successful)
+            if successful
+            else None
+        )
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Picked up the target object in {successes}/"
+                    f"{len(records)} Episodes ({score:.3f} success rate); "
+                    f"{picked_up_keys} acquired the matching key and "
+                    f"{opened_doors} opened the target door."
+                ),
+                "success_rate": score,
+                "key_found_rate": found_keys / len(records),
+                "key_pickup_rate": picked_up_keys / len(records),
+                "target_door_open_rate": opened_doors / len(records),
+                "target_object_found_rate": found_targets / len(records),
+                "mean_return": mean_return,
+                "mean_steps": mean_steps,
+                "mean_steps_on_success": mean_success_steps,
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "key_found_episodes": found_keys,
+                "key_pickup_episodes": picked_up_keys,
+                "target_door_open_episodes": opened_doors,
+                "target_object_found_episodes": found_targets,
+                "truncated_episodes": truncations,
+                "policy_failures": failures,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+                "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+                "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+            },
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: KeyCorridorConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/KeyCorridor-v0/success-rate-v1",
+        description=(
+            "Search multiple partially observable rooms for the key matching "
+            "the mission color, unlock the target room, and pick up the "
+            "matching ball. Maximize success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "meaning": {
+                        "0": "east",
+                        "1": "south",
+                        "2": "west",
+                        "3": "north",
+                    },
+                },
+                "mission": {
+                    "type": "string",
+                    "values": list(_MISSIONS),
+                },
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "room_size": config.room_size,
+            "num_rows": config.num_rows,
+            "num_columns": 3,
+            "grid_width": config.grid_width,
+            "grid_height": config.grid_height,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission_template": "pick up the {color} ball",
+            "target_object": "ball",
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for picking up the target ball; "
+                "zero for timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _milestone_count(
+    records: Sequence[EpisodeRecord],
+    name: str,
+) -> int:
+    return sum(_reached_milestone(record, name) for record in records)
+
+
+def _reached_milestone(record: EpisodeRecord, name: str) -> bool:
+    for transition in record.transitions:
+        metrics = transition.step.metrics
+        if type(metrics) is dict and metrics.get(name) is True:
+            return True
+    return False
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "found_key": _reached_milestone(
+                        record,
+                        "found_key",
+                    ),
+                    "picked_up_key": _reached_milestone(
+                        record,
+                        "picked_up_key",
+                    ),
+                    "opened_target_door": _reached_milestone(
+                        record,
+                        "opened_target_door",
+                    ),
+                    "found_target_object": _reached_milestone(
+                        record,
+                        "found_target_object",
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError(
+                    "MiniGrid KeyCorridor trace Action is invalid"
+                )
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if (
+        type(metrics) is not dict
+        or set(metrics) != _METRIC_FIELDS
+        or any(type(value) is not bool for value in metrics.values())
+    ):
+        raise ValueError("MiniGrid KeyCorridor trace metrics are invalid")
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError("MiniGrid KeyCorridor trace observation is invalid")
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("MiniGrid KeyCorridor trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("MiniGrid KeyCorridor trace direction is invalid")
+    if type(mission) is not str or mission not in _MISSIONS:
+        raise ValueError("MiniGrid KeyCorridor trace mission is invalid")
+
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError(
+                    "MiniGrid KeyCorridor trace image codes are invalid"
+                )
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    return {
+        "direction": direction,
+        "mission": mission,
+        "target_color": mission.removeprefix("pick up the ").removesuffix(
+            " ball"
+        ),
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["KeyCorridorBenchmark"]

--- a/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/config.py
+++ b/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/config.py
@@ -1,0 +1,65 @@
+"""Typed, public MiniGrid KeyCorridor environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int, int]] = {
+    "S3R1": ("MiniGrid-KeyCorridorS3R1-v0", 3, 1),
+    "S3R2": ("MiniGrid-KeyCorridorS3R2-v0", 3, 2),
+    "S3R3": ("MiniGrid-KeyCorridorS3R3-v0", 3, 3),
+    "S4R3": ("MiniGrid-KeyCorridorS4R3-v0", 4, 3),
+    "S5R3": ("MiniGrid-KeyCorridorS5R3-v0", 5, 3),
+    "S6R3": ("MiniGrid-KeyCorridorS6R3-v0", 6, 3),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class KeyCorridorConfig:
+    """Parameters that define one MiniGrid KeyCorridor Benchmark identity."""
+
+    profile: str = "S4R3"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        """Return the upstream Gymnasium registration."""
+
+        return _PROFILES[self.profile][0]
+
+    @property
+    def room_size(self) -> int:
+        """Return the upstream room-size parameter."""
+
+        return _PROFILES[self.profile][1]
+
+    @property
+    def num_rows(self) -> int:
+        """Return the number of room rows."""
+
+        return _PROFILES[self.profile][2]
+
+    @property
+    def grid_width(self) -> int:
+        """Return the complete three-column grid width."""
+
+        return 3 * (self.room_size - 1) + 1
+
+    @property
+    def grid_height(self) -> int:
+        """Return the complete grid height."""
+
+        return self.num_rows * (self.room_size - 1) + 1
+
+    @property
+    def max_episode_steps(self) -> int:
+        """Return the upstream horizon."""
+
+        return 30 * self.room_size**2
+
+
+__all__ = ["KeyCorridorConfig"]

--- a/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/environment.py
+++ b/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/environment.py
@@ -1,0 +1,252 @@
+"""One fresh MiniGrid KeyCorridor Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401  # Import registers MiniGrid environments.
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import KeyCorridorConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_DOOR = 4
+_KEY = 5
+_BALL = 6
+_LOCKED = 2
+
+
+@dataclass(frozen=True, slots=True)
+class _ObservationFacts:
+    target_color: int
+    carrying_key_color: int | None
+    key_visible: bool
+    target_object_visible: bool
+    front_locked_door_color: int | None
+
+
+class KeyCorridorEnvironment:
+    """The seeded strict adapter around configured MiniGrid KeyCorridor."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: KeyCorridorConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not KeyCorridorConfig:
+            raise TypeError("config must be KeyCorridorConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "KeyCorridor configuration belongs in KeyCorridorConfig, "
+                "not EpisodeSpec.scenario"
+            )
+
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._target_color: int | None = None
+        self._carrying_key_color: int | None = None
+        self._front_locked_door_color: int | None = None
+        self._found_key = False
+        self._picked_up_key = False
+        self._opened_target_door = False
+        self._found_target_object = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._target_color = facts.target_color
+        self._update_facts(facts)
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+
+        opened_target_door = bool(
+            action == 5
+            and self._front_locked_door_color is not None
+            and self._carrying_key_color
+            == self._front_locked_door_color
+        )
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError(
+                "MiniGrid KeyCorridor returned invalid termination flags"
+            )
+        number = _number(reward, name="reward")
+        public, facts = _observation(observation)
+        if facts.target_color != self._target_color:
+            raise RuntimeError(
+                "MiniGrid KeyCorridor changed target color during an Episode"
+            )
+        self._opened_target_door = (
+            self._opened_target_door or opened_target_door
+        )
+        self._update_facts(facts)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "found_key": self._found_key,
+                "carrying_key": self._carrying_key_color is not None,
+                "picked_up_key": self._picked_up_key,
+                "opened_target_door": self._opened_target_door,
+                "found_target_object": self._found_target_object,
+                "success": bool(terminated and number > 0.0),
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+    def _update_facts(self, facts: _ObservationFacts) -> None:
+        self._carrying_key_color = facts.carrying_key_color
+        self._front_locked_door_color = facts.front_locked_door_color
+        self._found_key = self._found_key or facts.key_visible
+        self._picked_up_key = (
+            self._picked_up_key or facts.carrying_key_color is not None
+        )
+        self._found_target_object = (
+            self._found_target_object or facts.target_object_visible
+        )
+
+
+def _observation(
+    value: object,
+) -> tuple[dict[str, PolicyValue], _ObservationFacts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid KeyCorridor returned an invalid observation")
+
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid KeyCorridor returned an invalid image")
+    if (
+        numpy.any(image[:, :, 0] > 10)
+        or numpy.any(image[:, :, 1] > 5)
+        or numpy.any(image[:, :, 2] > 2)
+    ):
+        raise RuntimeError(
+            "MiniGrid KeyCorridor returned out-of-range image codes"
+        )
+
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid KeyCorridor returned an invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError(
+            "MiniGrid KeyCorridor returned an invalid direction"
+        )
+
+    mission = value["mission"]
+    if type(mission) is not str:
+        raise RuntimeError("MiniGrid KeyCorridor returned an invalid mission")
+    target_color = _target_color(mission)
+
+    carrying_key_color = (
+        int(image[3, 6, 1])
+        if image[3, 6, 0] == _KEY
+        else None
+    )
+    key_visible = bool(numpy.any(image[:, :, 0] == _KEY))
+    target_object_visible = bool(
+        numpy.any(
+            (image[:, :, 0] == _BALL)
+            & (image[:, :, 1] == target_color)
+        )
+    )
+    front_locked_door_color = (
+        int(image[3, 5, 1])
+        if image[3, 5, 0] == _DOOR
+        and image[3, 5, 2] == _LOCKED
+        else None
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _ObservationFacts(
+            target_color=target_color,
+            carrying_key_color=carrying_key_color,
+            key_visible=key_visible,
+            target_object_visible=target_object_visible,
+            front_locked_door_color=front_locked_door_color,
+        ),
+    )
+
+
+def _target_color(mission: str) -> int:
+    prefix = "pick up the "
+    suffix = " ball"
+    if not mission.startswith(prefix) or not mission.endswith(suffix):
+        raise RuntimeError("MiniGrid KeyCorridor returned an invalid mission")
+    color = mission[len(prefix) : -len(suffix)]
+    if color not in _COLORS:
+        raise RuntimeError("MiniGrid KeyCorridor returned an invalid mission")
+    return _COLORS.index(color)
+
+
+def _number(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(f"MiniGrid KeyCorridor returned an invalid {name}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(
+            f"MiniGrid KeyCorridor returned a non-finite {name}"
+        )
+    return number
+
+
+__all__ = ["KeyCorridorEnvironment"]

--- a/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/programs/baseline/policy.py
@@ -1,0 +1,528 @@
+"""A public-observation mapping and planning KeyCorridor baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_PICKUP = 3
+_DROP = 4
+_TOGGLE = 5
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Map rooms and plan through the key, locked door, and target object."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._target_color: int | None = None
+        self._target_door: Position | None = None
+        self._has_key = False
+        self._carried_key_color: int | None = None
+        self._opened_target_door = False
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction, mission = self._read_observation(observation)
+        target_color = self._read_target_color(mission)
+        if self._target_color is None:
+            self._target_color = target_color
+        elif self._target_color != target_color:
+            raise ValueError("mission changed during the Episode")
+        self._integrate(image, direction)
+
+        if not self._opened_target_door:
+            if not self._has_key:
+                key = self._known_object("key")
+                if key is not None:
+                    return self._interact(
+                        key,
+                        action=_PICKUP,
+                        direction=direction,
+                    )
+                return self._explore(direction)
+            if self._target_door is not None:
+                return self._interact(
+                    self._target_door,
+                    action=_TOGGLE,
+                    direction=direction,
+                )
+            return self._explore(direction)
+
+        if self._has_key:
+            return self._drop_key(direction)
+
+        target = self._known_object("ball", target_color)
+        if target is not None:
+            return self._interact(
+                target,
+                action=_PICKUP,
+                direction=direction,
+            )
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int, str]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        mission = observation["mission"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        if type(mission) is not str:
+            raise ValueError("observation mission is invalid")
+        return image, direction, mission
+
+    def _read_target_color(self, mission: str) -> int:
+        prefix = "pick up the "
+        suffix = " ball"
+        if not mission.startswith(prefix) or not mission.endswith(suffix):
+            raise ValueError("observation mission is invalid")
+        color = mission[len(prefix) : -len(suffix)]
+        if color not in self._colors:
+            raise ValueError("observation mission color is invalid")
+        return self._colors[color]
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        assert self._target_color is not None
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    if object_code == self._objects["key"]:
+                        self._has_key = True
+                        self._carried_key_color = color_code
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+                if (
+                    object_code == self._objects["door"]
+                    and state_code == self._states["locked"]
+                ):
+                    self._target_door = world
+                if (
+                    world == self._target_door
+                    and state_code == self._states["open"]
+                ):
+                    self._opened_target_door = True
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_object(
+        self,
+        name: str,
+        color: int | None = None,
+    ) -> Position | None:
+        object_code = self._objects[name]
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == object_code
+                and (color is None or cell[1] == color)
+            ),
+            None,
+        )
+
+    def _interact(
+        self,
+        target: Position,
+        *,
+        action: int,
+        direction: int,
+    ) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+
+        target_direction = _direction_between(approach_position, target)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+
+        if action == _PICKUP:
+            if self._grid[target][0] == self._objects["key"]:
+                self._has_key = True
+                self._carried_key_color = self._grid[target][1]
+            self._grid[target] = (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        elif action == _TOGGLE:
+            self._grid[target] = (
+                self._objects["door"],
+                self._grid[target][1],
+                self._states["open"],
+            )
+            if target == self._target_door:
+                self._opened_target_door = True
+        return action
+
+    def _drop_key(self, direction: int) -> int:
+        candidates = tuple(
+            (target_direction, neighbor)
+            for target_direction, neighbor in _neighbors(self._position)
+            if self._grid.get(neighbor, (None, None, None))[0]
+            == self._objects["empty"]
+        )
+        if not candidates:
+            moves = tuple(
+                neighbor
+                for _, neighbor in _neighbors(self._position)
+                if self._traversable(neighbor)
+            )
+            if not moves:
+                return self._explore(direction)
+            return self._follow((min(moves),), direction)
+        target_direction, target = min(
+            candidates,
+            key=lambda item: item[1],
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+
+        color = self._carried_key_color
+        if color is None:
+            raise ValueError("carried key color is unavailable")
+        self._grid[target] = (
+            self._objects["key"],
+            color,
+            self._states["open"],
+        )
+        self._has_key = False
+        self._carried_key_color = None
+        return _DROP
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if frontiers:
+            _, frontier, frontier_direction = min(
+                frontiers,
+                key=lambda item: (item[0], item[1], item[2]),
+            )
+            if frontier != self._position:
+                action = self._navigate(frontier, direction)
+                if action is not None:
+                    return action
+            turn = _turn_toward(direction, frontier_direction)
+            if turn is not None:
+                return turn
+            return _RIGHT
+
+        door = self._nearest_openable_door()
+        if door is not None:
+            return self._interact(
+                door,
+                action=_TOGGLE,
+                direction=direction,
+            )
+        return _RIGHT
+
+    def _nearest_openable_door(self) -> Position | None:
+        candidates: list[tuple[int, Position]] = []
+        for position, cell in self._grid.items():
+            if cell[0] != self._objects["door"]:
+                continue
+            if cell[2] == self._states["closed"] or (
+                cell[2] == self._states["locked"]
+                and self._has_key
+                and position == self._target_door
+            ):
+                approach = self._best_approach(position)
+                if approach is not None:
+                    candidates.append((len(approach[1]), position))
+        if not candidates:
+            return None
+        return min(candidates, key=lambda item: (item[0], item[1]))[1]
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        if cell is None:
+            return False
+        object_code, _, state_code = cell
+        return bool(
+            object_code
+            in {
+                self._objects["empty"],
+                self._objects["floor"],
+                self._objects["goal"],
+            }
+            or (
+                object_code == self._objects["door"]
+                and state_code == self._states["open"]
+            )
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_colors = parameters.get("color_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_colors) is not dict
+        or set(raw_colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in raw_colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in raw_colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/keycorridor/tests/test_keycorridor.py
+++ b/environments/minigrid/minigrid/keycorridor/tests/test_keycorridor.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_keycorridor import (
+    KeyCorridorBenchmark,
+    KeyCorridorConfig,
+    baseline_program,
+)
+
+
+class KeyCorridorBenchmarkTests(unittest.TestCase):
+    def test_config_profiles_define_distinct_environment_identity(self) -> None:
+        default = KeyCorridorBenchmark()
+        small = KeyCorridorBenchmark(KeyCorridorConfig(profile="S3R1"))
+        large = KeyCorridorBenchmark(KeyCorridorConfig(profile="S6R3"))
+
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/KeyCorridor-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 480)
+        self.assertEqual(small.spec.max_episode_steps, 270)
+        self.assertEqual(large.spec.max_episode_steps, 1_080)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            small.spec.environment_digest,
+        )
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            large.spec.environment_digest,
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["profile"],
+            "S4R3",
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["grid_width"],
+            10,
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["grid_height"],
+            10,
+        )
+
+        exposed = default.spec.environment_parameters["color_encoding"]
+        self.assertIsInstance(exposed, dict)
+        assert isinstance(exposed, dict)
+        exposed["purple"] = 100
+        fresh = default.spec.environment_parameters["color_encoding"]
+        self.assertIsInstance(fresh, dict)
+        assert isinstance(fresh, dict)
+        self.assertEqual(fresh["purple"], 3)
+
+    def test_config_rejects_unsupported_or_ambiguous_profiles(self) -> None:
+        with self.assertRaises(ValueError):
+            KeyCorridorConfig(profile="S4R2")
+        with self.assertRaises(ValueError):
+            KeyCorridorConfig(profile=4)  # type: ignore[arg-type]
+
+    def test_episode_planning_is_reproducible_and_split_scoped(self) -> None:
+        benchmark = KeyCorridorBenchmark()
+
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        validation = tuple(
+            benchmark.episodes("validation", seed=7, count=10)
+        )
+
+        self.assertEqual(train, repeated)
+        self.assertEqual(len({item.environment_seed for item in train}), 10)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in validation
+            )
+        )
+        self.assertTrue(all(item.scenario is None for item in train))
+
+    def test_environment_is_conformant_and_rejects_invalid_actions(
+        self,
+    ) -> None:
+        benchmark = KeyCorridorBenchmark(
+            KeyCorridorConfig(profile="S3R1")
+        )
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertEqual(
+                set(observation),
+                {"image", "direction", "mission"},
+            )
+            image = observation["image"]
+            self.assertIsInstance(image, TensorValue)
+            assert isinstance(image, TensorValue)
+            self.assertEqual(image.dtype, "uint8")
+            self.assertEqual(image.shape, (7, 7, 3))
+            self.assertEqual(len(image.data), 147)
+            mission = observation["mission"]
+            self.assertIsInstance(mission, str)
+            assert isinstance(mission, str)
+            self.assertTrue(mission.startswith("pick up the "))
+            self.assertTrue(mission.endswith(" ball"))
+        finally:
+            environment.close()
+            environment.close()
+
+        invalid_actions: tuple[PolicyValue, ...] = (
+            -1,
+            7,
+            True,
+            2.0,
+            [2],
+        )
+        for invalid in invalid_actions:
+            environment = benchmark.make_environment(
+                EpisodeSpec(environment_seed=123)
+            )
+            try:
+                environment.reset()
+                with self.assertRaises(InvalidAction):
+                    environment.step(invalid)
+            finally:
+                environment.close()
+
+    def test_episode_scenario_cannot_override_benchmark_configuration(
+        self,
+    ) -> None:
+        benchmark = KeyCorridorBenchmark()
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(
+                    environment_seed=1,
+                    scenario={"profile": "S3R1"},
+                )
+            )
+
+    def test_feedback_penalizes_failure_and_keeps_identity_private(self) -> None:
+        benchmark = KeyCorridorBenchmark()
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+
+        feedback = benchmark.feedback((failed,))
+
+        self.assertEqual(feedback.score, 0.0)
+        self.assertEqual(len(feedback.artifacts), 1)
+        trace = feedback.artifacts[0]
+        self.assertEqual(trace.name, "trace.jsonl")
+        self.assertNotIn(b"environment_seed", trace.read_bytes())
+        self.assertNotIn(b"policy_seed", trace.read_bytes())
+        self.assertNotIn(b'"profile"', trace.read_bytes())
+        self.assertIsInstance(feedback.content, dict)
+        assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["policy_failures"], 1)
+        self.assertEqual(feedback.content["key_found_episodes"], 0)
+        self.assertEqual(feedback.content["key_pickup_episodes"], 0)
+        self.assertEqual(
+            feedback.content["target_door_open_episodes"],
+            0,
+        )
+
+    def test_baseline_solves_every_public_profile_and_publishes_trace(
+        self,
+    ) -> None:
+        for profile in (
+            "S3R1",
+            "S3R2",
+            "S3R3",
+            "S4R3",
+            "S5R3",
+            "S6R3",
+        ):
+            with self.subTest(profile=profile):
+                benchmark = KeyCorridorBenchmark(
+                    KeyCorridorConfig(profile=profile)
+                )
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=6,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+
+                self.assertEqual(
+                    result.benchmark_id,
+                    "minigrid/KeyCorridor-v0/success-rate-v1",
+                )
+                self.assertEqual(
+                    result.environment_digest,
+                    benchmark.spec.environment_digest,
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["key_pickup_rate"],
+                    1.0,
+                )
+                self.assertEqual(
+                    result.feedback.content["target_door_open_rate"],
+                    1.0,
+                )
+                self.assertEqual(
+                    result.feedback.content["target_object_found_rate"],
+                    1.0,
+                )
+                trace = result.feedback.artifacts[0]
+                documents = tuple(
+                    json.loads(line)
+                    for line in trace.read_bytes().splitlines()
+                )
+                transitions = tuple(
+                    document
+                    for document in documents
+                    if document["type"] == "transition"
+                )
+                self.assertEqual(trace.name, "trace.jsonl")
+                self.assertEqual(
+                    trace.media_type,
+                    "application/x-ndjson",
+                )
+                self.assertTrue(transitions)
+                self.assertTrue(
+                    all(
+                        "target_color" in item["next_observation"]
+                        for item in transitions
+                    )
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "pick up the purple ball",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/keycorridor/uv.lock
+++ b/environments/minigrid/minigrid/keycorridor/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-keycorridor"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/lava_gap/.gitignore
+++ b/environments/minigrid/minigrid/lava_gap/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/lava_gap/README.md
+++ b/environments/minigrid/minigrid/lava_gap/README.md
@@ -1,0 +1,16 @@
+# MiniGrid LavaGap Benchmark
+
+An independently installable EvoPolicyGym Benchmark for all three MiniGrid
+`LavaGap` size registrations.
+
+```python
+from minigrid_lava_gap import LavaGapBenchmark, LavaGapConfig
+
+benchmark = LavaGapBenchmark(LavaGapConfig(profile="S7"))
+```
+
+The Policy must safely discover the opening through a generated lava strip and reach
+the opposite-corner goal. Feedback reports goal discovery and hazard entry;
+the bounded semantic trace contains no seeds, private identity, or Host paths.
+The packaged baseline never moves into an unknown or observed obstacle cell.
+Trusted baseline tests use `ProcessExecution.unsafe()`, which is not a sandbox.

--- a/environments/minigrid/minigrid/lava_gap/pyproject.toml
+++ b/environments/minigrid/minigrid/lava_gap/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-lava-gap"
+version = "0.1.0"
+description = "The MiniGrid LavaGap Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_lava_gap"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/__init__.py
+++ b/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/__init__.py
@@ -1,0 +1,8 @@
+"""The public MiniGrid LavaGap Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import LavaGapBenchmark
+from .config import LavaGapConfig
+
+__all__ = ["LavaGapBenchmark", "LavaGapConfig", "baseline_program"]
+

--- a/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/baseline.py
+++ b/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid LavaGap Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_lava_gap").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/benchmark.py
+++ b/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/benchmark.py
@@ -1,0 +1,325 @@
+"""MiniGrid LavaGap with deterministic plans and safety traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import LavaGapConfig
+from .environment import LavaGapEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-minigrid-lava_gap/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_OBJECTS = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATES = ("open", "closed", "locked")
+_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTIONS: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRICS = {"goal_found", "hazard_entered", "success"}
+
+
+class LavaGapBenchmark:
+    """Safe-navigation success rate through one generated lava barrier."""
+
+    def __init__(self, config: LavaGapConfig | None = None) -> None:
+        if config is None:
+            config = LavaGapConfig()
+        if type(config) is not LavaGapConfig:
+            raise TypeError("config must be LavaGapConfig")
+        self._config = config
+        self._spec = _spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return LavaGapEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successes = sum(_success(record) for record in records)
+        score = successes / len(records)
+        goal_found = sum(_reached(r, "goal_found") for r in records)
+        hazards = sum(_reached(r, "hazard_entered") for r in records)
+        traced = records[:4]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the goal in {successes}/{len(records)} Episodes "
+                    f"({score:.3f} success rate); {hazards} entered a hazard."
+                ),
+                "success_rate": score,
+                "goal_found_rate": goal_found / len(records),
+                "hazard_rate": hazards / len(records),
+                "mean_return": statistics.fmean(
+                    r.total_reward if r.policy_failure is None else 0.0
+                    for r in records
+                ),
+                "mean_steps": statistics.fmean(r.steps for r in records),
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "hazard_episodes": hazards,
+                "truncated_episodes": sum(_truncated(r) for r in records),
+                "policy_failures": sum(
+                    r.policy_failure is not None for r in records
+                ),
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+            },
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec(config: LavaGapConfig) -> BenchmarkSpec:
+    mission = "avoid the lava and get to the green goal square"
+    return BenchmarkSpec(
+        id="minigrid/LavaGap-v0/success-rate-v1",
+        description=(
+            "Discover the single opening in a generated vertical lava strip "
+            "and safely reach the opposite-corner goal."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "constant": mission},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTIONS,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "size": config.size,
+            "start_position": [1, 1],
+            "goal_position": [config.size - 2, config.size - 2],
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": mission,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECTS)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLORS)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATES)
+            },
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _success(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _reached(record: EpisodeRecord, name: str) -> bool:
+    return any(
+        type(item.step.metrics) is dict
+        and item.step.metrics.get(name) is True
+        for item in record.transitions
+    )
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _success(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                }
+            )
+        )
+        indices = (
+            tuple(range(record.steps))
+            if record.steps <= 160
+            else (*range(128), *range(record.steps - 32, record.steps))
+        )
+        for index in indices:
+            item = record.transitions[index]
+            if type(item.action) is not int or not 0 <= item.action <= 6:
+                raise ValueError("MiniGrid LavaGap trace Action is invalid")
+            if (
+                type(item.step.metrics) is not dict
+                or set(item.step.metrics) != _METRICS
+            ):
+                raise ValueError("MiniGrid LavaGap trace metrics are invalid")
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": index,
+                        "action": item.action,
+                        "action_meaning": _ACTIONS[str(item.action)],
+                        "reward": item.step.reward,
+                        "next_observation": _trace_observation(
+                            item.step.observation
+                        ),
+                        "terminated": item.step.terminated,
+                        "truncated": item.step.truncated,
+                        "metrics": item.step.metrics,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_observation(value: PolicyValue) -> dict[str, PolicyValue]:
+    if type(value) is not dict:
+        raise ValueError("MiniGrid LavaGap trace observation is invalid")
+    image = value.get("image")
+    direction = value.get("direction")
+    mission = value.get("mission")
+    if (
+        type(image) is not TensorValue
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+        or type(direction) is not int
+        or type(mission) is not str
+    ):
+        raise ValueError("MiniGrid LavaGap trace observation is invalid")
+    rows: list[PolicyValue] = []
+    for y in range(7):
+        rows.append(
+            "".join(
+                _SYMBOLS[image.data[(x * 7 + y) * 3]]
+                for x in range(7)
+            )
+        )
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+    }
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
+__all__ = ["LavaGapBenchmark"]

--- a/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/config.py
+++ b/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/config.py
@@ -1,0 +1,38 @@
+"""Typed, public MiniGrid LavaGap environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int]] = {
+    "S5": ("MiniGrid-LavaGapS5-v0", 5),
+    "S6": ("MiniGrid-LavaGapS6-v0", 6),
+    "S7": ("MiniGrid-LavaGapS7-v0", 7),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class LavaGapConfig:
+    """Parameters defining one LavaGap Benchmark identity."""
+
+    profile: str = "S7"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        return _PROFILES[self.profile][0]
+
+    @property
+    def size(self) -> int:
+        return _PROFILES[self.profile][1]
+
+    @property
+    def max_episode_steps(self) -> int:
+        return 4 * self.size**2
+
+
+__all__ = ["LavaGapConfig"]

--- a/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/environment.py
+++ b/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/environment.py
@@ -1,0 +1,151 @@
+"""One fresh MiniGrid LavaGap Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import LavaGapConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_GOAL = 8
+
+
+@dataclass(frozen=True, slots=True)
+class _Facts:
+    goal_visible: bool
+
+
+class LavaGapEnvironment:
+    """Strict seeded adapter around a configured LavaGap registration."""
+
+    def __init__(self, episode: EpisodeSpec, *, config: LavaGapConfig) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not LavaGapConfig:
+            raise TypeError("config must be LavaGapConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "LavaGap configuration belongs in LavaGapConfig"
+            )
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._goal_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._goal_found = facts.goal_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid LavaGap returned invalid flags")
+        number = _number(reward)
+        public, facts = _observation(observation)
+        self._goal_found = self._goal_found or facts.goal_visible
+        success = bool(terminated and number > 0.0)
+        hazard = bool(terminated and action == 2 and not success)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "goal_found": self._goal_found,
+                "hazard_entered": hazard,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(value: object) -> tuple[dict[str, PolicyValue], _Facts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid LavaGap returned invalid observation")
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid LavaGap returned invalid image")
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid LavaGap returned invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid LavaGap returned invalid direction")
+    mission = value["mission"]
+    if (
+        type(mission) is not str
+        or mission != "avoid the lava and get to the green goal square"
+    ):
+        raise RuntimeError("MiniGrid LavaGap returned invalid mission")
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _Facts(goal_visible=bool(numpy.any(image[:, :, 0] == _GOAL))),
+    )
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("MiniGrid LavaGap returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("MiniGrid LavaGap returned non-finite reward")
+    return number
+
+
+__all__ = ["LavaGapEnvironment"]

--- a/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/programs/baseline/policy.py
@@ -1,0 +1,275 @@
+"""A public-observation safe exploration baseline for LavaGap."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Reveal unknown cells without entering them and plan through openings."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+        size: int,
+    ) -> None:
+        self._objects = object_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._goal = (size - 3, size - 3)
+        self._grid: dict[Position, Cell] = {
+            self._position: (self._objects["empty"], self._states["open"]),
+            self._goal: (self._objects["goal"], self._states["open"]),
+        }
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+        self._integrate(image, direction)
+        action = self._navigate(self._goal, direction)
+        if action is not None:
+            return action
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        image = observation.get("image")
+        direction = observation.get("direction")
+        if (
+            type(image) is not TensorValue
+            or image.shape != (self._view_size, self._view_size, 3)
+            or image.dtype != "uint8"
+            or type(direction) is not int
+            or not 0 <= direction <= 3
+        ):
+            raise ValueError("observation is invalid")
+        return image, direction
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _VECTORS[direction]
+        right_x, right_y = _VECTORS[(direction + 1) % 4]
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                offset = (view_x * self._view_size + view_y) * 3
+                object_code = image.data[offset]
+                state_code = image.data[offset + 2]
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (object_code, state_code)
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        return None if not path else self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        turn = _turn_toward(
+            direction,
+            _direction_between(self._position, next_position),
+        )
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers = [
+            (distance, position, frontier_direction)
+            for position, distance in distances.items()
+            for frontier_direction, neighbor in _neighbors(position)
+            if neighbor not in self._grid
+        ]
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(frontiers)
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        return _RIGHT if turn is None else turn
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        return bool(
+            cell is not None
+            and cell[0]
+            in {
+                self._objects["empty"],
+                self._objects["floor"],
+                self._objects["goal"],
+            }
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    values = context.environment_parameters
+    objects = values.get("object_encoding")
+    states = values.get("state_encoding")
+    view_size = values.get("view_size")
+    agent_position = values.get("agent_view_position")
+    size = values.get("size")
+    names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(objects) is not dict
+        or set(objects) != names
+        or any(type(value) is not int for value in objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(states) is not dict
+        or set(states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(view_size) is not int or view_size != 7:
+        raise ValueError("view_size is invalid")
+    if type(agent_position) is not list or agent_position != [3, 6]:
+        raise ValueError("agent_view_position is invalid")
+    if type(size) is not int or size not in {5, 6, 7}:
+        raise ValueError("size is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in objects.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in states.items()
+        },
+        view_size=view_size,
+        agent_view_position=(3, 6),
+        size=size,
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        path.append(current)
+        current = previous[current]
+    path.reverse()
+    return tuple(path[1:])

--- a/environments/minigrid/minigrid/lava_gap/tests/test_lava_gap.py
+++ b/environments/minigrid/minigrid/lava_gap/tests/test_lava_gap.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import EpisodeRecord, EpisodeSpec
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_lava_gap import (
+    LavaGapBenchmark,
+    LavaGapConfig,
+    baseline_program,
+)
+
+
+class LavaGapTests(unittest.TestCase):
+    def test_profiles_define_identity(self) -> None:
+        default = LavaGapBenchmark()
+        small = LavaGapBenchmark(LavaGapConfig(profile="S5"))
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/LavaGap-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 196)
+        self.assertEqual(small.spec.max_episode_steps, 100)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            small.spec.environment_digest,
+        )
+        with self.assertRaises(ValueError):
+            LavaGapConfig(profile="S9")
+
+    def test_split_planning_and_scenario_rejection(self) -> None:
+        benchmark = LavaGapBenchmark()
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"size": 11})
+            )
+
+    def test_feedback_privacy(self) -> None:
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        trace = (
+            LavaGapBenchmark().feedback((failed,)).artifacts[0].read_bytes()
+        )
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+
+    def test_baseline_solves_all_profiles_without_hazard(self) -> None:
+        profiles = ("S5", "S6", "S7")
+        for profile in profiles:
+            with self.subTest(profile=profile):
+                benchmark = LavaGapBenchmark(
+                    LavaGapConfig(profile=profile)
+                )
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=6,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["hazard_rate"],
+                    0.0,
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "avoid the lava and get to the green goal square",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/lava_gap/uv.lock
+++ b/environments/minigrid/minigrid/lava_gap/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-lava-gap"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/locked_room/.gitignore
+++ b/environments/minigrid/minigrid/locked_room/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/locked_room/README.md
+++ b/environments/minigrid/minigrid/locked_room/README.md
@@ -1,0 +1,17 @@
+# MiniGrid LockedRoom Benchmark
+
+An independently installable EvoPolicyGym Benchmark for
+[MiniGrid LockedRoom](https://minigrid.farama.org/environments/minigrid/LockedRoomEnv/).
+The Policy searches six rooms, follows the mission to the target-color key,
+unlocks the matching room, and reaches its goal.
+
+```python
+from minigrid_locked_room import LockedRoomBenchmark, baseline_program
+```
+
+Feedback and the bounded semantic trace report ordinary doors opened, key
+discovery/acquisition, target-door completion, and goal discovery without
+publishing seeds, private identity, or Host paths. The baseline uses public
+observations only. `ProcessExecution.unsafe()` is used only for trusted
+baseline tests and is not a sandbox.
+

--- a/environments/minigrid/minigrid/locked_room/pyproject.toml
+++ b/environments/minigrid/minigrid/locked_room/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-locked-room"
+version = "0.1.0"
+description = "The MiniGrid LockedRoom Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_locked_room"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/__init__.py
+++ b/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/__init__.py
@@ -1,0 +1,7 @@
+"""The public MiniGrid LockedRoom Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import LockedRoomBenchmark
+
+__all__ = ["LockedRoomBenchmark", "baseline_program"]
+

--- a/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/baseline.py
+++ b/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/baseline.py
@@ -1,0 +1,22 @@
+"""Packaged initial Program for MiniGrid LockedRoom Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_locked_room").joinpath(
+        "programs",
+        "baseline",
+    )
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/benchmark.py
+++ b/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/benchmark.py
@@ -1,0 +1,360 @@
+"""MiniGrid LockedRoom with deterministic plans and milestone traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .environment import LockedRoomEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-minigrid-locked-room/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_OBJECTS = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATES = ("open", "closed", "locked")
+_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_MISSIONS = tuple(
+    f"get the {target} key from the {room} room, "
+    f"unlock the {target} door and go to the goal"
+    for target in _COLORS
+    for room in _COLORS
+    if room != target
+)
+_ACTIONS: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRICS = {
+    "opened_doors",
+    "key_found",
+    "key_picked_up",
+    "target_door_opened",
+    "goal_found",
+    "success",
+}
+
+
+class LockedRoomBenchmark:
+    """Success rate for the six-room key-conditioned navigation task."""
+
+    def __init__(self) -> None:
+        self._spec = _spec()
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return LockedRoomEnvironment(episode)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successes = sum(_success(record) for record in records)
+        score = successes / len(records)
+        bool_names = _METRICS - {"success", "opened_doors"}
+        counts = {
+            name: sum(_reached(record, name) for record in records)
+            for name in bool_names
+        }
+        opened = tuple(_maximum(record, "opened_doors") for record in records)
+        traced = records[:4]
+        content: dict[str, PolicyValue] = {
+            "summary": (
+                f"Recovered the mission key, unlocked its room, and reached "
+                f"the goal in {successes}/{len(records)} Episodes "
+                f"({score:.3f} success rate)."
+            ),
+            "success_rate": score,
+            "mean_opened_doors": statistics.fmean(opened),
+            "mean_return": statistics.fmean(
+                record.total_reward
+                if record.policy_failure is None
+                else 0.0
+                for record in records
+            ),
+            "mean_steps": statistics.fmean(r.steps for r in records),
+            "episodes": len(records),
+            "successful_episodes": successes,
+            "truncated_episodes": sum(_truncated(r) for r in records),
+            "policy_failures": sum(
+                record.policy_failure is not None for record in records
+            ),
+            "traced_episodes": len(traced),
+            "trace_episodes_omitted": len(records) - len(traced),
+        }
+        for name, value in counts.items():
+            content[f"{name}_rate"] = value / len(records)
+            content[f"{name}_episodes"] = value
+        return Feedback(
+            score=score,
+            content=content,
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec() -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/LockedRoom-v0/success-rate-v1",
+        description=(
+            "Search six rooms according to the mission, recover the key "
+            "matching the locked room, unlock it, and reach its goal."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "values": list(_MISSIONS)},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTIONS,
+        },
+        metadata={
+            "environment": "MiniGrid-LockedRoom-v0",
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "size": 19,
+            "rooms": 6,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission_template": (
+                "get the {target_color} key from the {key_room_color} room, "
+                "unlock the {target_color} door and go to the goal"
+            ),
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECTS)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLORS)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATES)
+            },
+        },
+        max_episode_steps=190,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _success(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _reached(record: EpisodeRecord, name: str) -> bool:
+    return any(
+        type(item.step.metrics) is dict
+        and item.step.metrics.get(name) is True
+        for item in record.transitions
+    )
+
+
+def _maximum(record: EpisodeRecord, name: str) -> int:
+    values = [
+        item.step.metrics.get(name)
+        for item in record.transitions
+        if type(item.step.metrics) is dict
+    ]
+    return max(
+        (
+            value
+            for value in values
+            if type(value) is int
+        ),
+        default=0,
+    )
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _success(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                }
+            )
+        )
+        indices = (
+            tuple(range(record.steps))
+            if record.steps <= 160
+            else (*range(128), *range(record.steps - 32, record.steps))
+        )
+        for index in indices:
+            item = record.transitions[index]
+            if type(item.action) is not int or not 0 <= item.action <= 6:
+                raise ValueError(
+                    "MiniGrid LockedRoom trace Action is invalid"
+                )
+            if type(item.step.metrics) is not dict:
+                raise ValueError(
+                    "MiniGrid LockedRoom trace metrics are invalid"
+                )
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": index,
+                        "action": item.action,
+                        "action_meaning": _ACTIONS[str(item.action)],
+                        "reward": item.step.reward,
+                        "next_observation": _trace_observation(
+                            item.step.observation
+                        ),
+                        "terminated": item.step.terminated,
+                        "truncated": item.step.truncated,
+                        "metrics": item.step.metrics,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_observation(value: PolicyValue) -> dict[str, PolicyValue]:
+    if type(value) is not dict:
+        raise ValueError("MiniGrid LockedRoom trace observation is invalid")
+    image = value.get("image")
+    direction = value.get("direction")
+    mission = value.get("mission")
+    if (
+        type(image) is not TensorValue
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+        or type(direction) is not int
+        or type(mission) is not str
+        or mission not in _MISSIONS
+    ):
+        raise ValueError("MiniGrid LockedRoom trace observation is invalid")
+    rows: list[PolicyValue] = []
+    for y in range(7):
+        rows.append(
+            "".join(
+                _SYMBOLS[image.data[(x * 7 + y) * 3]]
+                for x in range(7)
+            )
+        )
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+    }
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
+__all__ = ["LockedRoomBenchmark"]

--- a/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/environment.py
+++ b/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/environment.py
@@ -1,0 +1,229 @@
+"""One fresh MiniGrid LockedRoom Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_DOOR = 4
+_KEY = 5
+_GOAL = 8
+_CLOSED = 1
+_LOCKED = 2
+
+
+@dataclass(frozen=True, slots=True)
+class _Facts:
+    target_color: int
+    target_key_visible: bool
+    carried_key_color: int | None
+    goal_visible: bool
+    front_door: tuple[int, int] | None
+
+
+class LockedRoomEnvironment:
+    """Strict seeded adapter around MiniGrid LockedRoom."""
+
+    def __init__(self, episode: EpisodeSpec) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if episode.scenario is not None:
+            raise ValueError("LockedRoom has no Episode scenario overrides")
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make("MiniGrid-LockedRoom-v0"),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._target_color: int | None = None
+        self._carried_key_color: int | None = None
+        self._front_door: tuple[int, int] | None = None
+        self._key_found = False
+        self._key_picked_up = False
+        self._target_door_opened = False
+        self._goal_found = False
+        self._opened_doors = 0
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._target_color = facts.target_color
+        self._update(facts)
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        opened_door = bool(
+            action == 5
+            and self._front_door is not None
+            and (
+                self._front_door[1] == _CLOSED
+                or (
+                    self._front_door[1] == _LOCKED
+                    and self._carried_key_color == self._front_door[0]
+                )
+            )
+        )
+        opened_target = bool(
+            opened_door
+            and self._front_door is not None
+            and self._front_door[0] == self._target_color
+            and self._front_door[1] == _LOCKED
+        )
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid LockedRoom returned invalid flags")
+        number = _number(reward)
+        public, facts = _observation(observation)
+        if facts.target_color != self._target_color:
+            raise RuntimeError("MiniGrid LockedRoom changed mission target")
+        if opened_door:
+            self._opened_doors += 1
+        self._target_door_opened = (
+            self._target_door_opened or opened_target
+        )
+        self._update(facts)
+        success = bool(terminated and number > 0.0)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "opened_doors": self._opened_doors,
+                "key_found": self._key_found,
+                "key_picked_up": self._key_picked_up,
+                "target_door_opened": self._target_door_opened,
+                "goal_found": self._goal_found,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+    def _update(self, facts: _Facts) -> None:
+        self._carried_key_color = facts.carried_key_color
+        self._front_door = facts.front_door
+        self._key_found = self._key_found or facts.target_key_visible
+        self._key_picked_up = (
+            self._key_picked_up
+            or facts.carried_key_color == self._target_color
+        )
+        self._goal_found = self._goal_found or facts.goal_visible
+
+
+def _observation(value: object) -> tuple[dict[str, PolicyValue], _Facts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid LockedRoom returned invalid observation")
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid LockedRoom returned invalid image")
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid LockedRoom returned invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid LockedRoom returned invalid direction")
+    mission = value["mission"]
+    if type(mission) is not str:
+        raise RuntimeError("MiniGrid LockedRoom returned invalid mission")
+    target_color = _target_color(mission)
+    carried_key_color = (
+        int(image[3, 6, 1])
+        if image[3, 6, 0] == _KEY
+        else None
+    )
+    front_door = (
+        (int(image[3, 5, 1]), int(image[3, 5, 2]))
+        if image[3, 5, 0] == _DOOR
+        else None
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _Facts(
+            target_color=target_color,
+            target_key_visible=bool(
+                numpy.any(
+                    (image[:, :, 0] == _KEY)
+                    & (image[:, :, 1] == target_color)
+                )
+            ),
+            carried_key_color=carried_key_color,
+            goal_visible=bool(numpy.any(image[:, :, 0] == _GOAL)),
+            front_door=front_door,
+        ),
+    )
+
+
+def _target_color(mission: str) -> int:
+    prefix = "get the "
+    suffix = " key from the "
+    if not mission.startswith(prefix) or suffix not in mission:
+        raise RuntimeError("MiniGrid LockedRoom returned invalid mission")
+    color = mission.removeprefix(prefix).split(suffix, maxsplit=1)[0]
+    expected = f"unlock the {color} door and go to the goal"
+    if color not in _COLORS or expected not in mission:
+        raise RuntimeError("MiniGrid LockedRoom returned invalid mission")
+    return _COLORS.index(color)
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("MiniGrid LockedRoom returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("MiniGrid LockedRoom returned non-finite reward")
+    return number
+
+
+__all__ = ["LockedRoomEnvironment"]

--- a/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/programs/baseline/policy.py
@@ -1,0 +1,460 @@
+"""A public-observation mapping and planning LockedRoom baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_PICKUP = 3
+_TOGGLE = 5
+_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Open ordinary rooms, obtain the mission key, and reach the goal."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._target_color: int | None = None
+        self._carried_key_color: int | None = None
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction, mission = self._read_observation(observation)
+        target_color = self._read_target_color(mission)
+        if self._target_color is None:
+            self._target_color = target_color
+        elif self._target_color != target_color:
+            raise ValueError("mission changed during the Episode")
+        self._integrate(image, direction)
+
+        if self._carried_key_color is None:
+            key = self._known_matching(
+                self._objects["key"],
+                target_color,
+            )
+            if key is not None:
+                return self._interact(key, _PICKUP, direction)
+        else:
+            locked = self._known_door(
+                target_color,
+                self._states["locked"],
+            )
+            if locked is not None:
+                return self._interact(locked, _TOGGLE, direction)
+
+        goal = self._known_object("goal")
+        if goal is not None:
+            action = self._navigate(goal, direction)
+            if action is not None:
+                return action
+
+        closed = self._nearest_door(self._states["closed"])
+        if closed is not None:
+            return self._interact(closed, _TOGGLE, direction)
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int, str]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        mission = observation["mission"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        if type(mission) is not str:
+            raise ValueError("observation mission is invalid")
+        return image, direction, mission
+
+    def _read_target_color(self, mission: str) -> int:
+        prefix = "get the "
+        separator = " key from the "
+        if not mission.startswith(prefix) or separator not in mission:
+            raise ValueError("observation mission is invalid")
+        color = mission.removeprefix(prefix).split(separator, maxsplit=1)[0]
+        if (
+            color not in self._colors
+            or f"unlock the {color} door and go to the goal"
+            not in mission
+        ):
+            raise ValueError("observation mission is invalid")
+        return self._colors[color]
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _VECTORS[direction]
+        right_x, right_y = _VECTORS[(direction + 1) % 4]
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    if object_code == self._objects["key"]:
+                        self._carried_key_color = color_code
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+
+    def _cell(self, image: TensorValue, x: int, y: int) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_matching(
+        self,
+        object_code: int,
+        color_code: int,
+    ) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == object_code and cell[1] == color_code
+            ),
+            None,
+        )
+
+    def _known_object(self, name: str) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == self._objects[name]
+            ),
+            None,
+        )
+
+    def _known_door(self, color: int, state: int) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == self._objects["door"]
+                and cell[1] == color
+                and cell[2] == state
+            ),
+            None,
+        )
+
+    def _nearest_door(self, state: int) -> Position | None:
+        candidates: list[tuple[int, Position]] = []
+        for position, cell in self._grid.items():
+            if (
+                cell[0] != self._objects["door"]
+                or cell[2] != state
+            ):
+                continue
+            approach = self._best_approach(position)
+            if approach is not None:
+                candidates.append((len(approach[1]), position))
+        return (
+            None
+            if not candidates
+            else min(candidates, key=lambda item: (item[0], item[1]))[1]
+        )
+
+    def _interact(
+        self,
+        target: Position,
+        action: int,
+        direction: int,
+    ) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+        turn = _turn_toward(
+            direction,
+            _direction_between(approach_position, target),
+        )
+        if turn is not None:
+            return turn
+        cell = self._grid[target]
+        if action == _PICKUP:
+            self._carried_key_color = cell[1]
+            self._grid[target] = (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        else:
+            self._grid[target] = (
+                self._objects["door"],
+                cell[1],
+                self._states["open"],
+            )
+        return action
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if self._traversable(neighbor):
+                path = self._shortest_path(neighbor)
+                if path is not None:
+                    candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(candidates)
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        return None if not path else self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        turn = _turn_toward(
+            direction,
+            _direction_between(self._position, next_position),
+        )
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers = [
+            (distance, position, unknown_direction)
+            for position, distance in distances.items()
+            for unknown_direction, neighbor in _neighbors(position)
+            if neighbor not in self._grid
+        ]
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(frontiers)
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        return _RIGHT if turn is None else turn
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        return bool(
+            cell is not None
+            and (
+                cell[0]
+                in {
+                    self._objects["empty"],
+                    self._objects["floor"],
+                    self._objects["goal"],
+                }
+                or (
+                    cell[0] == self._objects["door"]
+                    and cell[2] == self._states["open"]
+                )
+            )
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    values = context.environment_parameters
+    objects = values.get("object_encoding")
+    colors = values.get("color_encoding")
+    states = values.get("state_encoding")
+    view_size = values.get("view_size")
+    agent_position = values.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(objects) is not dict
+        or set(objects) != object_names
+        or any(type(value) is not int for value in objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(colors) is not dict
+        or set(colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(states) is not dict
+        or set(states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(view_size) is not int or view_size != 7:
+        raise ValueError("view_size is invalid")
+    if type(agent_position) is not list or agent_position != [3, 6]:
+        raise ValueError("agent_view_position is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in states.items()
+        },
+        view_size=view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        path.append(current)
+        current = previous[current]
+    path.reverse()
+    return tuple(path[1:])

--- a/environments/minigrid/minigrid/locked_room/tests/test_locked_room.py
+++ b/environments/minigrid/minigrid/locked_room/tests/test_locked_room.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_locked_room import LockedRoomBenchmark, baseline_program
+
+
+class LockedRoomTests(unittest.TestCase):
+    def test_spec_and_split_planning(self) -> None:
+        benchmark = LockedRoomBenchmark()
+        self.assertEqual(
+            benchmark.spec.id,
+            "minigrid/LockedRoom-v0/success-rate-v1",
+        )
+        self.assertEqual(benchmark.spec.max_episode_steps, 190)
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+
+    def test_environment_contract_and_invalid_action(self) -> None:
+        benchmark = LockedRoomBenchmark()
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 5, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertIsInstance(observation["image"], TensorValue)
+            self.assertIn(" unlock the ", str(observation["mission"]))
+            with self.assertRaises(InvalidAction):
+                environment.step(7)
+        finally:
+            environment.close()
+
+    def test_scenario_and_feedback_privacy(self) -> None:
+        with self.assertRaises(ValueError):
+            LockedRoomBenchmark().make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"size": 8})
+            )
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        trace = (
+            LockedRoomBenchmark().feedback((failed,)).artifacts[0].read_bytes()
+        )
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+
+    def test_baseline_solves_task(self) -> None:
+        result = evaluate(
+            baseline_program(),
+            LockedRoomBenchmark(),
+            execution=ProcessExecution.unsafe(),
+            config=EvaluationConfig(
+                split="validation",
+                episodes=12,
+                seed=5,
+                episode_timeout_seconds=10,
+            ),
+        )
+        self.assertEqual(result.feedback.score, 1.0)
+        self.assertIsInstance(result.feedback.content, dict)
+        assert isinstance(result.feedback.content, dict)
+        for name in (
+            "key_picked_up_rate",
+            "target_door_opened_rate",
+            "goal_found_rate",
+        ):
+            self.assertEqual(result.feedback.content[name], 1.0)
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": (
+            "get the red key from the green room, "
+            "unlock the red door and go to the goal"
+        ),
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/locked_room/uv.lock
+++ b/environments/minigrid/minigrid/locked_room/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-locked-room"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/memory/.gitignore
+++ b/environments/minigrid/minigrid/memory/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+dist/
+build/
+*.egg-info/
+__pycache__/
+*.py[cod]

--- a/environments/minigrid/minigrid/memory/README.md
+++ b/environments/minigrid/minigrid/memory/README.md
@@ -1,0 +1,52 @@
+# MiniGrid Memory Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid Memory](https://minigrid.farama.org/environments/minigrid/MemoryEnv/)
+partially observable T-maze.
+
+The Policy sees the upstream `7 × 7 × 3` egocentric symbolic image, compass
+direction, and mission text. It must remember whether the green cue was a key
+or a ball, walk down the corridor, and select the matching object. The primary
+score is Episode success rate.
+
+## Install and test
+
+From the EvoPolicyGym repository root:
+
+```console
+uv sync --project environments/minigrid/minigrid/memory --extra dev
+uv run --project environments/minigrid/minigrid/memory \
+  python -m unittest discover \
+  -s environments/minigrid/minigrid/memory/tests
+uv build environments/minigrid/minigrid/memory
+```
+
+## Public API
+
+```python
+from minigrid_memory import MemoryBenchmark, MemoryConfig, baseline_program
+
+benchmark = MemoryBenchmark(
+    MemoryConfig(profile="13x13-random"),
+)
+program = baseline_program()
+```
+
+Available profiles are `11x11`, `13x13`, `13x13-random`, and
+`17x17-random`. The default random-length profile prevents a Policy from
+solving the task using one fixed action count.
+
+Feedback includes aggregate success, return, step, wrong-target, truncation,
+and Policy-failure statistics. `trace.jsonl` contains a bounded semantic trace
+for at most four Episodes; long traces retain the first 128 and last 32
+transitions. Trace rows and visible-object records are derived only from
+Policy-visible observations and contain no Episode seed or private Case
+identity.
+
+The packaged baseline is intentionally small. It is a finite-state Policy
+whose same-Episode state remembers the cue; it uses only public Policy context
+and observations.
+
+Tests that use `ProcessExecution.unsafe()` run trusted packaged code only.
+That backend is a local process mechanism, not a sandbox and not suitable for
+hostile Programs.

--- a/environments/minigrid/minigrid/memory/pyproject.toml
+++ b/environments/minigrid/minigrid/memory/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-memory"
+version = "0.1.0"
+description = "The MiniGrid Memory Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = [
+    "mypy==2.3.0",
+    "ruff>=0.12.0",
+]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_memory"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/README.md",
+    "/pyproject.toml",
+    "/src",
+    "/tests",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/minigrid/minigrid/memory/src/minigrid_memory/__init__.py
+++ b/environments/minigrid/minigrid/memory/src/minigrid_memory/__init__.py
@@ -1,0 +1,11 @@
+"""The public MiniGrid Memory Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import MemoryBenchmark
+from .config import MemoryConfig
+
+__all__ = [
+    "MemoryBenchmark",
+    "MemoryConfig",
+    "baseline_program",
+]

--- a/environments/minigrid/minigrid/memory/src/minigrid_memory/baseline.py
+++ b/environments/minigrid/minigrid/memory/src/minigrid_memory/baseline.py
@@ -1,0 +1,18 @@
+"""Packaged initial Program for MiniGrid Memory development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the finite-state memory baseline."""
+
+    resource = files("minigrid_memory").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]

--- a/environments/minigrid/minigrid/memory/src/minigrid_memory/benchmark.py
+++ b/environments/minigrid/minigrid/memory/src/minigrid_memory/benchmark.py
@@ -1,0 +1,394 @@
+"""MiniGrid Memory with deterministic plans and bounded semantic traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import MemoryConfig
+from .environment import MemoryEnvironment
+
+_EPISODE_SEED_DOMAIN = b"evopolicygym-minigrid-memory/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_MISSION = "go to the matching object at the end of the hallway"
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+
+
+class MemoryBenchmark:
+    """Success rate on a partially observable object-memory T-maze."""
+
+    def __init__(self, config: MemoryConfig | None = None) -> None:
+        if config is None:
+            config = MemoryConfig()
+        if type(config) is not MemoryConfig:
+            raise TypeError("config must be MemoryConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return MemoryEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        mean_success_steps: PolicyValue = (
+            statistics.fmean(record.steps for record in successful)
+            if successful
+            else None
+        )
+        failures = sum(record.policy_failure is not None for record in records)
+        wrong_targets = sum(_wrong_target(record) for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the matching object in {successes}/{len(records)} "
+                    f"Episodes ({score:.3f} success rate)."
+                ),
+                "success_rate": score,
+                "mean_return": mean_return,
+                "mean_steps": mean_steps,
+                "mean_steps_on_success": mean_success_steps,
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "wrong_target_episodes": wrong_targets,
+                "truncated_episodes": truncations,
+                "policy_failures": failures,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+                "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+                "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+            },
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: MemoryConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/Memory-v0/success-rate-v1",
+        description=(
+            "Remember whether the green cue is a key or ball, traverse the "
+            "partially observable hallway, and choose the matching object at "
+            "the T-junction. Maximize success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "meaning": {
+                        "0": "east",
+                        "1": "south",
+                        "2": "west",
+                        "3": "north",
+                    },
+                },
+                "mission": {
+                    "type": "string",
+                    "constant": _MISSION,
+                },
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "size": config.size,
+            "random_length": config.random_length,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": _MISSION,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for reaching the matching object; "
+                "zero for a wrong object or timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _wrong_target(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward == 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _successful(record),
+                    "wrong_target": _wrong_target(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError("MiniGrid Memory trace Action is invalid")
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": transition.step.metrics,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError("MiniGrid Memory trace observation is invalid")
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("MiniGrid Memory trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("MiniGrid Memory trace direction is invalid")
+    if type(mission) is not str or mission != _MISSION:
+        raise ValueError("MiniGrid Memory trace mission is invalid")
+
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError("MiniGrid Memory trace image codes are invalid")
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["MemoryBenchmark"]

--- a/environments/minigrid/minigrid/memory/src/minigrid_memory/config.py
+++ b/environments/minigrid/minigrid/memory/src/minigrid_memory/config.py
@@ -1,0 +1,51 @@
+"""Typed, public MiniGrid Memory environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int, bool]] = {
+    "11x11": ("MiniGrid-MemoryS11-v0", 11, False),
+    "13x13": ("MiniGrid-MemoryS13-v0", 13, False),
+    "13x13-random": ("MiniGrid-MemoryS13Random-v0", 13, True),
+    "17x17-random": ("MiniGrid-MemoryS17Random-v0", 17, True),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryConfig:
+    """Parameters that define one MiniGrid Memory Benchmark identity."""
+
+    profile: str = "13x13-random"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        """Return the upstream Gymnasium registration."""
+
+        return _PROFILES[self.profile][0]
+
+    @property
+    def size(self) -> int:
+        """Return the outer grid size."""
+
+        return _PROFILES[self.profile][1]
+
+    @property
+    def random_length(self) -> bool:
+        """Return whether the corridor length varies by Episode."""
+
+        return _PROFILES[self.profile][2]
+
+    @property
+    def max_episode_steps(self) -> int:
+        """Return the upstream horizon."""
+
+        return 5 * self.size**2
+
+
+__all__ = ["MemoryConfig"]

--- a/environments/minigrid/minigrid/memory/src/minigrid_memory/environment.py
+++ b/environments/minigrid/minigrid/memory/src/minigrid_memory/environment.py
@@ -1,0 +1,146 @@
+"""One fresh MiniGrid Memory Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401  # Import registers MiniGrid environments.
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import MemoryConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_MISSION = "go to the matching object at the end of the hallway"
+
+
+class MemoryEnvironment:
+    """The seeded strict adapter around a configured MiniGrid Memory task."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: MemoryConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not MemoryConfig:
+            raise TypeError("config must be MemoryConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "Memory configuration belongs in MemoryConfig, "
+                "not EpisodeSpec.scenario"
+            )
+
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        self._started = True
+        return _observation(observation)
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid Memory returned invalid termination flags")
+        number = _number(reward, name="reward")
+        self._done = terminated or truncated
+        return Step(
+            observation=_observation(observation),
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={"success": bool(terminated and number > 0.0)},
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(value: object) -> dict[str, PolicyValue]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid Memory returned an invalid observation")
+
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid Memory returned an invalid image")
+    if (
+        numpy.any(image[:, :, 0] > 10)
+        or numpy.any(image[:, :, 1] > 5)
+        or numpy.any(image[:, :, 2] > 2)
+    ):
+        raise RuntimeError("MiniGrid Memory returned out-of-range image codes")
+
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid Memory returned an invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid Memory returned an invalid direction")
+
+    mission = value["mission"]
+    if type(mission) is not str or mission != _MISSION:
+        raise RuntimeError("MiniGrid Memory returned an invalid mission")
+
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=_IMAGE_SHAPE,
+            data=image.tobytes(order="C"),
+        ),
+        "direction": direction,
+        "mission": mission,
+    }
+
+
+def _number(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(f"MiniGrid Memory returned an invalid {name}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(f"MiniGrid Memory returned a non-finite {name}")
+    return number
+
+
+__all__ = ["MemoryEnvironment"]

--- a/environments/minigrid/minigrid/memory/src/minigrid_memory/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/memory/src/minigrid_memory/programs/baseline/policy.py
@@ -1,0 +1,148 @@
+"""A finite-state baseline that remembers the cue object."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_WEST = 2
+_EAST = 0
+_NORTH = 3
+_SOUTH = 1
+_WALL = 2
+
+
+class BaselinePolicy:
+    """Solve the canonical T-maze from egocentric observations only."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        view_size: int,
+    ) -> None:
+        self._object_encoding = object_encoding
+        self._view_size = view_size
+        self._target: int | None = None
+        self._phase = "find_cue"
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+
+        if self._phase == "find_cue":
+            visible = self._visible_targets(image)
+            if visible:
+                self._target = visible[0]
+            if direction != _WEST:
+                return _RIGHT
+            if self._wall_ahead(image):
+                if self._target is None:
+                    raise ValueError("cue object was not observed")
+                self._phase = "reach_junction"
+                return _LEFT
+            return _FORWARD
+
+        if self._phase == "reach_junction":
+            if direction != _EAST:
+                return _LEFT
+            if self._wall_ahead(image):
+                self._phase = "choose_branch"
+                return _LEFT
+            return _FORWARD
+
+        if self._phase == "choose_branch":
+            if direction != _NORTH:
+                return _LEFT
+            assert self._target is not None
+            if self._target in self._visible_targets(image):
+                self._phase = "finish"
+                return _FORWARD
+            self._phase = "turn_south"
+            return _RIGHT
+
+        if self._phase == "turn_south":
+            if direction != _SOUTH:
+                return _RIGHT
+            self._phase = "finish"
+            return _FORWARD
+
+        return _FORWARD
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        return image, direction
+
+    def _wall_ahead(self, image: TensorValue) -> bool:
+        center = self._view_size // 2
+        return self._object_at(image, center, self._view_size - 2) == _WALL
+
+    def _visible_targets(self, image: TensorValue) -> tuple[int, ...]:
+        targets = {
+            self._object_encoding["key"],
+            self._object_encoding["ball"],
+        }
+        visible: list[int] = []
+        for x in range(self._view_size):
+            for y in range(self._view_size):
+                object_code = self._object_at(image, x, y)
+                if object_code in targets:
+                    visible.append(object_code)
+        return tuple(visible)
+
+    def _object_at(self, image: TensorValue, x: int, y: int) -> int:
+        offset = (x * self._view_size + y) * 3
+        return image.data[offset]
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_encoding = parameters.get("object_encoding")
+    raw_view_size = parameters.get("view_size")
+    if type(raw_encoding) is not dict:
+        raise ValueError("object_encoding is invalid")
+    encoding = raw_encoding
+    if (
+        set(encoding) != {
+            "unseen",
+            "empty",
+            "wall",
+            "floor",
+            "door",
+            "key",
+            "ball",
+            "box",
+            "goal",
+            "lava",
+            "agent",
+        }
+        or any(type(value) is not int for value in encoding.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in encoding.items()
+        },
+        view_size=raw_view_size,
+    )

--- a/environments/minigrid/minigrid/memory/tests/test_memory.py
+++ b/environments/minigrid/minigrid/memory/tests/test_memory.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_memory import (
+    MemoryBenchmark,
+    MemoryConfig,
+    baseline_program,
+)
+
+
+class MemoryBenchmarkTests(unittest.TestCase):
+    def test_config_profiles_define_distinct_environment_identity(self) -> None:
+        default = MemoryBenchmark()
+        fixed = MemoryBenchmark(MemoryConfig(profile="13x13"))
+        large = MemoryBenchmark(MemoryConfig(profile="17x17-random"))
+
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/Memory-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 845)
+        self.assertEqual(large.spec.max_episode_steps, 1_445)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            fixed.spec.environment_digest,
+        )
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            large.spec.environment_digest,
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["profile"],
+            "13x13-random",
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["random_length"],
+            True,
+        )
+
+        exposed = default.spec.environment_parameters["object_encoding"]
+        self.assertIsInstance(exposed, dict)
+        assert isinstance(exposed, dict)
+        exposed["key"] = 100
+        fresh = default.spec.environment_parameters["object_encoding"]
+        self.assertIsInstance(fresh, dict)
+        assert isinstance(fresh, dict)
+        self.assertEqual(fresh["key"], 5)
+
+    def test_config_rejects_unsupported_or_ambiguous_profiles(self) -> None:
+        with self.assertRaises(ValueError):
+            MemoryConfig(profile="19x19")
+        with self.assertRaises(ValueError):
+            MemoryConfig(profile=13)  # type: ignore[arg-type]
+
+    def test_episode_planning_is_reproducible_and_split_scoped(self) -> None:
+        benchmark = MemoryBenchmark()
+
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        validation = tuple(
+            benchmark.episodes("validation", seed=7, count=10)
+        )
+
+        self.assertEqual(train, repeated)
+        self.assertEqual(len({item.environment_seed for item in train}), 10)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in validation
+            )
+        )
+        self.assertTrue(all(item.scenario is None for item in train))
+
+    def test_environment_is_conformant_and_rejects_invalid_actions(
+        self,
+    ) -> None:
+        benchmark = MemoryBenchmark(MemoryConfig(profile="11x11"))
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 0, 2, 2),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertEqual(
+                set(observation),
+                {"image", "direction", "mission"},
+            )
+            image = observation["image"]
+            self.assertIsInstance(image, TensorValue)
+            assert isinstance(image, TensorValue)
+            self.assertEqual(image.dtype, "uint8")
+            self.assertEqual(image.shape, (7, 7, 3))
+            self.assertEqual(len(image.data), 147)
+            self.assertEqual(observation["direction"], 0)
+        finally:
+            environment.close()
+            environment.close()
+
+        invalid_actions: tuple[PolicyValue, ...] = (
+            -1,
+            7,
+            True,
+            2.0,
+            [2],
+        )
+        for invalid in invalid_actions:
+            environment = benchmark.make_environment(
+                EpisodeSpec(environment_seed=123)
+            )
+            try:
+                environment.reset()
+                with self.assertRaises(InvalidAction):
+                    environment.step(invalid)
+            finally:
+                environment.close()
+
+    def test_episode_scenario_cannot_override_benchmark_configuration(
+        self,
+    ) -> None:
+        benchmark = MemoryBenchmark()
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(
+                    environment_seed=1,
+                    scenario={"profile": "11x11"},
+                )
+            )
+
+    def test_feedback_penalizes_failure_and_keeps_identity_private(self) -> None:
+        benchmark = MemoryBenchmark()
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+
+        feedback = benchmark.feedback((failed,))
+
+        self.assertEqual(feedback.score, 0.0)
+        self.assertEqual(len(feedback.artifacts), 1)
+        trace = feedback.artifacts[0]
+        self.assertEqual(trace.name, "trace.jsonl")
+        self.assertNotIn(b"environment_seed", trace.read_bytes())
+        self.assertNotIn(b"policy_seed", trace.read_bytes())
+        self.assertNotIn(b'"profile"', trace.read_bytes())
+        self.assertIsInstance(feedback.content, dict)
+        assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["policy_failures"], 1)
+        self.assertEqual(feedback.content["successful_episodes"], 0)
+
+    def test_baseline_solves_every_public_profile_and_publishes_trace(
+        self,
+    ) -> None:
+        for profile in (
+            "11x11",
+            "13x13",
+            "13x13-random",
+            "17x17-random",
+        ):
+            with self.subTest(profile=profile):
+                benchmark = MemoryBenchmark(MemoryConfig(profile=profile))
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=4,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+
+                self.assertEqual(
+                    result.benchmark_id,
+                    "minigrid/Memory-v0/success-rate-v1",
+                )
+                self.assertEqual(
+                    result.environment_digest,
+                    benchmark.spec.environment_digest,
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                trace = result.feedback.artifacts[0]
+                documents = tuple(
+                    json.loads(line)
+                    for line in trace.read_bytes().splitlines()
+                )
+                transitions = tuple(
+                    document
+                    for document in documents
+                    if document["type"] == "transition"
+                )
+                self.assertEqual(trace.name, "trace.jsonl")
+                self.assertEqual(
+                    trace.media_type,
+                    "application/x-ndjson",
+                )
+                self.assertTrue(transitions)
+                self.assertTrue(
+                    all(
+                        "grid_rows" in item["next_observation"]
+                        for item in transitions
+                    )
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "go to the matching object at the end of the hallway",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/memory/uv.lock
+++ b/environments/minigrid/minigrid/memory/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-memory"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/multiroom/.gitignore
+++ b/environments/minigrid/minigrid/multiroom/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/multiroom/README.md
+++ b/environments/minigrid/minigrid/multiroom/README.md
@@ -1,0 +1,57 @@
+# MiniGrid MultiRoom Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid MultiRoom](https://minigrid.farama.org/environments/minigrid/MultiRoomEnv/)
+navigation task.
+
+The Policy receives the upstream `7 × 7 × 3` egocentric symbolic image,
+compass direction, and fixed mission. It must discover a chain of rooms, open
+the connecting doors, and reach the green goal in the final room. The primary
+score is Episode success rate.
+
+## Install and test
+
+From the EvoPolicyGym repository root:
+
+```console
+uv sync --project environments/minigrid/minigrid/multiroom --extra dev
+uv run --project environments/minigrid/minigrid/multiroom \
+  python -m unittest discover \
+  -s environments/minigrid/minigrid/multiroom/tests
+uv build environments/minigrid/minigrid/multiroom
+```
+
+## Public API
+
+```python
+from minigrid_multiroom import (
+    MultiRoomBenchmark,
+    MultiRoomConfig,
+    baseline_program,
+)
+
+benchmark = MultiRoomBenchmark(
+    MultiRoomConfig(profile="N6-S10"),
+)
+program = baseline_program()
+```
+
+Available profiles are `N2-S4`, `N4-S5`, `N4-S5-v0-legacy-N6`, and
+`N6-S10`. The legacy profile preserves the upstream registration whose name
+says four rooms but whose configuration actually generates six. A profile is
+Host-selected before a Run and contributes to the environment digest.
+
+Feedback reports success, final-goal discovery, and opened-door counts,
+together with return, step, truncation, and Policy-failure statistics.
+`trace.jsonl` contains a bounded semantic trace for at most four Episodes,
+retaining the first 128 and last 32 transitions of long Episodes. It contains
+no Episode seed, private Case identity, or Host path.
+
+The packaged baseline builds a relative map from public egocentric
+observations, opens reachable doors, and shortest-path plans to the goal. It
+consumes no private environment state.
+
+Tests that use `ProcessExecution.unsafe()` run trusted packaged code only.
+That backend is a local process mechanism, not a sandbox and not suitable for
+hostile Programs.
+

--- a/environments/minigrid/minigrid/multiroom/pyproject.toml
+++ b/environments/minigrid/minigrid/multiroom/pyproject.toml
@@ -1,0 +1,69 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-multiroom"
+version = "0.1.0"
+description = "The MiniGrid MultiRoom Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = [
+    "mypy==2.3.0",
+    "ruff>=0.12.0",
+]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_multiroom"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/README.md",
+    "/pyproject.toml",
+    "/src",
+    "/tests",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/__init__.py
+++ b/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/__init__.py
@@ -1,0 +1,12 @@
+"""The public MiniGrid MultiRoom Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import MultiRoomBenchmark
+from .config import MultiRoomConfig
+
+__all__ = [
+    "MultiRoomBenchmark",
+    "MultiRoomConfig",
+    "baseline_program",
+]
+

--- a/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/baseline.py
+++ b/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid MultiRoom development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_multiroom").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/benchmark.py
+++ b/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/benchmark.py
@@ -1,0 +1,441 @@
+"""MiniGrid MultiRoom with deterministic plans and milestone traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import MultiRoomConfig
+from .environment import MultiRoomEnvironment
+
+_EPISODE_SEED_DOMAIN = b"evopolicygym-minigrid-multiroom/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_MISSION = "traverse the rooms to get to the goal"
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+
+
+class MultiRoomBenchmark:
+    """Success rate on a partially observable connected-room task."""
+
+    def __init__(self, config: MultiRoomConfig | None = None) -> None:
+        if config is None:
+            config = MultiRoomConfig()
+        if type(config) is not MultiRoomConfig:
+            raise TypeError("config must be MultiRoomConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return MultiRoomEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        found_goals = sum(
+            _reached_bool_milestone(record, "goal_found")
+            for record in records
+        )
+        opened_doors = tuple(_opened_doors(record) for record in records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        mean_success_steps: PolicyValue = (
+            statistics.fmean(record.steps for record in successful)
+            if successful
+            else None
+        )
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Reached the final room goal in {successes}/"
+                    f"{len(records)} Episodes ({score:.3f} success rate), "
+                    f"opening {sum(opened_doors)} doors in total."
+                ),
+                "success_rate": score,
+                "goal_found_rate": found_goals / len(records),
+                "mean_opened_doors": statistics.fmean(opened_doors),
+                "mean_return": mean_return,
+                "mean_steps": mean_steps,
+                "mean_steps_on_success": mean_success_steps,
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "goal_found_episodes": found_goals,
+                "opened_doors": sum(opened_doors),
+                "truncated_episodes": truncations,
+                "policy_failures": failures,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+                "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+                "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+            },
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: MultiRoomConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/MultiRoom-v0/success-rate-v1",
+        description=(
+            "Explore a chain of partially observable rooms, open successive "
+            "doors, and reach the green goal in the final room. Maximize "
+            "success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "meaning": {
+                        "0": "east",
+                        "1": "south",
+                        "2": "west",
+                        "3": "north",
+                    },
+                },
+                "mission": {
+                    "type": "string",
+                    "constant": _MISSION,
+                },
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "minimum_rooms": config.minimum_rooms,
+            "maximum_rooms": config.maximum_rooms,
+            "maximum_room_size": config.maximum_room_size,
+            "grid_width": 25,
+            "grid_height": 25,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": _MISSION,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for reaching the final goal; "
+                "zero for timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _reached_bool_milestone(record: EpisodeRecord, name: str) -> bool:
+    for transition in record.transitions:
+        metrics = transition.step.metrics
+        if type(metrics) is dict and metrics.get(name) is True:
+            return True
+    return False
+
+
+def _opened_doors(record: EpisodeRecord) -> int:
+    maximum = 0
+    for transition in record.transitions:
+        metrics = transition.step.metrics
+        if type(metrics) is dict:
+            value = metrics.get("opened_doors")
+            if type(value) is int and value >= maximum:
+                maximum = value
+    return maximum
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "opened_doors": _opened_doors(record),
+                    "goal_found": _reached_bool_milestone(
+                        record,
+                        "goal_found",
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError("MiniGrid MultiRoom trace Action is invalid")
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if type(metrics) is not dict or set(metrics) != {
+        "opened_doors",
+        "goal_found",
+        "success",
+    }:
+        raise ValueError("MiniGrid MultiRoom trace metrics are invalid")
+    opened_doors = metrics["opened_doors"]
+    if (
+        type(opened_doors) is not int
+        or opened_doors < 0
+        or type(metrics["goal_found"]) is not bool
+        or type(metrics["success"]) is not bool
+    ):
+        raise ValueError("MiniGrid MultiRoom trace metrics are invalid")
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError("MiniGrid MultiRoom trace observation is invalid")
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("MiniGrid MultiRoom trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("MiniGrid MultiRoom trace direction is invalid")
+    if type(mission) is not str or mission != _MISSION:
+        raise ValueError("MiniGrid MultiRoom trace mission is invalid")
+
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError(
+                    "MiniGrid MultiRoom trace image codes are invalid"
+                )
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["MultiRoomBenchmark"]

--- a/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/config.py
+++ b/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/config.py
@@ -1,0 +1,63 @@
+"""Typed, public MiniGrid MultiRoom environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int, int, int]] = {
+    "N2-S4": ("MiniGrid-MultiRoom-N2-S4-v0", 2, 2, 4),
+    "N4-S5": ("MiniGrid-MultiRoom-N4-S5-v1", 4, 4, 5),
+    "N4-S5-v0-legacy-N6": (
+        "MiniGrid-MultiRoom-N4-S5-v0",
+        6,
+        6,
+        5,
+    ),
+    "N6-S10": ("MiniGrid-MultiRoom-N6-v0", 6, 6, 10),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class MultiRoomConfig:
+    """Parameters that define one MiniGrid MultiRoom Benchmark identity."""
+
+    profile: str = "N6-S10"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        """Return the upstream Gymnasium registration."""
+
+        return _PROFILES[self.profile][0]
+
+    @property
+    def minimum_rooms(self) -> int:
+        """Return the minimum generated room count."""
+
+        return _PROFILES[self.profile][1]
+
+    @property
+    def maximum_rooms(self) -> int:
+        """Return the maximum generated room count."""
+
+        return _PROFILES[self.profile][2]
+
+    @property
+    def maximum_room_size(self) -> int:
+        """Return the upstream maximum room dimension."""
+
+        return _PROFILES[self.profile][3]
+
+    @property
+    def max_episode_steps(self) -> int:
+        """Return the upstream horizon."""
+
+        return self.maximum_rooms * 20
+
+
+__all__ = ["MultiRoomConfig"]
+

--- a/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/environment.py
+++ b/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/environment.py
@@ -1,0 +1,188 @@
+"""One fresh MiniGrid MultiRoom Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401  # Import registers MiniGrid environments.
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import MultiRoomConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_MISSION = "traverse the rooms to get to the goal"
+_DOOR = 4
+_GOAL = 8
+_CLOSED = 1
+
+
+@dataclass(frozen=True, slots=True)
+class _ObservationFacts:
+    goal_visible: bool
+    front_closed_door: bool
+
+
+class MultiRoomEnvironment:
+    """The seeded strict adapter around configured MiniGrid MultiRoom."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: MultiRoomConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not MultiRoomConfig:
+            raise TypeError("config must be MultiRoomConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "MultiRoom configuration belongs in MultiRoomConfig, "
+                "not EpisodeSpec.scenario"
+            )
+
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._front_closed_door = False
+        self._goal_found = False
+        self._opened_doors = 0
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._front_closed_door = facts.front_closed_door
+        self._goal_found = facts.goal_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+
+        opened_door = bool(action == 5 and self._front_closed_door)
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError(
+                "MiniGrid MultiRoom returned invalid termination flags"
+            )
+        number = _number(reward, name="reward")
+        public, facts = _observation(observation)
+        self._front_closed_door = facts.front_closed_door
+        self._goal_found = self._goal_found or facts.goal_visible
+        if opened_door:
+            self._opened_doors += 1
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "opened_doors": self._opened_doors,
+                "goal_found": self._goal_found,
+                "success": bool(terminated and number > 0.0),
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(
+    value: object,
+) -> tuple[dict[str, PolicyValue], _ObservationFacts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid MultiRoom returned an invalid observation")
+
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid MultiRoom returned an invalid image")
+    if (
+        numpy.any(image[:, :, 0] > 10)
+        or numpy.any(image[:, :, 1] > 5)
+        or numpy.any(image[:, :, 2] > 2)
+    ):
+        raise RuntimeError(
+            "MiniGrid MultiRoom returned out-of-range image codes"
+        )
+
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid MultiRoom returned an invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid MultiRoom returned an invalid direction")
+
+    mission = value["mission"]
+    if type(mission) is not str or mission != _MISSION:
+        raise RuntimeError("MiniGrid MultiRoom returned an invalid mission")
+
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _ObservationFacts(
+            goal_visible=bool(numpy.any(image[:, :, 0] == _GOAL)),
+            front_closed_door=bool(
+                image[3, 5, 0] == _DOOR and image[3, 5, 2] == _CLOSED
+            ),
+        ),
+    )
+
+
+def _number(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(f"MiniGrid MultiRoom returned an invalid {name}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(
+            f"MiniGrid MultiRoom returned a non-finite {name}"
+        )
+    return number
+
+
+__all__ = ["MultiRoomEnvironment"]

--- a/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/programs/baseline/policy.py
@@ -1,0 +1,379 @@
+"""A public-observation mapping and planning MultiRoom baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_TOGGLE = 5
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Map rooms, open doors, and shortest-path plan to the goal."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (self._objects["empty"], self._states["open"])
+        }
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+        self._integrate(image, direction)
+
+        goal = self._known_object("goal")
+        if goal is not None:
+            action = self._navigate(goal, direction)
+            if action is not None:
+                return action
+
+        door = self._nearest_closed_door()
+        if door is not None:
+            return self._interact(door, direction)
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        return image, direction
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, _, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (object_code, state_code)
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> tuple[int, int, int]:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_object(self, name: str) -> Position | None:
+        code = self._objects[name]
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == code
+            ),
+            None,
+        )
+
+    def _nearest_closed_door(self) -> Position | None:
+        candidates: list[tuple[int, Position]] = []
+        for position, cell in self._grid.items():
+            if (
+                cell[0] != self._objects["door"]
+                or cell[1] != self._states["closed"]
+            ):
+                continue
+            approach = self._best_approach(position)
+            if approach is not None:
+                candidates.append((len(approach[1]), position))
+        if not candidates:
+            return None
+        return min(candidates, key=lambda item: (item[0], item[1]))[1]
+
+    def _interact(self, target: Position, direction: int) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+
+        target_direction = _direction_between(approach_position, target)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._grid[target] = (
+            self._objects["door"],
+            self._states["open"],
+        )
+        return _TOGGLE
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if not frontiers:
+            return _RIGHT
+
+        _, frontier, frontier_direction = min(
+            frontiers,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+
+        turn = _turn_toward(direction, frontier_direction)
+        if turn is not None:
+            return turn
+        return _RIGHT
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        if cell is None:
+            return False
+        object_code, state_code = cell
+        return bool(
+            object_code
+            in {
+                self._objects["empty"],
+                self._objects["floor"],
+                self._objects["goal"],
+            }
+            or (
+                object_code == self._objects["door"]
+                and state_code == self._states["open"]
+            )
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/multiroom/tests/test_multiroom.py
+++ b/environments/minigrid/minigrid/multiroom/tests/test_multiroom.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_multiroom import (
+    MultiRoomBenchmark,
+    MultiRoomConfig,
+    baseline_program,
+)
+
+
+class MultiRoomBenchmarkTests(unittest.TestCase):
+    def test_config_profiles_define_distinct_environment_identity(self) -> None:
+        default = MultiRoomBenchmark()
+        small = MultiRoomBenchmark(MultiRoomConfig(profile="N2-S4"))
+        fixed = MultiRoomBenchmark(MultiRoomConfig(profile="N4-S5"))
+        legacy = MultiRoomBenchmark(
+            MultiRoomConfig(profile="N4-S5-v0-legacy-N6")
+        )
+
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/MultiRoom-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 120)
+        self.assertEqual(small.spec.max_episode_steps, 40)
+        self.assertEqual(fixed.spec.max_episode_steps, 80)
+        self.assertEqual(legacy.spec.max_episode_steps, 120)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            small.spec.environment_digest,
+        )
+        self.assertNotEqual(
+            fixed.spec.environment_digest,
+            legacy.spec.environment_digest,
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["profile"],
+            "N6-S10",
+        )
+        self.assertEqual(
+            legacy.spec.environment_parameters["maximum_rooms"],
+            6,
+        )
+
+    def test_config_rejects_unsupported_or_ambiguous_profiles(self) -> None:
+        with self.assertRaises(ValueError):
+            MultiRoomConfig(profile="N4-S5-v0")
+        with self.assertRaises(ValueError):
+            MultiRoomConfig(profile=6)  # type: ignore[arg-type]
+
+    def test_episode_planning_is_reproducible_and_split_scoped(self) -> None:
+        benchmark = MultiRoomBenchmark()
+
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        validation = tuple(
+            benchmark.episodes("validation", seed=7, count=10)
+        )
+
+        self.assertEqual(train, repeated)
+        self.assertEqual(len({item.environment_seed for item in train}), 10)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in validation
+            )
+        )
+        self.assertTrue(all(item.scenario is None for item in train))
+
+    def test_environment_is_conformant_and_rejects_invalid_actions(
+        self,
+    ) -> None:
+        benchmark = MultiRoomBenchmark(MultiRoomConfig(profile="N2-S4"))
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 5, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertEqual(
+                set(observation),
+                {"image", "direction", "mission"},
+            )
+            image = observation["image"]
+            self.assertIsInstance(image, TensorValue)
+            assert isinstance(image, TensorValue)
+            self.assertEqual(image.dtype, "uint8")
+            self.assertEqual(image.shape, (7, 7, 3))
+            self.assertEqual(len(image.data), 147)
+            self.assertEqual(
+                observation["mission"],
+                "traverse the rooms to get to the goal",
+            )
+        finally:
+            environment.close()
+            environment.close()
+
+        invalid_actions: tuple[PolicyValue, ...] = (
+            -1,
+            7,
+            True,
+            2.0,
+            [2],
+        )
+        for invalid in invalid_actions:
+            environment = benchmark.make_environment(
+                EpisodeSpec(environment_seed=123)
+            )
+            try:
+                environment.reset()
+                with self.assertRaises(InvalidAction):
+                    environment.step(invalid)
+            finally:
+                environment.close()
+
+    def test_episode_scenario_cannot_override_benchmark_configuration(
+        self,
+    ) -> None:
+        benchmark = MultiRoomBenchmark()
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(
+                    environment_seed=1,
+                    scenario={"profile": "N2-S4"},
+                )
+            )
+
+    def test_feedback_penalizes_failure_and_keeps_identity_private(self) -> None:
+        benchmark = MultiRoomBenchmark()
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+
+        feedback = benchmark.feedback((failed,))
+
+        self.assertEqual(feedback.score, 0.0)
+        self.assertEqual(len(feedback.artifacts), 1)
+        trace = feedback.artifacts[0]
+        self.assertEqual(trace.name, "trace.jsonl")
+        self.assertNotIn(b"environment_seed", trace.read_bytes())
+        self.assertNotIn(b"policy_seed", trace.read_bytes())
+        self.assertNotIn(b'"profile"', trace.read_bytes())
+        self.assertIsInstance(feedback.content, dict)
+        assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["policy_failures"], 1)
+        self.assertEqual(feedback.content["goal_found_episodes"], 0)
+        self.assertEqual(feedback.content["opened_doors"], 0)
+
+    def test_baseline_solves_every_public_profile_and_publishes_trace(
+        self,
+    ) -> None:
+        profiles = (
+            "N2-S4",
+            "N4-S5",
+            "N4-S5-v0-legacy-N6",
+            "N6-S10",
+        )
+        for profile in profiles:
+            with self.subTest(profile=profile):
+                benchmark = MultiRoomBenchmark(
+                    MultiRoomConfig(profile=profile)
+                )
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=6,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+
+                self.assertEqual(
+                    result.benchmark_id,
+                    "minigrid/MultiRoom-v0/success-rate-v1",
+                )
+                self.assertEqual(
+                    result.environment_digest,
+                    benchmark.spec.environment_digest,
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["goal_found_rate"],
+                    1.0,
+                )
+                trace = result.feedback.artifacts[0]
+                documents = tuple(
+                    json.loads(line)
+                    for line in trace.read_bytes().splitlines()
+                )
+                transitions = tuple(
+                    document
+                    for document in documents
+                    if document["type"] == "transition"
+                )
+                self.assertEqual(trace.name, "trace.jsonl")
+                self.assertEqual(
+                    trace.media_type,
+                    "application/x-ndjson",
+                )
+                self.assertTrue(transitions)
+                self.assertTrue(
+                    all(
+                        "visible_objects" in item["next_observation"]
+                        for item in transitions
+                    )
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "traverse the rooms to get to the goal",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/multiroom/uv.lock
+++ b/environments/minigrid/minigrid/multiroom/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-multiroom"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/obstructed_maze/.gitignore
+++ b/environments/minigrid/minigrid/obstructed_maze/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/obstructed_maze/README.md
+++ b/environments/minigrid/minigrid/obstructed_maze/README.md
@@ -1,0 +1,32 @@
+# MiniGrid ObstructedMaze Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid ObstructedMaze](https://minigrid.farama.org/environments/minigrid/ObstructedMazeEnv/)
+long-horizon manipulation task.
+
+The Policy must open boxes containing keys, move balls obstructing locked
+doors, unlock the selected maze, and pick up the blue mission ball.
+Feedback and the bounded semantic `trace.jsonl` expose the public progress
+ladder without publishing Episode seeds, private identity, or Host paths.
+
+```python
+from minigrid_obstructed_maze import (
+    ObstructedMazeBenchmark,
+    ObstructedMazeConfig,
+    baseline_program,
+)
+
+benchmark = ObstructedMazeBenchmark(
+    ObstructedMazeConfig(profile="Full-v1")
+)
+program = baseline_program()
+```
+
+The packaged baseline builds a relative map from Policy-visible observations
+and implements the complete object-moving and unlocking state machine. Tests
+using `ProcessExecution.unsafe()` execute trusted packaged code only; that
+backend is not a sandbox.
+
+All 13 upstream registrations are profiles, from `1Dl-v0` through `Full-v1`.
+The Host selects one profile before the Run; the profile is visible to the
+Agent, fixed for the Run, and included in the environment digest.

--- a/environments/minigrid/minigrid/obstructed_maze/pyproject.toml
+++ b/environments/minigrid/minigrid/obstructed_maze/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-obstructed-maze"
+version = "0.1.0"
+description = "The MiniGrid ObstructedMaze Benchmark for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_obstructed_maze"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/__init__.py
+++ b/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/__init__.py
@@ -1,0 +1,11 @@
+"""The public ObstructedMaze Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import ObstructedMazeBenchmark
+from .config import ObstructedMazeConfig
+
+__all__ = [
+    "ObstructedMazeBenchmark",
+    "ObstructedMazeConfig",
+    "baseline_program",
+]

--- a/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/baseline.py
+++ b/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/baseline.py
@@ -1,0 +1,22 @@
+"""Packaged initial Program for ObstructedMaze Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_obstructed_maze").joinpath(
+        "programs",
+        "baseline",
+    )
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/benchmark.py
+++ b/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/benchmark.py
@@ -1,0 +1,425 @@
+"""ObstructedMaze with deterministic plans and milestone traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import ObstructedMazeConfig
+from .environment import ObstructedMazeEnvironment
+
+_EPISODE_SEED_DOMAIN = (
+    b"evopolicygym-minigrid-obstructed-maze/episode-seed/v1\0"
+)
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_MISSION = "pick up the blue ball"
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRIC_FIELDS = {
+    "blocker_found",
+    "blocker_moved",
+    "key_found",
+    "key_picked_up",
+    "door_opened",
+    "target_found",
+    "success",
+}
+
+
+class ObstructedMazeBenchmark:
+    """Success rate for the complete blocked-door manipulation chain."""
+
+    def __init__(
+        self,
+        config: ObstructedMazeConfig | None = None,
+    ) -> None:
+        if config is None:
+            config = ObstructedMazeConfig()
+        if type(config) is not ObstructedMazeConfig:
+            raise TypeError("config must be ObstructedMazeConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return ObstructedMazeEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        counts = {
+            name: _milestone_count(records, name)
+            for name in _METRIC_FIELDS - {"success"}
+        }
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        content: dict[str, PolicyValue] = {
+            "summary": (
+                f"Moved the blocker, unlocked the room, and collected the "
+                f"target in {successes}/{len(records)} Episodes "
+                f"({score:.3f} success rate)."
+            ),
+            "success_rate": score,
+            "mean_return": mean_return,
+            "mean_steps": mean_steps,
+            "mean_steps_on_success": (
+                statistics.fmean(record.steps for record in successful)
+                if successful
+                else None
+            ),
+            "episodes": len(records),
+            "successful_episodes": successes,
+            "truncated_episodes": truncations,
+            "policy_failures": failures,
+            "traced_episodes": len(traced),
+            "trace_episodes_omitted": len(records) - len(traced),
+            "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+            "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+        }
+        for name, value in counts.items():
+            content[f"{name}_episodes"] = value
+            content[f"{name}_rate"] = value / len(records)
+        return Feedback(
+            score=score,
+            content=content,
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: ObstructedMazeConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/ObstructedMaze-v0/success-rate-v1",
+        description=(
+            "Open boxes containing keys, move balls obstructing doors, "
+            "unlock the selected maze, and pick up the blue target ball."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "constant": _MISSION},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "room_size": 6,
+            "num_rows": config.rows,
+            "num_columns": config.columns,
+            "key_in_box": config.key_in_box,
+            "blocked": config.blocked,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": _MISSION,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for picking up the target ball; "
+                "zero for timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _milestone_count(
+    records: Sequence[EpisodeRecord],
+    name: str,
+) -> int:
+    return sum(
+        any(
+            type(transition.step.metrics) is dict
+            and transition.step.metrics.get(name) is True
+            for transition in record.transitions
+        )
+        for record in records
+    )
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError(
+                    "ObstructedMaze trace Action is invalid"
+                )
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if (
+        type(metrics) is not dict
+        or set(metrics) != _METRIC_FIELDS
+        or any(type(value) is not bool for value in metrics.values())
+    ):
+        raise ValueError("ObstructedMaze trace metrics are invalid")
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError("ObstructedMaze trace observation is invalid")
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("ObstructedMaze trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("ObstructedMaze trace direction is invalid")
+    if type(mission) is not str or mission != _MISSION:
+        raise ValueError("ObstructedMaze trace mission is invalid")
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError(
+                    "ObstructedMaze trace image codes are invalid"
+                )
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["ObstructedMazeBenchmark"]

--- a/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/config.py
+++ b/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/config.py
@@ -1,0 +1,66 @@
+"""Typed, public MiniGrid ObstructedMaze configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+type Profile = tuple[str, int, int, int, bool, bool]
+
+_PROFILES: dict[str, Profile] = {
+    "1Dl-v0": ("MiniGrid-ObstructedMaze-1Dl-v0", 1, 2, 2, False, False),
+    "1Dlh-v0": ("MiniGrid-ObstructedMaze-1Dlh-v0", 1, 2, 2, True, False),
+    "1Dlhb-v0": ("MiniGrid-ObstructedMaze-1Dlhb-v0", 1, 2, 2, True, True),
+    "2Dl-v0": ("MiniGrid-ObstructedMaze-2Dl-v0", 3, 3, 4, False, False),
+    "2Dlh-v0": ("MiniGrid-ObstructedMaze-2Dlh-v0", 3, 3, 4, True, False),
+    "2Dlhb-v0": ("MiniGrid-ObstructedMaze-2Dlhb-v0", 3, 3, 4, True, True),
+    "2Dlhb-v1": ("MiniGrid-ObstructedMaze-2Dlhb-v1", 3, 3, 4, True, True),
+    "1Q-v0": ("MiniGrid-ObstructedMaze-1Q-v0", 3, 3, 5, True, True),
+    "1Q-v1": ("MiniGrid-ObstructedMaze-1Q-v1", 3, 3, 5, True, True),
+    "2Q-v0": ("MiniGrid-ObstructedMaze-2Q-v0", 3, 3, 11, True, True),
+    "2Q-v1": ("MiniGrid-ObstructedMaze-2Q-v1", 3, 3, 11, True, True),
+    "Full-v0": ("MiniGrid-ObstructedMaze-Full-v0", 3, 3, 25, True, True),
+    "Full-v1": ("MiniGrid-ObstructedMaze-Full-v1", 3, 3, 25, True, True),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ObstructedMazeConfig:
+    """Parameters defining one ObstructedMaze Benchmark identity."""
+
+    profile: str = "1Dlhb-v0"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        return _PROFILES[self.profile][0]
+
+    @property
+    def rows(self) -> int:
+        return _PROFILES[self.profile][1]
+
+    @property
+    def columns(self) -> int:
+        return _PROFILES[self.profile][2]
+
+    @property
+    def horizon_rooms(self) -> int:
+        return _PROFILES[self.profile][3]
+
+    @property
+    def key_in_box(self) -> bool:
+        return _PROFILES[self.profile][4]
+
+    @property
+    def blocked(self) -> bool:
+        return _PROFILES[self.profile][5]
+
+    @property
+    def max_episode_steps(self) -> int:
+        return 4 * self.horizon_rooms * 6**2
+
+
+__all__ = ["ObstructedMazeConfig"]

--- a/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/environment.py
+++ b/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/environment.py
@@ -1,0 +1,270 @@
+"""One fresh ObstructedMaze Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import ObstructedMazeConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_DOOR = 4
+_KEY = 5
+_BALL = 6
+_BOX = 7
+_LOCKED = 2
+
+
+@dataclass(frozen=True, slots=True)
+class _Facts:
+    target: tuple[int, int]
+    carried: tuple[int, int] | None
+    key_visible: bool
+    blocker_visible: bool
+    target_visible: bool
+    front_object: int
+    front_locked_door_color: int | None
+
+
+class ObstructedMazeEnvironment:
+    """Strict seeded adapter around the upstream environment."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: ObstructedMazeConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not ObstructedMazeConfig:
+            raise TypeError("config must be ObstructedMazeConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "ObstructedMaze configuration belongs in "
+                "ObstructedMazeConfig"
+            )
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._target: tuple[int, int] | None = None
+        self._front_object = 0
+        self._front_locked_door_color: int | None = None
+        self._carried: tuple[int, int] | None = None
+        self._key_found = False
+        self._blocker_found = False
+        self._target_found = False
+        self._blocker_moved = False
+        self._key_picked_up = False
+        self._door_opened = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._target = facts.target
+        self._update(facts)
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        moved_blocker = bool(
+            action == 3
+            and self._carried is None
+            and self._front_object_is_blocker()
+        )
+        picked_key = bool(
+            action == 3
+            and self._carried is None
+            and self._front_object_is_key()
+        )
+        opened_door = bool(
+            action == 5
+            and self._front_locked_door_color is not None
+            and self._carried
+            == (_KEY, self._front_locked_door_color)
+        )
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError(
+                "MiniGrid ObstructedMaze returned invalid flags"
+            )
+        number = _number(reward)
+        public, facts = _observation(observation)
+        if facts.target != self._target:
+            raise RuntimeError(
+                "MiniGrid ObstructedMaze changed its mission"
+            )
+        self._blocker_moved = self._blocker_moved or moved_blocker
+        self._key_picked_up = self._key_picked_up or picked_key
+        self._door_opened = self._door_opened or opened_door
+        self._update(facts)
+        success = bool(terminated and number > 0.0)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "blocker_found": self._blocker_found,
+                "blocker_moved": self._blocker_moved,
+                "key_found": self._key_found,
+                "key_picked_up": self._key_picked_up,
+                "door_opened": self._door_opened,
+                "target_found": self._target_found,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+    def _update(self, facts: _Facts) -> None:
+        self._carried = facts.carried
+        self._front_object = facts.front_object
+        self._front_locked_door_color = facts.front_locked_door_color
+        self._key_found = self._key_found or facts.key_visible
+        self._blocker_found = self._blocker_found or facts.blocker_visible
+        self._target_found = self._target_found or facts.target_visible
+
+    def _front_object_is_blocker(self) -> bool:
+        return self._front_object == _BALL
+
+    def _front_object_is_key(self) -> bool:
+        return self._front_object == _KEY
+
+
+def _observation(value: object) -> tuple[dict[str, PolicyValue], _Facts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError(
+            "MiniGrid ObstructedMaze returned invalid observation"
+        )
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError(
+            "MiniGrid ObstructedMaze returned invalid image"
+        )
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid ObstructedMaze returned invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError(
+            "MiniGrid ObstructedMaze returned invalid direction"
+        )
+    mission = value["mission"]
+    if type(mission) is not str:
+        raise RuntimeError(
+            "MiniGrid ObstructedMaze returned invalid mission"
+        )
+    target = _target(mission)
+    carried_code = int(image[3, 6, 0])
+    carried = (
+        (carried_code, int(image[3, 6, 1]))
+        if carried_code in {_KEY, _BALL, _BOX}
+        else None
+    )
+    front_locked_door_color = (
+        int(image[3, 5, 1])
+        if image[3, 5, 0] == _DOOR
+        and image[3, 5, 2] == _LOCKED
+        else None
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _Facts(
+            target=target,
+            carried=carried,
+            key_visible=bool(numpy.any(image[:, :, 0] == _KEY)),
+            blocker_visible=bool(numpy.any(image[:, :, 0] == _BALL)),
+            target_visible=bool(
+                numpy.any(
+                    (image[:, :, 0] == target[0])
+                    & (image[:, :, 1] == target[1])
+                )
+            ),
+            front_object=int(image[3, 5, 0]),
+            front_locked_door_color=front_locked_door_color,
+        ),
+    )
+
+
+def _target(mission: str) -> tuple[int, int]:
+    prefix = "pick up the "
+    if not mission.startswith(prefix):
+        raise RuntimeError(
+            "MiniGrid ObstructedMaze returned invalid mission"
+        )
+    parts = mission.removeprefix(prefix).split(" ")
+    kinds = {"ball": _BALL}
+    if len(parts) != 2 or parts[0] not in _COLORS or parts[1] not in kinds:
+        raise RuntimeError(
+            "MiniGrid ObstructedMaze returned invalid mission"
+        )
+    return kinds[parts[1]], _COLORS.index(parts[0])
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(
+            "MiniGrid ObstructedMaze returned invalid reward"
+        )
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(
+            "MiniGrid ObstructedMaze returned non-finite reward"
+        )
+    return number
+
+
+__all__ = ["ObstructedMazeEnvironment"]

--- a/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/programs/baseline/policy.py
@@ -1,0 +1,664 @@
+"""A public-observation planner for ObstructedMaze."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_PICKUP = 3
+_DROP = 4
+_TOGGLE = 5
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Open key boxes, move blockers, unlock doors, and collect the ball."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._target: tuple[int, int] | None = None
+        self._carried: tuple[int, int] | None = None
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction, mission = self._read_observation(observation)
+        target = self._read_target(mission)
+        if self._target is None:
+            self._target = target
+        elif self._target != target:
+            raise ValueError("mission changed during the Episode")
+        self._integrate(image, direction)
+
+        if self._carried is not None:
+            carried_type, carried_color = self._carried
+            if carried_type == self._objects["key"]:
+                door = self._known_door(
+                    color=carried_color,
+                    state=self._states["locked"],
+                    approachable=True,
+                )
+                if door is not None:
+                    return self._interact(
+                        door,
+                        action=_TOGGLE,
+                        direction=direction,
+                    )
+                closed = self._known_door(
+                    state=self._states["closed"],
+                    approachable=True,
+                )
+                if closed is not None:
+                    return self._interact(
+                        closed,
+                        action=_TOGGLE,
+                        direction=direction,
+                    )
+                if self._has_frontier():
+                    return self._explore(direction)
+            return self._drop_safely(direction)
+
+        target_position = self._known_matching(target)
+        if (
+            target_position is not None
+            and self._best_approach(target_position) is not None
+        ):
+            return self._interact(
+                target_position,
+                action=_PICKUP,
+                direction=direction,
+            )
+
+        locked_door = self._known_pending_locked_door()
+        if locked_door is not None:
+            blocker = self._door_blocker(locked_door)
+            if blocker is not None:
+                return self._interact(
+                    blocker,
+                    action=_PICKUP,
+                    direction=direction,
+                )
+            door_color = self._grid[locked_door][1]
+            key = self._known_matching(
+                (self._objects["key"], door_color)
+            )
+            if key is not None:
+                return self._interact(
+                    key,
+                    action=_PICKUP,
+                    direction=direction,
+                )
+            box = self._known_object(self._objects["box"])
+            if box is not None:
+                return self._interact(
+                    box,
+                    action=_TOGGLE,
+                    direction=direction,
+                )
+        closed_door = self._known_door(
+            state=self._states["closed"],
+            approachable=True,
+        )
+        if closed_door is not None:
+            return self._interact(
+                closed_door,
+                action=_TOGGLE,
+                direction=direction,
+            )
+        box = self._known_object(self._objects["box"])
+        if box is not None:
+            return self._interact(
+                box,
+                action=_TOGGLE,
+                direction=direction,
+            )
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int, str]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        mission = observation["mission"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        if type(mission) is not str:
+            raise ValueError("observation mission is invalid")
+        return image, direction, mission
+
+    def _read_target(self, mission: str) -> tuple[int, int]:
+        prefix = "pick up the "
+        if not mission.startswith(prefix):
+            raise ValueError("observation mission is invalid")
+        parts = mission.removeprefix(prefix).split(" ")
+        if (
+            len(parts) != 2
+            or parts[0] not in self._colors
+            or parts[1] != "ball"
+        ):
+            raise ValueError("observation mission is invalid")
+        return self._objects[parts[1]], self._colors[parts[0]]
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+        carried_types = {
+            self._objects["key"],
+            self._objects["ball"],
+            self._objects["box"],
+        }
+        self._carried = None
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    if object_code in carried_types:
+                        self._carried = (object_code, color_code)
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_matching(
+        self,
+        target: tuple[int, int],
+    ) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[:2] == target
+            ),
+            None,
+        )
+
+    def _known_object(self, object_code: int) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == object_code
+                and self._best_approach(position) is not None
+            ),
+            None,
+        )
+
+    def _known_door(
+        self,
+        *,
+        color: int | None = None,
+        state: int | None = None,
+        approachable: bool = False,
+    ) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == self._objects["door"]
+                and (color is None or cell[1] == color)
+                and (state is None or cell[2] == state)
+                and (
+                    not approachable
+                    or self._best_approach(position) is not None
+                )
+            ),
+            None,
+        )
+
+    def _known_pending_locked_door(self) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == self._objects["door"]
+                and cell[2] == self._states["locked"]
+                and (
+                    self._best_approach(position) is not None
+                    or self._door_blocker(position) is not None
+                    or self._matching_key_blocks_door(position) is not None
+                )
+            ),
+            None,
+        )
+
+    def _matching_key_blocks_door(
+        self,
+        door: Position,
+    ) -> Position | None:
+        color = self._grid[door][1]
+        return next(
+            (
+                position
+                for _, position in _neighbors(door)
+                if (cell := self._grid.get(position)) is not None
+                if cell[:2] == (self._objects["key"], color)
+                and self._best_approach(position) is not None
+            ),
+            None,
+        )
+
+    def _door_blocker(self, door: Position) -> Position | None:
+        for _, neighbor in _neighbors(door):
+            cell = self._grid.get(neighbor)
+            if (
+                cell is not None
+                and cell[0] == self._objects["ball"]
+                and self._best_approach(neighbor) is not None
+            ):
+                return neighbor
+        return None
+
+    def _interact(
+        self,
+        target: Position,
+        *,
+        action: int,
+        direction: int,
+    ) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+        target_direction = _direction_between(approach_position, target)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        if action == _PICKUP:
+            cell = self._grid[target]
+            self._carried = (cell[0], cell[1])
+            self._grid[target] = (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        elif (
+            action == _TOGGLE
+            and self._grid[target][0] == self._objects["door"]
+        ):
+            cell = self._grid[target]
+            self._grid[target] = (
+                self._objects["door"],
+                cell[1],
+                self._states["open"],
+            )
+        elif action == _TOGGLE:
+            del self._grid[target]
+        return action
+
+    def _drop_safely(self, direction: int) -> int:
+        plan = self._best_drop_plan(prefer_away_from_doors=True)
+        if plan is None:
+            plan = self._best_drop_plan(prefer_away_from_doors=False)
+        if plan is None:
+            return self._explore(direction)
+        approach, drop_position, path = plan
+        if path:
+            return self._follow(path, direction)
+        drop_direction = _direction_between(approach, drop_position)
+        turn = _turn_toward(direction, drop_direction)
+        if turn is not None:
+            return turn
+        if self._carried is None:
+            raise ValueError("carried object disappeared")
+        self._grid[drop_position] = (
+            self._carried[0],
+            self._carried[1],
+            self._states["open"],
+        )
+        self._carried = None
+        return _DROP
+
+    def _best_drop_plan(
+        self,
+        *,
+        prefer_away_from_doors: bool,
+    ) -> tuple[Position, Position, tuple[Position, ...]] | None:
+        doors = tuple(
+            position
+            for position, cell in self._grid.items()
+            if cell[0] == self._objects["door"]
+        )
+        candidates: list[
+            tuple[int, Position, Position, tuple[Position, ...]]
+        ] = []
+        for drop_position, cell in self._grid.items():
+            if cell[0] not in {
+                self._objects["empty"],
+                self._objects["floor"],
+            }:
+                continue
+            if prefer_away_from_doors and any(
+                max(
+                    abs(drop_position[0] - door[0]),
+                    abs(drop_position[1] - door[1]),
+                )
+                <= 1
+                for door in doors
+            ):
+                continue
+            for _, approach in _neighbors(drop_position):
+                if not self._traversable(approach):
+                    continue
+                path = self._shortest_path(approach)
+                if path is not None:
+                    candidates.append(
+                        (
+                            len(path),
+                            approach,
+                            drop_position,
+                            path,
+                        )
+                    )
+        if not candidates:
+            return None
+        _, approach, drop_position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        return approach, drop_position, path
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(
+            frontiers,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        if turn is not None:
+            return turn
+        return _RIGHT
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _has_frontier(self) -> bool:
+        return any(
+            neighbor not in self._grid
+            for position in self._reachable_distances()
+            for _, neighbor in _neighbors(position)
+        )
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        if cell is None:
+            return False
+        return bool(
+            cell[0]
+            in {
+                self._objects["empty"],
+                self._objects["floor"],
+                self._objects["goal"],
+            }
+            or (
+                cell[0] == self._objects["door"]
+                and cell[2] == self._states["open"]
+            )
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_colors = parameters.get("color_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_colors) is not dict
+        or set(raw_colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in raw_colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in raw_colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/obstructed_maze/tests/test_obstructed_maze.py
+++ b/environments/minigrid/minigrid/obstructed_maze/tests/test_obstructed_maze.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_obstructed_maze import (
+    ObstructedMazeBenchmark,
+    ObstructedMazeConfig,
+    baseline_program,
+)
+
+
+class ObstructedMazeTests(unittest.TestCase):
+    def test_spec_and_split_planning(self) -> None:
+        benchmark = ObstructedMazeBenchmark()
+        self.assertEqual(
+            benchmark.spec.id,
+            "minigrid/ObstructedMaze-v0/success-rate-v1",
+        )
+        self.assertEqual(benchmark.spec.max_episode_steps, 288)
+        full = ObstructedMazeBenchmark(
+            ObstructedMazeConfig(profile="Full-v1")
+        )
+        self.assertEqual(full.spec.max_episode_steps, 3600)
+        self.assertNotEqual(
+            benchmark.spec.environment_digest,
+            full.spec.environment_digest,
+        )
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertEqual(train, repeated)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+
+    def test_environment_contract_and_invalid_actions(self) -> None:
+        benchmark = ObstructedMazeBenchmark()
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 5, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertIsInstance(observation["image"], TensorValue)
+            self.assertTrue(
+                str(observation["mission"]).startswith("pick up the ")
+            )
+            with self.assertRaises(InvalidAction):
+                environment.step(7)
+        finally:
+            environment.close()
+            environment.close()
+
+    def test_scenario_override_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            ObstructedMazeBenchmark().make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"room_size": 8})
+            )
+
+    def test_feedback_keeps_identity_private(self) -> None:
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        feedback = ObstructedMazeBenchmark().feedback((failed,))
+        trace = feedback.artifacts[0].read_bytes()
+        self.assertEqual(feedback.score, 0.0)
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+        self.assertNotIn(b'"scenario"', trace)
+
+    def test_baseline_completes_public_progress_ladder(self) -> None:
+        profiles = (
+            "1Dl-v0",
+            "1Dlh-v0",
+            "1Dlhb-v0",
+            "2Dl-v0",
+            "2Dlh-v0",
+            "2Dlhb-v0",
+            "2Dlhb-v1",
+            "1Q-v0",
+            "1Q-v1",
+            "2Q-v0",
+            "2Q-v1",
+            "Full-v0",
+            "Full-v1",
+        )
+        for profile in profiles:
+            with self.subTest(profile=profile):
+                result = evaluate(
+                    baseline_program(),
+                    ObstructedMazeBenchmark(
+                        ObstructedMazeConfig(profile=profile)
+                    ),
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=1,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(
+                    result.feedback.artifacts[0].name,
+                    "trace.jsonl",
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "pick up the blue ball",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/obstructed_maze/uv.lock
+++ b/environments/minigrid/minigrid/obstructed_maze/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-obstructed-maze"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/playground/.gitignore
+++ b/environments/minigrid/minigrid/playground/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/playground/README.md
+++ b/environments/minigrid/minigrid/playground/README.md
@@ -1,0 +1,17 @@
+# MiniGrid Playground Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the MiniGrid
+`Playground` registration.
+
+```python
+from minigrid_playground import PlaygroundBenchmark
+
+benchmark = PlaygroundBenchmark()
+```
+
+The Policy must open generated doors and visit all nine rooms. Feedback reports
+mean room coverage and full-coverage success;
+the bounded semantic trace contains no seeds, private identity, or Host paths.
+The packaged baseline never moves into an unknown or observed obstacle cell.
+The fixed public horizon is 1000 steps (the upstream default is 100).
+Trusted baseline tests use `ProcessExecution.unsafe()`, which is not a sandbox.

--- a/environments/minigrid/minigrid/playground/pyproject.toml
+++ b/environments/minigrid/minigrid/playground/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-playground"
+version = "0.1.0"
+description = "The MiniGrid Playground Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_playground"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/playground/src/minigrid_playground/__init__.py
+++ b/environments/minigrid/minigrid/playground/src/minigrid_playground/__init__.py
@@ -1,0 +1,6 @@
+"""The public MiniGrid Playground Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import PlaygroundBenchmark
+
+__all__ = ["PlaygroundBenchmark", "baseline_program"]

--- a/environments/minigrid/minigrid/playground/src/minigrid_playground/baseline.py
+++ b/environments/minigrid/minigrid/playground/src/minigrid_playground/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid Playground Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_playground").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/playground/src/minigrid_playground/benchmark.py
+++ b/environments/minigrid/minigrid/playground/src/minigrid_playground/benchmark.py
@@ -1,0 +1,326 @@
+"""MiniGrid Playground room coverage with bounded semantic traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .environment import PlaygroundEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-minigrid-playground/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_EPISODE_STEPS = 1000
+_OBJECTS = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATES = ("open", "closed", "locked")
+_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTIONS: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRICS = {
+    "rooms_visited",
+    "room_coverage",
+    "new_room",
+    "success",
+}
+
+
+class PlaygroundBenchmark:
+    """Coverage score for a generated nine-room playground."""
+
+    def __init__(self) -> None:
+        self._spec = _spec()
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return PlaygroundEnvironment(episode)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successes = sum(_success(record) for record in records)
+        coverages = tuple(_final_coverage(record) for record in records)
+        score = statistics.fmean(coverages)
+        traced = records[:4]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Mean room coverage was {score:.3f}; all nine rooms were "
+                    f"visited in {successes}/{len(records)} Episodes."
+                ),
+                "mean_room_coverage": score,
+                "full_coverage_rate": successes / len(records),
+                "mean_return": statistics.fmean(
+                    r.total_reward if r.policy_failure is None else 0.0
+                    for r in records
+                ),
+                "mean_steps": statistics.fmean(r.steps for r in records),
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "truncated_episodes": sum(_truncated(r) for r in records),
+                "policy_failures": sum(
+                    r.policy_failure is not None for r in records
+                ),
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+            },
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec() -> BenchmarkSpec:
+    mission = ""
+    return BenchmarkSpec(
+        id="minigrid/Playground-v0/room-coverage-v1",
+        description=(
+            "Open doors and visit all nine rooms in a generated playground "
+            "containing colored objects."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "constant": mission},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTIONS,
+        },
+        metadata={
+            "environment": "MiniGrid-Playground-v0",
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "size": 19,
+            "rooms": 9,
+            "room_layout": [3, 3],
+            "upstream_default_max_episode_steps": 100,
+            "reward": "1 on first entry into each new room, otherwise 0",
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": mission,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECTS)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLORS)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATES)
+            },
+        },
+        max_episode_steps=_MAX_EPISODE_STEPS,
+        primary_metric="mean_room_coverage",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _success(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _final_coverage(record: EpisodeRecord) -> float:
+    if record.policy_failure is not None or not record.transitions:
+        return 0.0
+    metrics = record.transitions[-1].step.metrics
+    if type(metrics) is not dict:
+        return 0.0
+    value = metrics.get("room_coverage")
+    return float(value) if type(value) is float else 0.0
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "room_coverage": _final_coverage(record),
+                    "success": _success(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                }
+            )
+        )
+        indices = (
+            tuple(range(record.steps))
+            if record.steps <= 160
+            else (*range(128), *range(record.steps - 32, record.steps))
+        )
+        for index in indices:
+            item = record.transitions[index]
+            if type(item.action) is not int or not 0 <= item.action <= 6:
+                raise ValueError("MiniGrid Playground trace Action is invalid")
+            if (
+                type(item.step.metrics) is not dict
+                or set(item.step.metrics) != _METRICS
+            ):
+                raise ValueError("MiniGrid Playground trace metrics are invalid")
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": index,
+                        "action": item.action,
+                        "action_meaning": _ACTIONS[str(item.action)],
+                        "reward": item.step.reward,
+                        "next_observation": _trace_observation(
+                            item.step.observation
+                        ),
+                        "terminated": item.step.terminated,
+                        "truncated": item.step.truncated,
+                        "metrics": item.step.metrics,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_observation(value: PolicyValue) -> dict[str, PolicyValue]:
+    if type(value) is not dict:
+        raise ValueError("MiniGrid Playground trace observation is invalid")
+    image = value.get("image")
+    direction = value.get("direction")
+    mission = value.get("mission")
+    if (
+        type(image) is not TensorValue
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+        or type(direction) is not int
+        or type(mission) is not str
+    ):
+        raise ValueError("MiniGrid Playground trace observation is invalid")
+    rows: list[PolicyValue] = []
+    for y in range(7):
+        rows.append(
+            "".join(
+                _SYMBOLS[image.data[(x * 7 + y) * 3]]
+                for x in range(7)
+            )
+        )
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+    }
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
+__all__ = ["PlaygroundBenchmark"]

--- a/environments/minigrid/minigrid/playground/src/minigrid_playground/environment.py
+++ b/environments/minigrid/minigrid/playground/src/minigrid_playground/environment.py
@@ -1,0 +1,154 @@
+"""One fresh MiniGrid Playground room-coverage Environment per Episode."""
+
+from __future__ import annotations
+
+import operator
+from typing import SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+_ENVIRONMENT_ID = "MiniGrid-Playground-v0"
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_MAX_EPISODE_STEPS = 1000
+_ROOMS = 9
+
+
+class PlaygroundEnvironment:
+    """Strict seeded adapter that rewards first entry into each room."""
+
+    def __init__(self, episode: EpisodeSpec) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if episode.scenario is not None:
+            raise ValueError("Playground has no Episode scenario overrides")
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(
+                _ENVIRONMENT_ID,
+                max_steps=_MAX_EPISODE_STEPS,
+            ),
+        )
+        self._visited_rooms: set[tuple[int, int]] = set()
+        self._started = False
+        self._done = False
+        self._closed = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public = _observation(observation)
+        self._visited_rooms.add(self._room())
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+
+        observation, _, upstream_terminated, truncated, _ = (
+            self._environment.step(action)
+        )
+        if (
+            type(upstream_terminated) is not bool
+            or type(truncated) is not bool
+        ):
+            raise RuntimeError("MiniGrid Playground returned invalid flags")
+        public = _observation(observation)
+        room = self._room()
+        new_room = room not in self._visited_rooms
+        self._visited_rooms.add(room)
+        rooms_visited = len(self._visited_rooms)
+        success = rooms_visited == _ROOMS
+        terminated = upstream_terminated or success
+        coverage = rooms_visited / _ROOMS
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=1.0 if new_room else 0.0,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "rooms_visited": rooms_visited,
+                "room_coverage": coverage,
+                "new_room": new_room,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+    def _room(self) -> tuple[int, int]:
+        value = self._environment.get_wrapper_attr("agent_pos")
+        if (
+            not isinstance(value, (tuple, list, numpy.ndarray))
+            or len(value) != 2
+        ):
+            raise RuntimeError("MiniGrid Playground returned invalid position")
+        try:
+            x = operator.index(cast(SupportsIndex, value[0]))
+            y = operator.index(cast(SupportsIndex, value[1]))
+        except TypeError as error:
+            raise RuntimeError(
+                "MiniGrid Playground returned invalid position"
+            ) from error
+        if not 1 <= x <= 17 or not 1 <= y <= 17:
+            raise RuntimeError("MiniGrid Playground returned invalid position")
+        return min((x - 1) // 6, 2), min((y - 1) // 6, 2)
+
+
+def _observation(value: object) -> dict[str, PolicyValue]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid Playground returned invalid observation")
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid Playground returned invalid image")
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid Playground returned invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid Playground returned invalid direction")
+    mission = value["mission"]
+    if type(mission) is not str or mission != "":
+        raise RuntimeError("MiniGrid Playground returned invalid mission")
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=_IMAGE_SHAPE,
+            data=image.tobytes(order="C"),
+        ),
+        "direction": direction,
+        "mission": mission,
+    }
+
+
+__all__ = ["PlaygroundEnvironment"]

--- a/environments/minigrid/minigrid/playground/src/minigrid_playground/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/playground/src/minigrid_playground/programs/baseline/policy.py
@@ -1,0 +1,448 @@
+"""A public-observation mapping and planning Playground baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_PICKUP = 3
+_DROP = 4
+_TOGGLE = 5
+_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Open doors and explore every reachable room."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._carried: Cell | None = None
+        self._moved_objects: set[Position] = set()
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction, mission = self._read_observation(observation)
+        if mission != "":
+            raise ValueError("observation mission is invalid")
+        self._integrate(image, direction)
+
+        closed = self._nearest_door(self._states["closed"])
+        if closed is not None:
+            return self._open(closed, direction)
+        if not self._has_frontier():
+            if self._carried is not None:
+                return self._drop(direction)
+            portable = self._nearest_portable()
+            if portable is not None:
+                return self._pick_up(portable, direction)
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int, str]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        mission = observation["mission"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        if type(mission) is not str:
+            raise ValueError("observation mission is invalid")
+        return image, direction, mission
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _VECTORS[direction]
+        right_x, right_y = _VECTORS[(direction + 1) % 4]
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+
+    def _cell(self, image: TensorValue, x: int, y: int) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _nearest_door(self, state: int) -> Position | None:
+        candidates: list[tuple[int, Position]] = []
+        for position, cell in self._grid.items():
+            if (
+                cell[0] != self._objects["door"]
+                or cell[2] != state
+            ):
+                continue
+            approach = self._best_approach(position)
+            if approach is not None:
+                candidates.append((len(approach[1]), position))
+        return (
+            None
+            if not candidates
+            else min(candidates, key=lambda item: (item[0], item[1]))[1]
+        )
+
+    def _nearest_portable(self) -> Position | None:
+        candidates: list[tuple[int, Position]] = []
+        portable = {
+            self._objects["key"],
+            self._objects["ball"],
+            self._objects["box"],
+        }
+        for position, cell in self._grid.items():
+            if position in self._moved_objects or cell[0] not in portable:
+                continue
+            approach = self._best_approach(position)
+            if approach is not None:
+                candidates.append((len(approach[1]), position))
+        return (
+            None
+            if not candidates
+            else min(candidates, key=lambda item: (item[0], item[1]))[1]
+        )
+
+    def _open(
+        self,
+        target: Position,
+        direction: int,
+    ) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+        turn = _turn_toward(
+            direction,
+            _direction_between(approach_position, target),
+        )
+        if turn is not None:
+            return turn
+        cell = self._grid[target]
+        self._grid[target] = (
+            self._objects["door"],
+            cell[1],
+            self._states["open"],
+        )
+        return _TOGGLE
+
+    def _pick_up(self, target: Position, direction: int) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return _RIGHT
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+        turn = _turn_toward(
+            direction,
+            _direction_between(approach_position, target),
+        )
+        if turn is not None:
+            return turn
+        self._carried = self._grid[target]
+        self._grid[target] = (
+            self._objects["empty"],
+            self._colors["red"],
+            self._states["open"],
+        )
+        return _PICKUP
+
+    def _drop(self, direction: int) -> int:
+        if self._carried is None:
+            return _RIGHT
+        candidates = [
+            (target_direction, position)
+            for target_direction, position in _neighbors(self._position)
+            if self._grid.get(position, (None, None, None))[0]
+            == self._objects["empty"]
+        ]
+        if not candidates:
+            return _RIGHT
+        target_direction, position = min(candidates)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._grid[position] = self._carried
+        self._moved_objects.add(position)
+        self._carried = None
+        return _DROP
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if self._traversable(neighbor):
+                path = self._shortest_path(neighbor)
+                if path is not None:
+                    candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(candidates)
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        return None if not path else self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        turn = _turn_toward(
+            direction,
+            _direction_between(self._position, next_position),
+        )
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers = [
+            (distance, position, unknown_direction)
+            for position, distance in distances.items()
+            for unknown_direction, neighbor in _neighbors(position)
+            if neighbor not in self._grid
+        ]
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(frontiers)
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        return _RIGHT if turn is None else turn
+
+    def _has_frontier(self) -> bool:
+        return any(
+            neighbor not in self._grid
+            for position in self._reachable_distances()
+            for _, neighbor in _neighbors(position)
+        )
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        return bool(
+            cell is not None
+            and (
+                cell[0]
+                in {
+                    self._objects["empty"],
+                    self._objects["floor"],
+                    self._objects["goal"],
+                }
+                or (
+                    cell[0] == self._objects["door"]
+                    and cell[2] == self._states["open"]
+                )
+            )
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    values = context.environment_parameters
+    objects = values.get("object_encoding")
+    colors = values.get("color_encoding")
+    states = values.get("state_encoding")
+    view_size = values.get("view_size")
+    agent_position = values.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(objects) is not dict
+        or set(objects) != object_names
+        or any(type(value) is not int for value in objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(colors) is not dict
+        or set(colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(states) is not dict
+        or set(states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(view_size) is not int or view_size != 7:
+        raise ValueError("view_size is invalid")
+    if type(agent_position) is not list or agent_position != [3, 6]:
+        raise ValueError("agent_view_position is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in states.items()
+        },
+        view_size=view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        path.append(current)
+        current = previous[current]
+    path.reverse()
+    return tuple(path[1:])

--- a/environments/minigrid/minigrid/playground/tests/test_playground.py
+++ b/environments/minigrid/minigrid/playground/tests/test_playground.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import EpisodeRecord, EpisodeSpec
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_playground import (
+    PlaygroundBenchmark,
+    baseline_program,
+)
+
+
+class PlaygroundTests(unittest.TestCase):
+    def test_spec_defines_upstream_identity(self) -> None:
+        default = PlaygroundBenchmark()
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/Playground-v0/room-coverage-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 1000)
+        self.assertEqual(
+            default.spec.metadata["environment"],
+            "MiniGrid-Playground-v0",
+        )
+
+    def test_split_planning_and_scenario_rejection(self) -> None:
+        benchmark = PlaygroundBenchmark()
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"size": 11})
+            )
+
+    def test_feedback_privacy(self) -> None:
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        trace = (
+            PlaygroundBenchmark().feedback((failed,)).artifacts[0].read_bytes()
+        )
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+
+    def test_baseline_solves_seeded_episodes(self) -> None:
+        benchmark = PlaygroundBenchmark()
+        result = evaluate(
+            baseline_program(),
+            benchmark,
+            execution=ProcessExecution.unsafe(),
+            config=EvaluationConfig(
+                split="validation",
+                episodes=6,
+                seed=5,
+                episode_timeout_seconds=10,
+            ),
+        )
+        self.assertEqual(result.feedback.score, 1.0)
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/playground/uv.lock
+++ b/environments/minigrid/minigrid/playground/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-playground"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/put_near/.gitignore
+++ b/environments/minigrid/minigrid/put_near/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/put_near/README.md
+++ b/environments/minigrid/minigrid/put_near/README.md
@@ -1,0 +1,56 @@
+# MiniGrid PutNear Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid PutNear](https://minigrid.farama.org/environments/minigrid/PutNearEnv/)
+object-rearrangement task.
+
+The Policy receives the upstream `7 × 7 × 3` egocentric symbolic image,
+compass direction, and a relational mission. It must pick up exactly the named
+colored object and drop it in an empty cell next to a second named object.
+Wrong pickups and misplaced drops terminate the Episode with zero reward. The
+primary score is Episode success rate.
+
+## Install and test
+
+From the EvoPolicyGym repository root:
+
+```console
+uv sync --project environments/minigrid/minigrid/put_near --extra dev
+uv run --project environments/minigrid/minigrid/put_near \
+  python -m unittest discover \
+  -s environments/minigrid/minigrid/put_near/tests
+uv build environments/minigrid/minigrid/put_near
+```
+
+## Public API
+
+```python
+from minigrid_put_near import (
+    PutNearBenchmark,
+    PutNearConfig,
+    baseline_program,
+)
+
+benchmark = PutNearBenchmark(
+    PutNearConfig(profile="8x8-N3"),
+)
+program = baseline_program()
+```
+
+Available profiles are `6x6-N2` and `8x8-N3`. A profile is selected by the
+Host before a Run and contributes to the environment digest.
+
+Feedback reports success, discovery of both mission objects, wrong pickups,
+and misplaced drops, together with return, step, truncation, and
+Policy-failure statistics. `trace.jsonl` contains a bounded semantic trace for
+at most four Episodes and no Episode seed, private identity, or Host path.
+
+The packaged baseline parses the public mission, builds a relative map from
+public observations, shortest-path plans to the movable object, and selects a
+reachable empty drop cell adjacent to the target. It consumes no private
+environment state.
+
+Tests that use `ProcessExecution.unsafe()` run trusted packaged code only.
+That backend is a local process mechanism, not a sandbox and not suitable for
+hostile Programs.
+

--- a/environments/minigrid/minigrid/put_near/pyproject.toml
+++ b/environments/minigrid/minigrid/put_near/pyproject.toml
@@ -1,0 +1,69 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-put-near"
+version = "0.1.0"
+description = "The MiniGrid PutNear Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = [
+    "mypy==2.3.0",
+    "ruff>=0.12.0",
+]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_put_near"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/README.md",
+    "/pyproject.toml",
+    "/src",
+    "/tests",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/put_near/src/minigrid_put_near/__init__.py
+++ b/environments/minigrid/minigrid/put_near/src/minigrid_put_near/__init__.py
@@ -1,0 +1,12 @@
+"""The public MiniGrid PutNear Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import PutNearBenchmark
+from .config import PutNearConfig
+
+__all__ = [
+    "PutNearBenchmark",
+    "PutNearConfig",
+    "baseline_program",
+]
+

--- a/environments/minigrid/minigrid/put_near/src/minigrid_put_near/baseline.py
+++ b/environments/minigrid/minigrid/put_near/src/minigrid_put_near/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid PutNear development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_put_near").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/put_near/src/minigrid_put_near/benchmark.py
+++ b/environments/minigrid/minigrid/put_near/src/minigrid_put_near/benchmark.py
@@ -1,0 +1,478 @@
+"""MiniGrid PutNear with deterministic plans and placement traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import PutNearConfig
+from .environment import PutNearEnvironment
+
+_EPISODE_SEED_DOMAIN = b"evopolicygym-minigrid-put-near/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_DESCRIPTORS = tuple(
+    f"{color} {kind}"
+    for color in _COLOR_NAMES
+    for kind in ("key", "ball", "box")
+)
+_MISSIONS = tuple(
+    f"put the {move} near the {target}"
+    for move in _DESCRIPTORS
+    for target in _DESCRIPTORS
+    if move != target
+)
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRIC_FIELDS = {
+    "move_object_found",
+    "target_object_found",
+    "carrying_move_object",
+    "wrong_object",
+    "misplaced_object",
+    "success",
+}
+
+
+class PutNearBenchmark:
+    """Success rate on instruction-conditioned object rearrangement."""
+
+    def __init__(self, config: PutNearConfig | None = None) -> None:
+        if config is None:
+            config = PutNearConfig()
+        if type(config) is not PutNearConfig:
+            raise TypeError("config must be PutNearConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return PutNearEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        move_found = _milestone_count(records, "move_object_found")
+        target_found = _milestone_count(records, "target_object_found")
+        wrong_objects = _milestone_count(records, "wrong_object")
+        misplaced = _milestone_count(records, "misplaced_object")
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        mean_success_steps: PolicyValue = (
+            statistics.fmean(record.steps for record in successful)
+            if successful
+            else None
+        )
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Placed the requested object near its target in "
+                    f"{successes}/{len(records)} Episodes "
+                    f"({score:.3f} success rate); {wrong_objects} wrong "
+                    f"pickups and {misplaced} misplaced drops."
+                ),
+                "success_rate": score,
+                "move_object_found_rate": move_found / len(records),
+                "target_object_found_rate": target_found / len(records),
+                "wrong_object_rate": wrong_objects / len(records),
+                "misplaced_object_rate": misplaced / len(records),
+                "mean_return": mean_return,
+                "mean_steps": mean_steps,
+                "mean_steps_on_success": mean_success_steps,
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "move_object_found_episodes": move_found,
+                "target_object_found_episodes": target_found,
+                "wrong_object_episodes": wrong_objects,
+                "misplaced_object_episodes": misplaced,
+                "truncated_episodes": truncations,
+                "policy_failures": failures,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+                "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+                "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+            },
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: PutNearConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/PutNear-v0/success-rate-v1",
+        description=(
+            "Parse a relational mission, pick up exactly the requested "
+            "colored object, and drop it in an empty cell adjacent to the "
+            "named target object. Maximize success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "meaning": {
+                        "0": "east",
+                        "1": "south",
+                        "2": "west",
+                        "3": "north",
+                    },
+                },
+                "mission": {
+                    "type": "string",
+                    "values": list(_MISSIONS),
+                },
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "size": config.size,
+            "object_count": config.object_count,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission_template": (
+                "put the {move_color} {move_type} near the "
+                "{target_color} {target_type}"
+            ),
+            "object_types": ["key", "ball", "box"],
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for dropping the requested "
+                "object within Chebyshev distance one of the target; zero "
+                "for a wrong pickup, misplaced drop, or timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _milestone_count(
+    records: Sequence[EpisodeRecord],
+    name: str,
+) -> int:
+    return sum(_reached_milestone(record, name) for record in records)
+
+
+def _reached_milestone(record: EpisodeRecord, name: str) -> bool:
+    for transition in record.transitions:
+        metrics = transition.step.metrics
+        if type(metrics) is dict and metrics.get(name) is True:
+            return True
+    return False
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "move_object_found": _reached_milestone(
+                        record,
+                        "move_object_found",
+                    ),
+                    "target_object_found": _reached_milestone(
+                        record,
+                        "target_object_found",
+                    ),
+                    "wrong_object": _reached_milestone(
+                        record,
+                        "wrong_object",
+                    ),
+                    "misplaced_object": _reached_milestone(
+                        record,
+                        "misplaced_object",
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError("MiniGrid PutNear trace Action is invalid")
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if (
+        type(metrics) is not dict
+        or set(metrics) != _METRIC_FIELDS
+        or any(type(value) is not bool for value in metrics.values())
+    ):
+        raise ValueError("MiniGrid PutNear trace metrics are invalid")
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError("MiniGrid PutNear trace observation is invalid")
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("MiniGrid PutNear trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("MiniGrid PutNear trace direction is invalid")
+    if type(mission) is not str or mission not in _MISSIONS:
+        raise ValueError("MiniGrid PutNear trace mission is invalid")
+
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError(
+                    "MiniGrid PutNear trace image codes are invalid"
+                )
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    move_object, target_object = _mission_objects(mission)
+    return {
+        "direction": direction,
+        "mission": mission,
+        "move_object": move_object,
+        "target_object": target_object,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _mission_objects(mission: str) -> tuple[str, str]:
+    prefix = "put the "
+    separator = " near the "
+    if not mission.startswith(prefix) or separator not in mission:
+        raise ValueError("MiniGrid PutNear trace mission is invalid")
+    parts = mission.removeprefix(prefix).split(separator)
+    if len(parts) != 2 or any(part not in _DESCRIPTORS for part in parts):
+        raise ValueError("MiniGrid PutNear trace mission is invalid")
+    return parts[0], parts[1]
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["PutNearBenchmark"]

--- a/environments/minigrid/minigrid/put_near/src/minigrid_put_near/config.py
+++ b/environments/minigrid/minigrid/put_near/src/minigrid_put_near/config.py
@@ -1,0 +1,50 @@
+"""Typed, public MiniGrid PutNear environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int, int]] = {
+    "6x6-N2": ("MiniGrid-PutNear-6x6-N2-v0", 6, 2),
+    "8x8-N3": ("MiniGrid-PutNear-8x8-N3-v0", 8, 3),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PutNearConfig:
+    """Parameters that define one MiniGrid PutNear Benchmark identity."""
+
+    profile: str = "8x8-N3"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        """Return the upstream Gymnasium registration."""
+
+        return _PROFILES[self.profile][0]
+
+    @property
+    def size(self) -> int:
+        """Return the square grid size."""
+
+        return _PROFILES[self.profile][1]
+
+    @property
+    def object_count(self) -> int:
+        """Return the generated object count."""
+
+        return _PROFILES[self.profile][2]
+
+    @property
+    def max_episode_steps(self) -> int:
+        """Return the upstream horizon."""
+
+        return 5 * self.size
+
+
+__all__ = ["PutNearConfig"]
+

--- a/environments/minigrid/minigrid/put_near/src/minigrid_put_near/environment.py
+++ b/environments/minigrid/minigrid/put_near/src/minigrid_put_near/environment.py
@@ -1,0 +1,234 @@
+"""One fresh MiniGrid PutNear Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401  # Import registers MiniGrid environments.
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import PutNearConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_OBJECT_CODES = {"key": 5, "ball": 6, "box": 7}
+
+
+@dataclass(frozen=True, slots=True)
+class _ObservationFacts:
+    move_object: tuple[int, int]
+    target_object: tuple[int, int]
+    move_visible: bool
+    target_visible: bool
+    carried_object: tuple[int, int] | None
+
+
+class PutNearEnvironment:
+    """The seeded strict adapter around configured MiniGrid PutNear."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: PutNearConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not PutNearConfig:
+            raise TypeError("config must be PutNearConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "PutNear configuration belongs in PutNearConfig, "
+                "not EpisodeSpec.scenario"
+            )
+
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._mission_objects: tuple[tuple[int, int], tuple[int, int]] | None = None
+        self._move_found = False
+        self._target_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._mission_objects = (facts.move_object, facts.target_object)
+        self._move_found = facts.move_visible
+        self._target_found = facts.target_visible
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid PutNear returned invalid termination flags")
+        number = _number(reward, name="reward")
+        public, facts = _observation(observation)
+        if (facts.move_object, facts.target_object) != self._mission_objects:
+            raise RuntimeError(
+                "MiniGrid PutNear changed mission objects during an Episode"
+            )
+        self._move_found = self._move_found or facts.move_visible
+        self._target_found = self._target_found or facts.target_visible
+        success = bool(terminated and number > 0.0)
+        wrong_object = bool(
+            terminated
+            and action == 3
+            and facts.carried_object is not None
+            and facts.carried_object != facts.move_object
+        )
+        misplaced_object = bool(
+            terminated and action == 4 and not success
+        )
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "move_object_found": self._move_found,
+                "target_object_found": self._target_found,
+                "carrying_move_object": (
+                    facts.carried_object == facts.move_object
+                ),
+                "wrong_object": wrong_object,
+                "misplaced_object": misplaced_object,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(
+    value: object,
+) -> tuple[dict[str, PolicyValue], _ObservationFacts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid PutNear returned an invalid observation")
+
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid PutNear returned an invalid image")
+    if (
+        numpy.any(image[:, :, 0] > 10)
+        or numpy.any(image[:, :, 1] > 5)
+        or numpy.any(image[:, :, 2] > 2)
+    ):
+        raise RuntimeError("MiniGrid PutNear returned out-of-range image codes")
+
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid PutNear returned an invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid PutNear returned an invalid direction")
+
+    mission = value["mission"]
+    if type(mission) is not str:
+        raise RuntimeError("MiniGrid PutNear returned an invalid mission")
+    move_object, target_object = _mission_objects(mission)
+    carried_type = int(image[3, 6, 0])
+    carried_object = (
+        (carried_type, int(image[3, 6, 1]))
+        if carried_type in _OBJECT_CODES.values()
+        else None
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _ObservationFacts(
+            move_object=move_object,
+            target_object=target_object,
+            move_visible=_visible(image, move_object),
+            target_visible=_visible(image, target_object),
+            carried_object=carried_object,
+        ),
+    )
+
+
+def _mission_objects(
+    mission: str,
+) -> tuple[tuple[int, int], tuple[int, int]]:
+    prefix = "put the "
+    separator = " near the "
+    if not mission.startswith(prefix) or separator not in mission:
+        raise RuntimeError("MiniGrid PutNear returned an invalid mission")
+    move_text, target_text = mission.removeprefix(prefix).split(separator)
+    return _named_object(move_text), _named_object(target_text)
+
+
+def _named_object(text: str) -> tuple[int, int]:
+    parts = text.split(" ")
+    if len(parts) != 2 or parts[0] not in _COLORS or parts[1] not in _OBJECT_CODES:
+        raise RuntimeError("MiniGrid PutNear returned an invalid mission")
+    return _OBJECT_CODES[parts[1]], _COLORS.index(parts[0])
+
+
+def _visible(image: numpy.ndarray[tuple[int, ...], numpy.dtype[numpy.uint8]], target: tuple[int, int]) -> bool:
+    return bool(
+        numpy.any(
+            (image[:, :, 0] == target[0])
+            & (image[:, :, 1] == target[1])
+        )
+    )
+
+
+def _number(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError(f"MiniGrid PutNear returned an invalid {name}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError(f"MiniGrid PutNear returned a non-finite {name}")
+    return number
+
+
+__all__ = ["PutNearEnvironment"]

--- a/environments/minigrid/minigrid/put_near/src/minigrid_put_near/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/put_near/src/minigrid_put_near/programs/baseline/policy.py
@@ -1,0 +1,472 @@
+"""A public-observation mapping and planning PutNear baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_PICKUP = 3
+_DROP = 4
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Map candidates, carry the requested object, and place it near target."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._move_object: tuple[int, int] | None = None
+        self._target_object: tuple[int, int] | None = None
+        self._carrying = False
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction, mission = self._read_observation(observation)
+        move_object, target_object = self._read_mission(mission)
+        if self._move_object is None:
+            self._move_object = move_object
+            self._target_object = target_object
+        elif (
+            self._move_object != move_object
+            or self._target_object != target_object
+        ):
+            raise ValueError("mission changed during the Episode")
+        self._integrate(image, direction)
+
+        if not self._carrying:
+            movable = self._known_matching(move_object)
+            if movable is not None:
+                return self._pick_up(movable, direction)
+            return self._explore(direction)
+
+        target = self._known_matching(target_object)
+        if target is None:
+            return self._explore(direction)
+        return self._place_near(target, direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int, str]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        mission = observation["mission"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        if type(mission) is not str:
+            raise ValueError("observation mission is invalid")
+        return image, direction, mission
+
+    def _read_mission(
+        self,
+        mission: str,
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        prefix = "put the "
+        separator = " near the "
+        if not mission.startswith(prefix) or separator not in mission:
+            raise ValueError("observation mission is invalid")
+        move_text, target_text = mission.removeprefix(prefix).split(separator)
+        return self._named_object(move_text), self._named_object(target_text)
+
+    def _named_object(self, text: str) -> tuple[int, int]:
+        parts = text.split(" ")
+        if (
+            len(parts) != 2
+            or parts[0] not in self._colors
+            or parts[1] not in {"key", "ball", "box"}
+        ):
+            raise ValueError("observation mission is invalid")
+        return self._objects[parts[1]], self._colors[parts[0]]
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    if (
+                        self._move_object is not None
+                        and (object_code, color_code) == self._move_object
+                    ):
+                        self._carrying = True
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_matching(
+        self,
+        target: tuple[int, int],
+    ) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[:2] == target
+            ),
+            None,
+        )
+
+    def _pick_up(self, target: Position, direction: int) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+        target_direction = _direction_between(approach_position, target)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._carrying = True
+        self._grid[target] = (
+            self._objects["empty"],
+            self._colors["red"],
+            self._states["open"],
+        )
+        return _PICKUP
+
+    def _place_near(self, target: Position, direction: int) -> int:
+        plan = self._best_drop_plan(target)
+        if plan is None:
+            return self._explore(direction)
+        approach, drop_position, path = plan
+        if path:
+            return self._follow(path, direction)
+        target_direction = _direction_between(approach, drop_position)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        return _DROP
+
+    def _best_drop_plan(
+        self,
+        target: Position,
+    ) -> tuple[Position, Position, tuple[Position, ...]] | None:
+        candidates: list[
+            tuple[int, Position, Position, tuple[Position, ...]]
+        ] = []
+        for x in range(target[0] - 1, target[0] + 2):
+            for y in range(target[1] - 1, target[1] + 2):
+                drop_position = (x, y)
+                if drop_position == target or not self._empty(drop_position):
+                    continue
+                for _, approach in _neighbors(drop_position):
+                    if approach == target or not self._traversable(approach):
+                        continue
+                    path = self._shortest_path(approach)
+                    if path is not None:
+                        candidates.append(
+                            (
+                                len(path),
+                                approach,
+                                drop_position,
+                                path,
+                            )
+                        )
+        if not candidates:
+            return None
+        _, approach, drop_position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        return approach, drop_position, path
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if not frontiers:
+            return _RIGHT
+
+        _, frontier, frontier_direction = min(
+            frontiers,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+
+        turn = _turn_toward(direction, frontier_direction)
+        if turn is not None:
+            return turn
+        return _RIGHT
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _empty(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        return bool(
+            cell is not None
+            and cell[0] in {
+                self._objects["empty"],
+                self._objects["floor"],
+            }
+        )
+
+    def _traversable(self, position: Position) -> bool:
+        return self._empty(position)
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_colors = parameters.get("color_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_colors) is not dict
+        or set(raw_colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in raw_colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in raw_colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/put_near/tests/test_put_near.py
+++ b/environments/minigrid/minigrid/put_near/tests/test_put_near.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_put_near import (
+    PutNearBenchmark,
+    PutNearConfig,
+    baseline_program,
+)
+
+
+class PutNearBenchmarkTests(unittest.TestCase):
+    def test_config_profiles_define_distinct_environment_identity(self) -> None:
+        default = PutNearBenchmark()
+        small = PutNearBenchmark(PutNearConfig(profile="6x6-N2"))
+
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/PutNear-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 40)
+        self.assertEqual(small.spec.max_episode_steps, 30)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            small.spec.environment_digest,
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["profile"],
+            "8x8-N3",
+        )
+        self.assertEqual(
+            default.spec.environment_parameters["object_count"],
+            3,
+        )
+
+    def test_config_rejects_unsupported_or_ambiguous_profiles(self) -> None:
+        with self.assertRaises(ValueError):
+            PutNearConfig(profile="8x8")
+        with self.assertRaises(ValueError):
+            PutNearConfig(profile=8)  # type: ignore[arg-type]
+
+    def test_episode_planning_is_reproducible_and_split_scoped(self) -> None:
+        benchmark = PutNearBenchmark()
+
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        validation = tuple(
+            benchmark.episodes("validation", seed=7, count=10)
+        )
+
+        self.assertEqual(train, repeated)
+        self.assertEqual(len({item.environment_seed for item in train}), 10)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in validation
+            )
+        )
+        self.assertTrue(all(item.scenario is None for item in train))
+
+    def test_environment_is_conformant_and_rejects_invalid_actions(
+        self,
+    ) -> None:
+        benchmark = PutNearBenchmark(PutNearConfig(profile="6x6-N2"))
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 5, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertEqual(
+                set(observation),
+                {"image", "direction", "mission"},
+            )
+            image = observation["image"]
+            self.assertIsInstance(image, TensorValue)
+            assert isinstance(image, TensorValue)
+            self.assertEqual(image.dtype, "uint8")
+            self.assertEqual(image.shape, (7, 7, 3))
+            self.assertEqual(len(image.data), 147)
+            mission = observation["mission"]
+            self.assertIsInstance(mission, str)
+            assert isinstance(mission, str)
+            self.assertTrue(mission.startswith("put the "))
+            self.assertIn(" near the ", mission)
+        finally:
+            environment.close()
+            environment.close()
+
+        invalid_actions: tuple[PolicyValue, ...] = (
+            -1,
+            7,
+            True,
+            2.0,
+            [2],
+        )
+        for invalid in invalid_actions:
+            environment = benchmark.make_environment(
+                EpisodeSpec(environment_seed=123)
+            )
+            try:
+                environment.reset()
+                with self.assertRaises(InvalidAction):
+                    environment.step(invalid)
+            finally:
+                environment.close()
+
+    def test_episode_scenario_cannot_override_benchmark_configuration(
+        self,
+    ) -> None:
+        benchmark = PutNearBenchmark()
+        with self.assertRaises(ValueError):
+            benchmark.make_environment(
+                EpisodeSpec(
+                    environment_seed=1,
+                    scenario={"profile": "6x6-N2"},
+                )
+            )
+
+    def test_feedback_penalizes_failure_and_keeps_identity_private(self) -> None:
+        benchmark = PutNearBenchmark()
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+
+        feedback = benchmark.feedback((failed,))
+
+        self.assertEqual(feedback.score, 0.0)
+        self.assertEqual(len(feedback.artifacts), 1)
+        trace = feedback.artifacts[0]
+        self.assertEqual(trace.name, "trace.jsonl")
+        self.assertNotIn(b"environment_seed", trace.read_bytes())
+        self.assertNotIn(b"policy_seed", trace.read_bytes())
+        self.assertNotIn(b'"profile"', trace.read_bytes())
+        self.assertIsInstance(feedback.content, dict)
+        assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["policy_failures"], 1)
+        self.assertEqual(feedback.content["wrong_object_episodes"], 0)
+        self.assertEqual(feedback.content["misplaced_object_episodes"], 0)
+
+    def test_baseline_solves_every_public_profile_and_publishes_trace(
+        self,
+    ) -> None:
+        for profile in ("6x6-N2", "8x8-N3"):
+            with self.subTest(profile=profile):
+                benchmark = PutNearBenchmark(
+                    PutNearConfig(profile=profile)
+                )
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=8,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+
+                self.assertEqual(
+                    result.benchmark_id,
+                    "minigrid/PutNear-v0/success-rate-v1",
+                )
+                self.assertEqual(
+                    result.environment_digest,
+                    benchmark.spec.environment_digest,
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["wrong_object_rate"],
+                    0.0,
+                )
+                self.assertEqual(
+                    result.feedback.content["misplaced_object_rate"],
+                    0.0,
+                )
+                trace = result.feedback.artifacts[0]
+                documents = tuple(
+                    json.loads(line)
+                    for line in trace.read_bytes().splitlines()
+                )
+                transitions = tuple(
+                    document
+                    for document in documents
+                    if document["type"] == "transition"
+                )
+                self.assertEqual(trace.name, "trace.jsonl")
+                self.assertEqual(
+                    trace.media_type,
+                    "application/x-ndjson",
+                )
+                self.assertTrue(transitions)
+                self.assertTrue(
+                    all(
+                        "move_object" in item["next_observation"]
+                        and "target_object" in item["next_observation"]
+                        for item in transitions
+                    )
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "put the purple ball near the red key",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/put_near/uv.lock
+++ b/environments/minigrid/minigrid/put_near/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-put-near"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/red_blue_doors/.gitignore
+++ b/environments/minigrid/minigrid/red_blue_doors/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/red_blue_doors/README.md
+++ b/environments/minigrid/minigrid/red_blue_doors/README.md
@@ -1,0 +1,32 @@
+# MiniGrid RedBlueDoors Benchmark
+
+An independently installable EvoPolicyGym Benchmark for the
+[MiniGrid RedBlueDoors](https://minigrid.farama.org/environments/minigrid/RedBlueDoorEnv/)
+ordered interaction task.
+
+The Policy receives the upstream egocentric symbolic observation and must open
+the red door before opening the blue door. Opening blue first ends the Episode
+with zero reward. Available profiles are `6x6` and `8x8`; the Host selects one
+before a Run and it contributes to the environment digest.
+
+```python
+from minigrid_red_blue_doors import (
+    RedBlueDoorsBenchmark,
+    RedBlueDoorsConfig,
+    baseline_program,
+)
+
+benchmark = RedBlueDoorsBenchmark(RedBlueDoorsConfig(profile="8x8"))
+program = baseline_program()
+```
+
+Feedback and the bounded `trace.jsonl` report door discovery, red-door
+completion, order errors, success, returns, steps, truncation, and Policy
+failures without publishing seeds, private identity, or Host paths.
+
+The packaged baseline uses only public observations to map the central room
+and plans to the red and blue doors in mission order.
+
+Tests using `ProcessExecution.unsafe()` execute trusted packaged code only.
+That backend is a local process mechanism, not a sandbox.
+

--- a/environments/minigrid/minigrid/red_blue_doors/pyproject.toml
+++ b/environments/minigrid/minigrid/red_blue_doors/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-red-blue-doors"
+version = "0.1.0"
+description = "The MiniGrid RedBlueDoors Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_red_blue_doors"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/__init__.py
+++ b/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/__init__.py
@@ -1,0 +1,12 @@
+"""The public MiniGrid RedBlueDoors Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import RedBlueDoorsBenchmark
+from .config import RedBlueDoorsConfig
+
+__all__ = [
+    "RedBlueDoorsBenchmark",
+    "RedBlueDoorsConfig",
+    "baseline_program",
+]
+

--- a/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/baseline.py
+++ b/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/baseline.py
@@ -1,0 +1,22 @@
+"""Packaged initial Program for RedBlueDoors development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_red_blue_doors").joinpath(
+        "programs",
+        "baseline",
+    )
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/benchmark.py
+++ b/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/benchmark.py
@@ -1,0 +1,438 @@
+"""RedBlueDoors with deterministic plans and ordered-door traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import RedBlueDoorsConfig
+from .environment import RedBlueDoorsEnvironment
+
+_EPISODE_SEED_DOMAIN = (
+    b"evopolicygym-minigrid-red-blue-doors/episode-seed/v1\0"
+)
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+_TRACE_PREFIX_STEPS = 128
+_TRACE_SUFFIX_STEPS = 32
+_MISSION = "open the red door then the blue door"
+_OBJECT_NAMES = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLOR_NAMES = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATE_NAMES = ("open", "closed", "locked")
+_OBJECT_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTION_MEANING: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRIC_FIELDS = {
+    "red_door_found",
+    "blue_door_found",
+    "red_door_opened",
+    "blue_opened_before_red",
+    "success",
+}
+
+
+class RedBlueDoorsBenchmark:
+    """Success rate for opening two colored doors in order."""
+
+    def __init__(
+        self,
+        config: RedBlueDoorsConfig | None = None,
+    ) -> None:
+        if config is None:
+            config = RedBlueDoorsConfig()
+        if type(config) is not RedBlueDoorsConfig:
+            raise TypeError("config must be RedBlueDoorsConfig")
+        self._config = config
+        self._spec = _benchmark_spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_episode_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        return RedBlueDoorsEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successful = tuple(record for record in records if _successful(record))
+        successes = len(successful)
+        score = successes / len(records)
+        red_found = _milestone_count(records, "red_door_found")
+        blue_found = _milestone_count(records, "blue_door_found")
+        red_opened = _milestone_count(records, "red_door_opened")
+        order_errors = _milestone_count(records, "blue_opened_before_red")
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
+        mean_steps = statistics.fmean(record.steps for record in records)
+        mean_success_steps: PolicyValue = (
+            statistics.fmean(record.steps for record in successful)
+            if successful
+            else None
+        )
+        failures = sum(record.policy_failure is not None for record in records)
+        truncations = sum(_truncated(record) for record in records)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Opened red then blue in {successes}/{len(records)} "
+                    f"Episodes ({score:.3f} success rate); {order_errors} "
+                    f"opened blue before red."
+                ),
+                "success_rate": score,
+                "red_door_found_rate": red_found / len(records),
+                "blue_door_found_rate": blue_found / len(records),
+                "red_door_opened_rate": red_opened / len(records),
+                "order_error_rate": order_errors / len(records),
+                "mean_return": mean_return,
+                "mean_steps": mean_steps,
+                "mean_steps_on_success": mean_success_steps,
+                "episodes": len(records),
+                "successful_episodes": successes,
+                "red_door_found_episodes": red_found,
+                "blue_door_found_episodes": blue_found,
+                "red_door_opened_episodes": red_opened,
+                "order_error_episodes": order_errors,
+                "truncated_episodes": truncations,
+                "policy_failures": failures,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+                "trace_prefix_steps": _TRACE_PREFIX_STEPS,
+                "trace_suffix_steps": _TRACE_SUFFIX_STEPS,
+            },
+            artifacts=(_trace_artifact(traced),),
+        )
+
+
+def _benchmark_spec(config: RedBlueDoorsConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/RedBlueDoors-v0/success-rate-v1",
+        description=(
+            "Explore the central room, open the red door, then open the blue "
+            "door. Opening blue first fails immediately. Maximize success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                    "layout": "XYC",
+                    "channels": ["object", "color", "state"],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "constant": _MISSION},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTION_MEANING,
+        },
+        metadata={
+            "environment": config.environment_id,
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "room_size": config.room_size,
+            "grid_width": 2 * config.room_size,
+            "grid_height": config.room_size,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": _MISSION,
+            "required_order": ["red", "blue"],
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECT_NAMES)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLOR_NAMES)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATE_NAMES)
+            },
+            "reward": (
+                "positive discounted reward for opening blue after red; "
+                "zero for opening blue first or timeout"
+            ),
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _episode_seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_EPISODE_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _successful(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _milestone_count(
+    records: Sequence[EpisodeRecord],
+    name: str,
+) -> int:
+    return sum(_reached_milestone(record, name) for record in records)
+
+
+def _reached_milestone(record: EpisodeRecord, name: str) -> bool:
+    return any(
+        type(transition.step.metrics) is dict
+        and transition.step.metrics.get(name) is True
+        for transition in record.transitions
+    )
+
+
+def _trace_artifact(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        selected_steps = _trace_indices(record.steps)
+        lines.append(
+            _json_line(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "red_door_opened": _reached_milestone(
+                        record,
+                        "red_door_opened",
+                    ),
+                    "blue_opened_before_red": _reached_milestone(
+                        record,
+                        "blue_opened_before_red",
+                    ),
+                    "success": _successful(record),
+                    "truncated": _truncated(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                    "traced_steps": len(selected_steps),
+                    "omitted_steps": record.steps - len(selected_steps),
+                }
+            )
+        )
+        for step_index in selected_steps:
+            transition = record.transitions[step_index]
+            if type(transition.action) is not int or not 0 <= transition.action <= 6:
+                raise ValueError(
+                    "MiniGrid RedBlueDoors trace Action is invalid"
+                )
+            lines.append(
+                _json_line(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "action_meaning": _ACTION_MEANING[
+                            str(transition.action)
+                        ],
+                        "reward": transition.step.reward,
+                        "next_observation": _trace_observation(
+                            transition.step.observation
+                        ),
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                        "metrics": _trace_metrics(
+                            transition.step.metrics
+                        ),
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_indices(step_count: int) -> tuple[int, ...]:
+    if step_count <= _TRACE_PREFIX_STEPS + _TRACE_SUFFIX_STEPS:
+        return tuple(range(step_count))
+    return (
+        *range(_TRACE_PREFIX_STEPS),
+        *range(step_count - _TRACE_SUFFIX_STEPS, step_count),
+    )
+
+
+def _trace_metrics(metrics: PolicyValue) -> dict[str, PolicyValue]:
+    if (
+        type(metrics) is not dict
+        or set(metrics) != _METRIC_FIELDS
+        or any(type(value) is not bool for value in metrics.values())
+    ):
+        raise ValueError("MiniGrid RedBlueDoors trace metrics are invalid")
+    return dict(metrics)
+
+
+def _trace_observation(
+    observation: PolicyValue,
+) -> dict[str, PolicyValue]:
+    if type(observation) is not dict or set(observation) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise ValueError(
+            "MiniGrid RedBlueDoors trace observation is invalid"
+        )
+    image = observation["image"]
+    direction = observation["direction"]
+    mission = observation["mission"]
+    if (
+        type(image) is not TensorValue
+        or image.dtype != "uint8"
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+    ):
+        raise ValueError("MiniGrid RedBlueDoors trace image is invalid")
+    if type(direction) is not int or not 0 <= direction <= 3:
+        raise ValueError("MiniGrid RedBlueDoors trace direction is invalid")
+    if type(mission) is not str or mission != _MISSION:
+        raise ValueError("MiniGrid RedBlueDoors trace mission is invalid")
+    rows: list[PolicyValue] = []
+    visible_objects: list[PolicyValue] = []
+    for y in range(7):
+        row: list[str] = []
+        for x in range(7):
+            offset = (x * 7 + y) * 3
+            object_code, color_code, state_code = image.data[offset : offset + 3]
+            if (
+                object_code >= len(_OBJECT_NAMES)
+                or color_code >= len(_COLOR_NAMES)
+                or state_code >= len(_STATE_NAMES)
+            ):
+                raise ValueError(
+                    "MiniGrid RedBlueDoors trace image codes are invalid"
+                )
+            row.append(_OBJECT_SYMBOLS[object_code])
+            if object_code not in {0, 1}:
+                visible_objects.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "object": _OBJECT_NAMES[object_code],
+                        "color": _COLOR_NAMES[color_code],
+                        "state": _STATE_NAMES[state_code],
+                    }
+                )
+        rows.append("".join(row))
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+        "visible_objects": visible_objects,
+    }
+
+
+def _json_line(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["RedBlueDoorsBenchmark"]

--- a/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/config.py
+++ b/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/config.py
@@ -1,0 +1,44 @@
+"""Typed, public MiniGrid RedBlueDoors environment configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PROFILES: dict[str, tuple[str, int]] = {
+    "6x6": ("MiniGrid-RedBlueDoors-6x6-v0", 6),
+    "8x8": ("MiniGrid-RedBlueDoors-8x8-v0", 8),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RedBlueDoorsConfig:
+    """Parameters defining one RedBlueDoors Benchmark identity."""
+
+    profile: str = "8x8"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str or self.profile not in _PROFILES:
+            choices = "', '".join(_PROFILES)
+            raise ValueError(f"profile must be one of '{choices}'")
+
+    @property
+    def environment_id(self) -> str:
+        """Return the upstream Gymnasium registration."""
+
+        return _PROFILES[self.profile][0]
+
+    @property
+    def room_size(self) -> int:
+        """Return the upstream room-size parameter."""
+
+        return _PROFILES[self.profile][1]
+
+    @property
+    def max_episode_steps(self) -> int:
+        """Return the upstream horizon."""
+
+        return 20 * self.room_size**2
+
+
+__all__ = ["RedBlueDoorsConfig"]
+

--- a/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/environment.py
+++ b/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/environment.py
@@ -1,0 +1,216 @@
+"""One fresh MiniGrid RedBlueDoors Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import RedBlueDoorsConfig
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_MISSION = "open the red door then the blue door"
+_DOOR = 4
+_RED = 0
+_BLUE = 2
+_CLOSED = 1
+
+
+@dataclass(frozen=True, slots=True)
+class _ObservationFacts:
+    red_visible: bool
+    blue_visible: bool
+    front_door: tuple[int, int] | None
+
+
+class RedBlueDoorsEnvironment:
+    """Strict seeded adapter around MiniGrid RedBlueDoors."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: RedBlueDoorsConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not RedBlueDoorsConfig:
+            raise TypeError("config must be RedBlueDoorsConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "RedBlueDoors configuration belongs in RedBlueDoorsConfig, "
+                "not EpisodeSpec.scenario"
+            )
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._front_door: tuple[int, int] | None = None
+        self._red_found = False
+        self._blue_found = False
+        self._red_opened = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._update(facts)
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        opened_red = bool(
+            action == 5
+            and self._front_door == (_RED, _CLOSED)
+        )
+        opened_blue_before_red = bool(
+            action == 5
+            and self._front_door == (_BLUE, _CLOSED)
+            and not self._red_opened
+        )
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError(
+                "MiniGrid RedBlueDoors returned invalid termination flags"
+            )
+        number = _number(reward)
+        public, facts = _observation(observation)
+        self._red_opened = self._red_opened or opened_red
+        self._update(facts)
+        success = bool(terminated and number > 0.0)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "red_door_found": self._red_found,
+                "blue_door_found": self._blue_found,
+                "red_door_opened": self._red_opened,
+                "blue_opened_before_red": opened_blue_before_red,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+    def _update(self, facts: _ObservationFacts) -> None:
+        self._front_door = facts.front_door
+        self._red_found = self._red_found or facts.red_visible
+        self._blue_found = self._blue_found or facts.blue_visible
+
+
+def _observation(
+    value: object,
+) -> tuple[dict[str, PolicyValue], _ObservationFacts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError(
+            "MiniGrid RedBlueDoors returned an invalid observation"
+        )
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid RedBlueDoors returned an invalid image")
+    if (
+        numpy.any(image[:, :, 0] > 10)
+        or numpy.any(image[:, :, 1] > 5)
+        or numpy.any(image[:, :, 2] > 2)
+    ):
+        raise RuntimeError(
+            "MiniGrid RedBlueDoors returned out-of-range image codes"
+        )
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid RedBlueDoors returned an invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError(
+            "MiniGrid RedBlueDoors returned an invalid direction"
+        )
+    mission = value["mission"]
+    if type(mission) is not str or mission != _MISSION:
+        raise RuntimeError(
+            "MiniGrid RedBlueDoors returned an invalid mission"
+        )
+    front_door = (
+        (int(image[3, 5, 1]), int(image[3, 5, 2]))
+        if image[3, 5, 0] == _DOOR
+        else None
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _ObservationFacts(
+            red_visible=bool(
+                numpy.any(
+                    (image[:, :, 0] == _DOOR)
+                    & (image[:, :, 1] == _RED)
+                )
+            ),
+            blue_visible=bool(
+                numpy.any(
+                    (image[:, :, 0] == _DOOR)
+                    & (image[:, :, 1] == _BLUE)
+                )
+            ),
+            front_door=front_door,
+        ),
+    )
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("MiniGrid RedBlueDoors returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("MiniGrid RedBlueDoors returned non-finite reward")
+    return number
+
+
+__all__ = ["RedBlueDoorsEnvironment"]

--- a/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/programs/baseline/policy.py
@@ -1,0 +1,381 @@
+"""A public-observation ordered-door RedBlueDoors baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_TOGGLE = 5
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Map the room and open red before blue."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._red_opened = False
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+        self._integrate(image, direction)
+        target_color = (
+            self._colors["blue"]
+            if self._red_opened
+            else self._colors["red"]
+        )
+        target = self._known_door(target_color)
+        if target is not None:
+            return self._interact(target, direction)
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        return image, direction
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+                if (
+                    object_code == self._objects["door"]
+                    and color_code == self._colors["red"]
+                    and state_code == self._states["open"]
+                ):
+                    self._red_opened = True
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_door(self, color: int) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == self._objects["door"]
+                and cell[1] == color
+            ),
+            None,
+        )
+
+    def _interact(self, target: Position, direction: int) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+        target_direction = _direction_between(approach_position, target)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        color = self._grid[target][1]
+        self._grid[target] = (
+            self._objects["door"],
+            color,
+            self._states["open"],
+        )
+        if color == self._colors["red"]:
+            self._red_opened = True
+        return _TOGGLE
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        target_direction = _direction_between(
+            self._position,
+            next_position,
+        )
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers: list[tuple[int, Position, int]] = []
+        for position, distance in distances.items():
+            for unknown_direction, neighbor in _neighbors(position):
+                if neighbor not in self._grid:
+                    frontiers.append(
+                        (distance, position, unknown_direction)
+                    )
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(
+            frontiers,
+            key=lambda item: (item[0], item[1], item[2]),
+        )
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        if turn is not None:
+            return turn
+        return _RIGHT
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        if cell is None:
+            return False
+        return cell[0] in {
+            self._objects["empty"],
+            self._objects["floor"],
+            self._objects["goal"],
+        }
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_colors = parameters.get("color_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_colors) is not dict
+        or set(raw_colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in raw_colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if (
+        type(raw_agent_position) is not list
+        or raw_agent_position != [3, 6]
+    ):
+        raise ValueError("agent_view_position is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in raw_colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/red_blue_doors/tests/test_red_blue_doors.py
+++ b/environments/minigrid/minigrid/red_blue_doors/tests/test_red_blue_doors.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_red_blue_doors import (
+    RedBlueDoorsBenchmark,
+    RedBlueDoorsConfig,
+    baseline_program,
+)
+
+
+class RedBlueDoorsBenchmarkTests(unittest.TestCase):
+    def test_profiles_and_identity(self) -> None:
+        default = RedBlueDoorsBenchmark()
+        small = RedBlueDoorsBenchmark(
+            RedBlueDoorsConfig(profile="6x6")
+        )
+        self.assertEqual(
+            default.spec.id,
+            "minigrid/RedBlueDoors-v0/success-rate-v1",
+        )
+        self.assertEqual(default.spec.max_episode_steps, 1_280)
+        self.assertEqual(small.spec.max_episode_steps, 720)
+        self.assertNotEqual(
+            default.spec.environment_digest,
+            small.spec.environment_digest,
+        )
+        with self.assertRaises(ValueError):
+            RedBlueDoorsConfig(profile="7x7")
+
+    def test_episode_planning_is_split_scoped(self) -> None:
+        benchmark = RedBlueDoorsBenchmark()
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        repeated = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertEqual(train, repeated)
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+
+    def test_environment_contract_and_invalid_actions(self) -> None:
+        benchmark = RedBlueDoorsBenchmark(
+            RedBlueDoorsConfig(profile="6x6")
+        )
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 5, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            image = observation["image"]
+            self.assertIsInstance(image, TensorValue)
+            assert isinstance(image, TensorValue)
+            self.assertEqual(image.shape, (7, 7, 3))
+            self.assertEqual(
+                observation["mission"],
+                "open the red door then the blue door",
+            )
+            with self.assertRaises(InvalidAction):
+                environment.step(7)
+        finally:
+            environment.close()
+            environment.close()
+
+    def test_scenario_override_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            RedBlueDoorsBenchmark().make_environment(
+                EpisodeSpec(
+                    environment_seed=1,
+                    scenario={"profile": "6x6"},
+                )
+            )
+
+    def test_feedback_keeps_episode_identity_private(self) -> None:
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        feedback = RedBlueDoorsBenchmark().feedback((failed,))
+        trace = feedback.artifacts[0].read_bytes()
+        self.assertEqual(feedback.score, 0.0)
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+        self.assertNotIn(b'"profile"', trace)
+
+    def test_baseline_solves_every_profile(self) -> None:
+        for profile in ("6x6", "8x8"):
+            with self.subTest(profile=profile):
+                benchmark = RedBlueDoorsBenchmark(
+                    RedBlueDoorsConfig(profile=profile)
+                )
+                result = evaluate(
+                    baseline_program(),
+                    benchmark,
+                    execution=ProcessExecution.unsafe(),
+                    config=EvaluationConfig(
+                        split="validation",
+                        episodes=8,
+                        seed=5,
+                        episode_timeout_seconds=10,
+                    ),
+                )
+                self.assertEqual(result.feedback.score, 1.0)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
+                self.assertEqual(
+                    result.feedback.content["red_door_opened_rate"],
+                    1.0,
+                )
+                self.assertEqual(
+                    result.feedback.content["order_error_rate"],
+                    0.0,
+                )
+                self.assertEqual(
+                    result.feedback.artifacts[0].name,
+                    "trace.jsonl",
+                )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "open the red door then the blue door",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/red_blue_doors/uv.lock
+++ b/environments/minigrid/minigrid/red_blue_doors/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-red-blue-doors"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/unlock/.gitignore
+++ b/environments/minigrid/minigrid/unlock/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/unlock/README.md
+++ b/environments/minigrid/minigrid/unlock/README.md
@@ -1,0 +1,18 @@
+# MiniGrid Unlock Benchmark
+
+An independently installable EvoPolicyGym Benchmark for
+[MiniGrid Unlock](https://minigrid.farama.org/environments/minigrid/UnlockEnv/).
+The Policy must find the key matching a locked door and open it.
+
+```python
+from minigrid_unlock import UnlockBenchmark, baseline_program
+
+benchmark = UnlockBenchmark()
+program = baseline_program()
+```
+
+Feedback and the bounded semantic trace expose key discovery, acquisition, and
+door-opening progress without publishing seeds, private identity, or Host
+paths. The baseline uses public observations only. `ProcessExecution.unsafe()`
+is used only for trusted packaged baseline tests and is not a sandbox.
+

--- a/environments/minigrid/minigrid/unlock/pyproject.toml
+++ b/environments/minigrid/minigrid/unlock/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-unlock"
+version = "0.1.0"
+description = "The MiniGrid Unlock Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_unlock"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/unlock/src/minigrid_unlock/__init__.py
+++ b/environments/minigrid/minigrid/unlock/src/minigrid_unlock/__init__.py
@@ -1,0 +1,7 @@
+"""The public MiniGrid Unlock Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import UnlockBenchmark
+
+__all__ = ["UnlockBenchmark", "baseline_program"]
+

--- a/environments/minigrid/minigrid/unlock/src/minigrid_unlock/baseline.py
+++ b/environments/minigrid/minigrid/unlock/src/minigrid_unlock/baseline.py
@@ -1,0 +1,19 @@
+"""Packaged initial Program for MiniGrid Unlock development Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_unlock").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/unlock/src/minigrid_unlock/benchmark.py
+++ b/environments/minigrid/minigrid/unlock/src/minigrid_unlock/benchmark.py
@@ -1,0 +1,325 @@
+"""MiniGrid Unlock with deterministic plans and milestone traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .environment import UnlockEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-minigrid-unlock/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MISSION = "open the door"
+_OBJECTS = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATES = ("open", "closed", "locked")
+_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_ACTIONS: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRICS = {"key_found", "key_picked_up", "door_opened", "success"}
+
+
+class UnlockBenchmark:
+    """Success rate for finding a matching key and opening a locked door."""
+
+    def __init__(self) -> None:
+        self._spec = _spec()
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return UnlockEnvironment(episode)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successes = sum(_success(record) for record in records)
+        score = successes / len(records)
+        counts = {
+            name: sum(_reached(record, name) for record in records)
+            for name in _METRICS - {"success"}
+        }
+        traced = records[:4]
+        content: dict[str, PolicyValue] = {
+            "summary": (
+                f"Opened the locked door in {successes}/{len(records)} "
+                f"Episodes ({score:.3f} success rate)."
+            ),
+            "success_rate": score,
+            "mean_return": statistics.fmean(
+                record.total_reward
+                if record.policy_failure is None
+                else 0.0
+                for record in records
+            ),
+            "mean_steps": statistics.fmean(
+                record.steps for record in records
+            ),
+            "episodes": len(records),
+            "successful_episodes": successes,
+            "truncated_episodes": sum(_truncated(r) for r in records),
+            "policy_failures": sum(
+                record.policy_failure is not None for record in records
+            ),
+            "traced_episodes": len(traced),
+            "trace_episodes_omitted": len(records) - len(traced),
+        }
+        for name, value in counts.items():
+            content[f"{name}_rate"] = value / len(records)
+            content[f"{name}_episodes"] = value
+        return Feedback(
+            score=score,
+            content=content,
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec() -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/Unlock-v0/success-rate-v1",
+        description=(
+            "Explore the first room, pick up the key matching the locked "
+            "door, and unlock it. Maximize Episode success rate."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "constant": _MISSION},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTIONS,
+        },
+        metadata={
+            "environment": "MiniGrid-Unlock-v0",
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "room_size": 6,
+            "num_rows": 1,
+            "num_columns": 2,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission": _MISSION,
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECTS)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLORS)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATES)
+            },
+        },
+        max_episode_steps=8 * 6**2,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _success(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _reached(record: EpisodeRecord, name: str) -> bool:
+    return any(
+        type(item.step.metrics) is dict
+        and item.step.metrics.get(name) is True
+        for item in record.transitions
+    )
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _success(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                }
+            )
+        )
+        indices = (
+            tuple(range(record.steps))
+            if record.steps <= 160
+            else (*range(128), *range(record.steps - 32, record.steps))
+        )
+        for index in indices:
+            item = record.transitions[index]
+            if type(item.action) is not int or not 0 <= item.action <= 6:
+                raise ValueError("MiniGrid Unlock trace Action is invalid")
+            if (
+                type(item.step.metrics) is not dict
+                or set(item.step.metrics) != _METRICS
+            ):
+                raise ValueError("MiniGrid Unlock trace metrics are invalid")
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": index,
+                        "action": item.action,
+                        "action_meaning": _ACTIONS[str(item.action)],
+                        "reward": item.step.reward,
+                        "next_observation": _trace_observation(
+                            item.step.observation
+                        ),
+                        "terminated": item.step.terminated,
+                        "truncated": item.step.truncated,
+                        "metrics": item.step.metrics,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_observation(value: PolicyValue) -> dict[str, PolicyValue]:
+    if type(value) is not dict:
+        raise ValueError("MiniGrid Unlock trace observation is invalid")
+    image = value.get("image")
+    direction = value.get("direction")
+    mission = value.get("mission")
+    if (
+        type(image) is not TensorValue
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+        or type(direction) is not int
+        or type(mission) is not str
+        or mission != _MISSION
+    ):
+        raise ValueError("MiniGrid Unlock trace observation is invalid")
+    rows: list[PolicyValue] = []
+    for y in range(7):
+        row = "".join(
+            _SYMBOLS[image.data[(x * 7 + y) * 3]]
+            for x in range(7)
+        )
+        rows.append(row)
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+    }
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
+__all__ = ["UnlockBenchmark"]

--- a/environments/minigrid/minigrid/unlock/src/minigrid_unlock/environment.py
+++ b/environments/minigrid/minigrid/unlock/src/minigrid_unlock/environment.py
@@ -1,0 +1,178 @@
+"""One fresh MiniGrid Unlock Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+_ENVIRONMENT_ID = "MiniGrid-Unlock-v0"
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_MISSION = "open the door"
+_DOOR = 4
+_KEY = 5
+_LOCKED = 2
+
+
+@dataclass(frozen=True, slots=True)
+class _Facts:
+    key_visible: bool
+    carried_key_color: int | None
+    front_locked_door_color: int | None
+
+
+class UnlockEnvironment:
+    """Strict seeded adapter around MiniGrid Unlock."""
+
+    def __init__(self, episode: EpisodeSpec) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if episode.scenario is not None:
+            raise ValueError("Unlock has no Episode scenario overrides")
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(_ENVIRONMENT_ID),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._carried_key_color: int | None = None
+        self._front_locked_door_color: int | None = None
+        self._key_found = False
+        self._key_picked_up = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._update(facts)
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        opened_door = bool(
+            action == 5
+            and self._front_locked_door_color is not None
+            and self._carried_key_color
+            == self._front_locked_door_color
+        )
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid Unlock returned invalid flags")
+        number = _number(reward)
+        public, facts = _observation(observation)
+        self._update(facts)
+        success = bool(terminated and number > 0.0)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "key_found": self._key_found,
+                "key_picked_up": self._key_picked_up,
+                "door_opened": opened_door,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+    def _update(self, facts: _Facts) -> None:
+        self._carried_key_color = facts.carried_key_color
+        self._front_locked_door_color = facts.front_locked_door_color
+        self._key_found = self._key_found or facts.key_visible
+        self._key_picked_up = (
+            self._key_picked_up or facts.carried_key_color is not None
+        )
+
+
+def _observation(value: object) -> tuple[dict[str, PolicyValue], _Facts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid Unlock returned invalid observation")
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid Unlock returned invalid image")
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError("MiniGrid Unlock returned invalid direction") from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid Unlock returned invalid direction")
+    mission = value["mission"]
+    if type(mission) is not str or mission != _MISSION:
+        raise RuntimeError("MiniGrid Unlock returned invalid mission")
+    carried_key_color = (
+        int(image[3, 6, 1])
+        if image[3, 6, 0] == _KEY
+        else None
+    )
+    front_locked_door_color = (
+        int(image[3, 5, 1])
+        if image[3, 5, 0] == _DOOR
+        and image[3, 5, 2] == _LOCKED
+        else None
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _Facts(
+            key_visible=bool(numpy.any(image[:, :, 0] == _KEY)),
+            carried_key_color=carried_key_color,
+            front_locked_door_color=front_locked_door_color,
+        ),
+    )
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("MiniGrid Unlock returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("MiniGrid Unlock returned non-finite reward")
+    return number
+
+
+__all__ = ["UnlockEnvironment"]

--- a/environments/minigrid/minigrid/unlock/src/minigrid_unlock/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/unlock/src/minigrid_unlock/programs/baseline/policy.py
@@ -1,0 +1,399 @@
+"""A public-observation mapping and planning Unlock baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_PICKUP = 3
+_TOGGLE = 5
+_DIRECTION_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Find the key matching the locked door and open it."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._carried_key_color: int | None = None
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction = self._read_observation(observation)
+        self._integrate(image, direction)
+        if self._carried_key_color is None:
+            key = self._known_object("key")
+            if key is not None:
+                return self._interact(key, _PICKUP, direction)
+            return self._explore(direction)
+        door = self._known_door(self._carried_key_color)
+        if door is not None:
+            return self._interact(door, _TOGGLE, direction)
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        return image, direction
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _DIRECTION_VECTORS[direction]
+        right_x, right_y = _DIRECTION_VECTORS[(direction + 1) % 4]
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell_at(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    if object_code == self._objects["key"]:
+                        self._carried_key_color = color_code
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+
+    def _cell_at(
+        self,
+        image: TensorValue,
+        x: int,
+        y: int,
+    ) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_object(self, name: str) -> Position | None:
+        code = self._objects[name]
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == code
+            ),
+            None,
+        )
+
+    def _known_door(self, color: int) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == self._objects["door"]
+                and cell[1] == color
+                and cell[2] == self._states["locked"]
+            ),
+            None,
+        )
+
+    def _interact(
+        self,
+        target: Position,
+        action: int,
+        direction: int,
+    ) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+        target_direction = _direction_between(approach_position, target)
+        turn = _turn_toward(direction, target_direction)
+        if turn is not None:
+            return turn
+        cell = self._grid[target]
+        if action == _PICKUP:
+            self._carried_key_color = cell[1]
+            self._grid[target] = (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        else:
+            self._grid[target] = (
+                self._objects["door"],
+                cell[1],
+                self._states["open"],
+            )
+        return action
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if not self._traversable(neighbor):
+                continue
+            path = self._shortest_path(neighbor)
+            if path is not None:
+                candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(
+            candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        if not path:
+            return None
+        return self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        turn = _turn_toward(
+            direction,
+            _direction_between(self._position, next_position),
+        )
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers = [
+            (distance, position, unknown_direction)
+            for position, distance in distances.items()
+            for unknown_direction, neighbor in _neighbors(position)
+            if neighbor not in self._grid
+        ]
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(frontiers)
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        return _RIGHT if turn is None else turn
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        return bool(
+            cell is not None
+            and (
+                cell[0]
+                in {
+                    self._objects["empty"],
+                    self._objects["floor"],
+                    self._objects["goal"],
+                }
+                or (
+                    cell[0] == self._objects["door"]
+                    and cell[2] == self._states["open"]
+                )
+            )
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    parameters = context.environment_parameters
+    raw_objects = parameters.get("object_encoding")
+    raw_colors = parameters.get("color_encoding")
+    raw_states = parameters.get("state_encoding")
+    raw_view_size = parameters.get("view_size")
+    raw_agent_position = parameters.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(raw_objects) is not dict
+        or set(raw_objects) != object_names
+        or any(type(value) is not int for value in raw_objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(raw_colors) is not dict
+        or set(raw_colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in raw_colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(raw_states) is not dict
+        or set(raw_states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in raw_states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(raw_view_size) is not int or raw_view_size != 7:
+        raise ValueError("view_size is invalid")
+    if type(raw_agent_position) is not list or raw_agent_position != [3, 6]:
+        raise ValueError("agent_view_position is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in raw_objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in raw_colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in raw_states.items()
+        },
+        view_size=raw_view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_DIRECTION_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _DIRECTION_VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    reversed_path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        reversed_path.append(current)
+        current = previous[current]
+    reversed_path.reverse()
+    return tuple(reversed_path[1:])

--- a/environments/minigrid/minigrid/unlock/tests/test_unlock.py
+++ b/environments/minigrid/minigrid/unlock/tests/test_unlock.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_unlock import UnlockBenchmark, baseline_program
+
+
+class UnlockTests(unittest.TestCase):
+    def test_spec_and_split_planning(self) -> None:
+        benchmark = UnlockBenchmark()
+        self.assertEqual(
+            benchmark.spec.id,
+            "minigrid/Unlock-v0/success-rate-v1",
+        )
+        self.assertEqual(benchmark.spec.max_episode_steps, 288)
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+
+    def test_environment_contract_and_invalid_action(self) -> None:
+        benchmark = UnlockBenchmark()
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 5, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertIsInstance(observation["image"], TensorValue)
+            with self.assertRaises(InvalidAction):
+                environment.step(7)
+        finally:
+            environment.close()
+
+    def test_scenario_and_feedback_privacy(self) -> None:
+        with self.assertRaises(ValueError):
+            UnlockBenchmark().make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"size": 8})
+            )
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        trace = UnlockBenchmark().feedback((failed,)).artifacts[0].read_bytes()
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+
+    def test_baseline_solves_task(self) -> None:
+        result = evaluate(
+            baseline_program(),
+            UnlockBenchmark(),
+            execution=ProcessExecution.unsafe(),
+            config=EvaluationConfig(
+                split="validation",
+                episodes=12,
+                seed=5,
+                episode_timeout_seconds=10,
+            ),
+        )
+        self.assertEqual(result.feedback.score, 1.0)
+        self.assertIsInstance(result.feedback.content, dict)
+        assert isinstance(result.feedback.content, dict)
+        self.assertEqual(
+            result.feedback.content["key_picked_up_rate"],
+            1.0,
+        )
+        self.assertEqual(
+            result.feedback.content["door_opened_rate"],
+            1.0,
+        )
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "open the door",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/unlock/uv.lock
+++ b/environments/minigrid/minigrid/unlock/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-unlock"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/minigrid/minigrid/unlock_pickup/.gitignore
+++ b/environments/minigrid/minigrid/unlock_pickup/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+dist/*
+!dist/.gitignore
+

--- a/environments/minigrid/minigrid/unlock_pickup/README.md
+++ b/environments/minigrid/minigrid/unlock_pickup/README.md
@@ -1,0 +1,19 @@
+# MiniGrid UnlockPickup Benchmark
+
+An independently installable EvoPolicyGym Benchmark for
+[MiniGrid UnlockPickup](https://minigrid.farama.org/environments/minigrid/UnlockPickupEnv/).
+The Policy must acquire the matching key, unlock the second room, release the
+key, and collect the mission box.
+
+```python
+from minigrid_unlock_pickup import UnlockPickupBenchmark, baseline_program
+
+benchmark = UnlockPickupBenchmark()
+program = baseline_program()
+```
+
+Feedback and `trace.jsonl` expose the public progress ladder without
+publishing seeds, private identity, or Host paths. The packaged baseline uses
+public observations only. `ProcessExecution.unsafe()` is used only for trusted
+baseline tests and is not a sandbox.
+

--- a/environments/minigrid/minigrid/unlock_pickup/pyproject.toml
+++ b/environments/minigrid/minigrid/unlock_pickup/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "evopolicygym-benchmark-minigrid-unlock-pickup"
+version = "0.1.0"
+description = "The MiniGrid UnlockPickup Benchmark distribution for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "minigrid>=3.1.0,<4",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/minigrid_unlock_pickup"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+

--- a/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/__init__.py
+++ b/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/__init__.py
@@ -1,0 +1,7 @@
+"""The public MiniGrid UnlockPickup Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import UnlockPickupBenchmark
+
+__all__ = ["UnlockPickupBenchmark", "baseline_program"]
+

--- a/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/baseline.py
+++ b/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/baseline.py
@@ -1,0 +1,22 @@
+"""Packaged initial Program for MiniGrid UnlockPickup Runs."""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    """Return a detached snapshot of the public-observation baseline."""
+
+    resource = files("minigrid_unlock_pickup").joinpath(
+        "programs",
+        "baseline",
+    )
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]
+

--- a/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/benchmark.py
+++ b/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/benchmark.py
@@ -1,0 +1,339 @@
+"""MiniGrid UnlockPickup with deterministic plans and milestone traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .environment import UnlockPickupEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-minigrid-unlock-pickup/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_OBJECTS = (
+    "unseen",
+    "empty",
+    "wall",
+    "floor",
+    "door",
+    "key",
+    "ball",
+    "box",
+    "goal",
+    "lava",
+    "agent",
+)
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_STATES = ("open", "closed", "locked")
+_SYMBOLS = ("?", " ", "#", ".", "D", "K", "O", "B", "G", "L", "A")
+_MISSIONS = tuple(f"pick up the {color} box" for color in _COLORS)
+_ACTIONS: dict[str, PolicyValue] = {
+    "0": "turn_left",
+    "1": "turn_right",
+    "2": "move_forward",
+    "3": "pick_up",
+    "4": "drop",
+    "5": "toggle",
+    "6": "done",
+}
+_METRICS = {
+    "key_found",
+    "key_picked_up",
+    "door_opened",
+    "target_found",
+    "success",
+}
+
+
+class UnlockPickupBenchmark:
+    """Success rate for unlocking a room and collecting its target box."""
+
+    def __init__(self) -> None:
+        self._spec = _spec()
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return UnlockPickupEnvironment(episode)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        successes = sum(_success(record) for record in records)
+        score = successes / len(records)
+        counts = {
+            name: sum(_reached(record, name) for record in records)
+            for name in _METRICS - {"success"}
+        }
+        traced = records[:4]
+        content: dict[str, PolicyValue] = {
+            "summary": (
+                f"Unlocked the room and collected the target in "
+                f"{successes}/{len(records)} Episodes "
+                f"({score:.3f} success rate)."
+            ),
+            "success_rate": score,
+            "mean_return": statistics.fmean(
+                record.total_reward
+                if record.policy_failure is None
+                else 0.0
+                for record in records
+            ),
+            "mean_steps": statistics.fmean(
+                record.steps for record in records
+            ),
+            "episodes": len(records),
+            "successful_episodes": successes,
+            "truncated_episodes": sum(_truncated(r) for r in records),
+            "policy_failures": sum(
+                record.policy_failure is not None for record in records
+            ),
+            "traced_episodes": len(traced),
+            "trace_episodes_omitted": len(records) - len(traced),
+        }
+        for name, value in counts.items():
+            content[f"{name}_rate"] = value / len(records)
+            content[f"{name}_episodes"] = value
+        return Feedback(
+            score=score,
+            content=content,
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec() -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="minigrid/UnlockPickup-v0/success-rate-v1",
+        description=(
+            "Find the key matching a locked door, unlock the second room, "
+            "free the carrying slot, and pick up the mission box."
+        ),
+        observation_space={
+            "type": "object",
+            "fields": {
+                "image": {
+                    "type": "tensor",
+                    "dtype": "uint8",
+                    "shape": [7, 7, 3],
+                },
+                "direction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                },
+                "mission": {"type": "string", "values": list(_MISSIONS)},
+            },
+        },
+        action_space={
+            "type": "discrete",
+            "values": list(range(7)),
+            "meaning": _ACTIONS,
+        },
+        metadata={
+            "environment": "MiniGrid-UnlockPickup-v0",
+            "provider": "MiniGrid",
+            "failure_return": 0.0,
+            "partial_observability": True,
+        },
+        environment_parameters={
+            "room_size": 6,
+            "num_rows": 1,
+            "num_columns": 2,
+            "view_size": 7,
+            "agent_view_position": [3, 6],
+            "mission_template": "pick up the {color} box",
+            "object_encoding": {
+                name: code for code, name in enumerate(_OBJECTS)
+            },
+            "color_encoding": {
+                name: code for code, name in enumerate(_COLORS)
+            },
+            "state_encoding": {
+                name: code for code, name in enumerate(_STATES)
+            },
+        },
+        max_episode_steps=8 * 6**2,
+        primary_metric="success_rate",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _success(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+        and record.total_reward > 0.0
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _reached(record: EpisodeRecord, name: str) -> bool:
+    return any(
+        type(item.step.metrics) is dict
+        and item.step.metrics.get(name) is True
+        for item in record.transitions
+    )
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "steps": record.steps,
+                    "return": (
+                        record.total_reward
+                        if record.policy_failure is None
+                        else 0.0
+                    ),
+                    "success": _success(record),
+                    "failure": record.policy_failure,
+                    "initial_observation": _trace_observation(
+                        record.initial_observation
+                    ),
+                }
+            )
+        )
+        indices = (
+            tuple(range(record.steps))
+            if record.steps <= 160
+            else (*range(128), *range(record.steps - 32, record.steps))
+        )
+        for index in indices:
+            item = record.transitions[index]
+            if type(item.action) is not int or not 0 <= item.action <= 6:
+                raise ValueError(
+                    "MiniGrid UnlockPickup trace Action is invalid"
+                )
+            if (
+                type(item.step.metrics) is not dict
+                or set(item.step.metrics) != _METRICS
+            ):
+                raise ValueError(
+                    "MiniGrid UnlockPickup trace metrics are invalid"
+                )
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": index,
+                        "action": item.action,
+                        "action_meaning": _ACTIONS[str(item.action)],
+                        "reward": item.step.reward,
+                        "next_observation": _trace_observation(
+                            item.step.observation
+                        ),
+                        "terminated": item.step.terminated,
+                        "truncated": item.step.truncated,
+                        "metrics": item.step.metrics,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _trace_observation(value: PolicyValue) -> dict[str, PolicyValue]:
+    if type(value) is not dict:
+        raise ValueError("MiniGrid UnlockPickup trace observation is invalid")
+    image = value.get("image")
+    direction = value.get("direction")
+    mission = value.get("mission")
+    if (
+        type(image) is not TensorValue
+        or image.shape != (7, 7, 3)
+        or len(image.data) != 147
+        or type(direction) is not int
+        or type(mission) is not str
+        or mission not in _MISSIONS
+    ):
+        raise ValueError(
+            "MiniGrid UnlockPickup trace observation is invalid"
+        )
+    rows: list[PolicyValue] = []
+    for y in range(7):
+        rows.append(
+            "".join(
+                _SYMBOLS[image.data[(x * 7 + y) * 3]]
+                for x in range(7)
+            )
+        )
+    return {
+        "direction": direction,
+        "mission": mission,
+        "grid_rows": rows,
+    }
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
+__all__ = ["UnlockPickupBenchmark"]

--- a/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/environment.py
+++ b/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/environment.py
@@ -1,0 +1,214 @@
+"""One fresh MiniGrid UnlockPickup Environment per Episode."""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from typing import SupportsFloat, SupportsIndex, cast
+
+import gymnasium
+import minigrid  # noqa: F401
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+_IMAGE_SHAPE = (7, 7, 3)
+_ACTIONS = frozenset(range(7))
+_COLORS = ("red", "green", "blue", "purple", "yellow", "grey")
+_DOOR = 4
+_KEY = 5
+_BOX = 7
+_LOCKED = 2
+
+
+@dataclass(frozen=True, slots=True)
+class _Facts:
+    target: tuple[int, int]
+    carried: tuple[int, int] | None
+    key_visible: bool
+    target_visible: bool
+    front_locked_door_color: int | None
+
+
+class UnlockPickupEnvironment:
+    """Strict seeded adapter around MiniGrid UnlockPickup."""
+
+    def __init__(self, episode: EpisodeSpec) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if episode.scenario is not None:
+            raise ValueError("UnlockPickup has no Episode scenario overrides")
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make("MiniGrid-UnlockPickup-v0"),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._target: tuple[int, int] | None = None
+        self._carried: tuple[int, int] | None = None
+        self._front_locked_door_color: int | None = None
+        self._key_found = False
+        self._key_picked_up = False
+        self._door_opened = False
+        self._target_found = False
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        public, facts = _observation(observation)
+        self._target = facts.target
+        self._update(facts)
+        self._started = True
+        return public
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        opened_door = bool(
+            action == 5
+            and self._front_locked_door_color is not None
+            and self._carried
+            == (_KEY, self._front_locked_door_color)
+        )
+        observation, reward, terminated, truncated, _ = self._environment.step(
+            action
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("MiniGrid UnlockPickup returned invalid flags")
+        number = _number(reward)
+        public, facts = _observation(observation)
+        if facts.target != self._target:
+            raise RuntimeError("MiniGrid UnlockPickup changed its mission")
+        self._door_opened = self._door_opened or opened_door
+        self._update(facts)
+        success = bool(terminated and number > 0.0)
+        self._done = terminated or truncated
+        return Step(
+            observation=public,
+            reward=number,
+            terminated=terminated,
+            truncated=truncated,
+            metrics={
+                "key_found": self._key_found,
+                "key_picked_up": self._key_picked_up,
+                "door_opened": self._door_opened,
+                "target_found": self._target_found,
+                "success": success,
+            },
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+    def _update(self, facts: _Facts) -> None:
+        self._carried = facts.carried
+        self._front_locked_door_color = facts.front_locked_door_color
+        self._key_found = self._key_found or facts.key_visible
+        self._key_picked_up = (
+            self._key_picked_up
+            or (
+                facts.carried is not None
+                and facts.carried[0] == _KEY
+            )
+        )
+        self._target_found = self._target_found or facts.target_visible
+
+
+def _observation(value: object) -> tuple[dict[str, PolicyValue], _Facts]:
+    if type(value) is not dict or set(value) != {
+        "image",
+        "direction",
+        "mission",
+    }:
+        raise RuntimeError("MiniGrid UnlockPickup returned invalid observation")
+    image = value["image"]
+    if (
+        type(image) is not numpy.ndarray
+        or image.shape != _IMAGE_SHAPE
+        or image.dtype != numpy.dtype("uint8")
+    ):
+        raise RuntimeError("MiniGrid UnlockPickup returned invalid image")
+    try:
+        direction = operator.index(cast(SupportsIndex, value["direction"]))
+    except TypeError as error:
+        raise RuntimeError(
+            "MiniGrid UnlockPickup returned invalid direction"
+        ) from error
+    if not 0 <= direction <= 3:
+        raise RuntimeError("MiniGrid UnlockPickup returned invalid direction")
+    mission = value["mission"]
+    if type(mission) is not str:
+        raise RuntimeError("MiniGrid UnlockPickup returned invalid mission")
+    target = _target(mission)
+    carried_code = int(image[3, 6, 0])
+    carried = (
+        (carried_code, int(image[3, 6, 1]))
+        if carried_code in {_KEY, _BOX}
+        else None
+    )
+    front_locked_door_color = (
+        int(image[3, 5, 1])
+        if image[3, 5, 0] == _DOOR
+        and image[3, 5, 2] == _LOCKED
+        else None
+    )
+    return (
+        {
+            "image": TensorValue(
+                dtype="uint8",
+                shape=_IMAGE_SHAPE,
+                data=image.tobytes(order="C"),
+            ),
+            "direction": direction,
+            "mission": mission,
+        },
+        _Facts(
+            target=target,
+            carried=carried,
+            key_visible=bool(numpy.any(image[:, :, 0] == _KEY)),
+            target_visible=bool(
+                numpy.any(
+                    (image[:, :, 0] == target[0])
+                    & (image[:, :, 1] == target[1])
+                )
+            ),
+            front_locked_door_color=front_locked_door_color,
+        ),
+    )
+
+
+def _target(mission: str) -> tuple[int, int]:
+    prefix = "pick up the "
+    if not mission.startswith(prefix):
+        raise RuntimeError("MiniGrid UnlockPickup returned invalid mission")
+    parts = mission.removeprefix(prefix).split(" ")
+    if len(parts) != 2 or parts[0] not in _COLORS or parts[1] != "box":
+        raise RuntimeError("MiniGrid UnlockPickup returned invalid mission")
+    return _BOX, _COLORS.index(parts[0])
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("MiniGrid UnlockPickup returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("MiniGrid UnlockPickup returned non-finite reward")
+    return number
+
+
+__all__ = ["UnlockPickupEnvironment"]

--- a/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/programs/baseline/policy.py
+++ b/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/programs/baseline/policy.py
@@ -1,0 +1,504 @@
+"""A public-observation planner for MiniGrid UnlockPickup."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import cast
+
+from evopolicygym.policy import PolicyContext, PolicyValue, TensorValue
+
+type Position = tuple[int, int]
+type Cell = tuple[int, int, int]
+
+_LEFT = 0
+_RIGHT = 1
+_FORWARD = 2
+_PICKUP = 3
+_DROP = 4
+_TOGGLE = 5
+_VECTORS: tuple[Position, ...] = (
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+)
+
+
+class BaselinePolicy:
+    """Acquire the key, open the room, release it, and collect the box."""
+
+    def __init__(
+        self,
+        *,
+        object_encoding: dict[str, int],
+        color_encoding: dict[str, int],
+        state_encoding: dict[str, int],
+        view_size: int,
+        agent_view_position: Position,
+    ) -> None:
+        self._objects = object_encoding
+        self._colors = color_encoding
+        self._states = state_encoding
+        self._view_size = view_size
+        self._agent_view_position = agent_view_position
+        self._position = (0, 0)
+        self._grid: dict[Position, Cell] = {
+            self._position: (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        }
+        self._target: tuple[int, int] | None = None
+        self._carried: tuple[int, int] | None = None
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        image, direction, mission = self._read_observation(observation)
+        target = self._read_target(mission)
+        if self._target is None:
+            self._target = target
+        elif self._target != target:
+            raise ValueError("mission changed during the Episode")
+        self._integrate(image, direction)
+
+        if self._carried is not None:
+            carried_type, carried_color = self._carried
+            if carried_type == self._objects["key"]:
+                door = self._known_door(
+                    color=carried_color,
+                    state=self._states["locked"],
+                )
+                if door is not None:
+                    return self._interact(door, _TOGGLE, direction)
+            return self._drop(direction)
+
+        target_position = self._known_matching(target)
+        if (
+            target_position is not None
+            and self._best_approach(target_position) is not None
+        ):
+            return self._interact(target_position, _PICKUP, direction)
+
+        door = self._known_door(state=self._states["locked"])
+        if door is not None:
+            key = self._known_matching(
+                (self._objects["key"], self._grid[door][1])
+            )
+            if key is not None:
+                return self._interact(key, _PICKUP, direction)
+        return self._explore(direction)
+
+    def _read_observation(
+        self,
+        observation: PolicyValue,
+    ) -> tuple[TensorValue, int, str]:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        if set(observation) != {"image", "direction", "mission"}:
+            raise ValueError("observation fields are invalid")
+        image = observation["image"]
+        direction = observation["direction"]
+        mission = observation["mission"]
+        if (
+            type(image) is not TensorValue
+            or image.dtype != "uint8"
+            or image.shape != (self._view_size, self._view_size, 3)
+        ):
+            raise ValueError("observation image is invalid")
+        if type(direction) is not int or not 0 <= direction <= 3:
+            raise ValueError("observation direction is invalid")
+        if type(mission) is not str:
+            raise ValueError("observation mission is invalid")
+        return image, direction, mission
+
+    def _read_target(self, mission: str) -> tuple[int, int]:
+        prefix = "pick up the "
+        if not mission.startswith(prefix):
+            raise ValueError("observation mission is invalid")
+        parts = mission.removeprefix(prefix).split(" ")
+        if (
+            len(parts) != 2
+            or parts[0] not in self._colors
+            or parts[1] != "box"
+        ):
+            raise ValueError("observation mission is invalid")
+        return self._objects["box"], self._colors[parts[0]]
+
+    def _integrate(self, image: TensorValue, direction: int) -> None:
+        agent_x, agent_y = self._agent_view_position
+        forward_x, forward_y = _VECTORS[direction]
+        right_x, right_y = _VECTORS[(direction + 1) % 4]
+        self._carried = None
+        for view_x in range(self._view_size):
+            for view_y in range(self._view_size):
+                object_code, color_code, state_code = self._cell(
+                    image,
+                    view_x,
+                    view_y,
+                )
+                if (view_x, view_y) == self._agent_view_position:
+                    if object_code in {
+                        self._objects["key"],
+                        self._objects["box"],
+                    }:
+                        self._carried = (object_code, color_code)
+                    self._grid[self._position] = (
+                        self._objects["empty"],
+                        self._colors["red"],
+                        self._states["open"],
+                    )
+                    continue
+                if object_code == self._objects["unseen"]:
+                    continue
+                side = view_x - agent_x
+                forward = agent_y - view_y
+                world = (
+                    self._position[0]
+                    + forward * forward_x
+                    + side * right_x,
+                    self._position[1]
+                    + forward * forward_y
+                    + side * right_y,
+                )
+                self._grid[world] = (
+                    object_code,
+                    color_code,
+                    state_code,
+                )
+
+    def _cell(self, image: TensorValue, x: int, y: int) -> Cell:
+        offset = (x * self._view_size + y) * 3
+        return (
+            image.data[offset],
+            image.data[offset + 1],
+            image.data[offset + 2],
+        )
+
+    def _known_matching(
+        self,
+        target: tuple[int, int],
+    ) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[:2] == target
+            ),
+            None,
+        )
+
+    def _known_door(
+        self,
+        *,
+        color: int | None = None,
+        state: int | None = None,
+    ) -> Position | None:
+        return next(
+            (
+                position
+                for position, cell in self._grid.items()
+                if cell[0] == self._objects["door"]
+                and (color is None or cell[1] == color)
+                and (state is None or cell[2] == state)
+            ),
+            None,
+        )
+
+    def _interact(
+        self,
+        target: Position,
+        action: int,
+        direction: int,
+    ) -> int:
+        approach = self._best_approach(target)
+        if approach is None:
+            return self._explore(direction)
+        approach_position, path = approach
+        if path:
+            return self._follow(path, direction)
+        turn = _turn_toward(
+            direction,
+            _direction_between(approach_position, target),
+        )
+        if turn is not None:
+            return turn
+        cell = self._grid[target]
+        if action == _PICKUP:
+            self._carried = (cell[0], cell[1])
+            self._grid[target] = (
+                self._objects["empty"],
+                self._colors["red"],
+                self._states["open"],
+            )
+        else:
+            self._grid[target] = (
+                self._objects["door"],
+                cell[1],
+                self._states["open"],
+            )
+        return action
+
+    def _drop(self, direction: int) -> int:
+        plan = self._drop_plan()
+        if plan is None:
+            return self._explore(direction)
+        approach, destination, path = plan
+        if path:
+            return self._follow(path, direction)
+        turn = _turn_toward(
+            direction,
+            _direction_between(approach, destination),
+        )
+        if turn is not None:
+            return turn
+        if self._carried is None:
+            raise ValueError("carried object disappeared")
+        self._grid[destination] = (
+            self._carried[0],
+            self._carried[1],
+            self._states["open"],
+        )
+        self._carried = None
+        return _DROP
+
+    def _drop_plan(
+        self,
+    ) -> tuple[Position, Position, tuple[Position, ...]] | None:
+        doors = tuple(
+            position
+            for position, cell in self._grid.items()
+            if cell[0] == self._objects["door"]
+        )
+        candidates: list[
+            tuple[int, Position, Position, tuple[Position, ...]]
+        ] = []
+        for destination, cell in self._grid.items():
+            if cell[0] not in {
+                self._objects["empty"],
+                self._objects["floor"],
+            }:
+                continue
+            if any(
+                max(
+                    abs(destination[0] - door[0]),
+                    abs(destination[1] - door[1]),
+                )
+                <= 1
+                for door in doors
+            ):
+                continue
+            for _, approach in _neighbors(destination):
+                if not self._traversable(approach):
+                    continue
+                path = self._shortest_path(approach)
+                if path is not None:
+                    candidates.append(
+                        (len(path), approach, destination, path)
+                    )
+        if not candidates:
+            return None
+        _, approach, destination, path = min(candidates)
+        return approach, destination, path
+
+    def _best_approach(
+        self,
+        target: Position,
+    ) -> tuple[Position, tuple[Position, ...]] | None:
+        candidates: list[tuple[int, Position, tuple[Position, ...]]] = []
+        for _, neighbor in _neighbors(target):
+            if self._traversable(neighbor):
+                path = self._shortest_path(neighbor)
+                if path is not None:
+                    candidates.append((len(path), neighbor, path))
+        if not candidates:
+            return None
+        _, position, path = min(candidates)
+        return position, path
+
+    def _navigate(
+        self,
+        destination: Position,
+        direction: int,
+    ) -> int | None:
+        path = self._shortest_path(destination)
+        return None if not path else self._follow(path, direction)
+
+    def _follow(
+        self,
+        path: tuple[Position, ...],
+        direction: int,
+    ) -> int:
+        next_position = path[0]
+        turn = _turn_toward(
+            direction,
+            _direction_between(self._position, next_position),
+        )
+        if turn is not None:
+            return turn
+        self._position = next_position
+        return _FORWARD
+
+    def _shortest_path(
+        self,
+        destination: Position,
+    ) -> tuple[Position, ...] | None:
+        if destination == self._position:
+            return ()
+        queue: deque[Position] = deque((self._position,))
+        previous: dict[Position, Position | None] = {
+            self._position: None
+        }
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in previous or not self._traversable(neighbor):
+                    continue
+                previous[neighbor] = current
+                if neighbor == destination:
+                    return _reconstruct(previous, destination)
+                queue.append(neighbor)
+        return None
+
+    def _explore(self, direction: int) -> int:
+        distances = self._reachable_distances()
+        frontiers = [
+            (distance, position, unknown_direction)
+            for position, distance in distances.items()
+            for unknown_direction, neighbor in _neighbors(position)
+            if neighbor not in self._grid
+        ]
+        if not frontiers:
+            return _RIGHT
+        _, frontier, frontier_direction = min(frontiers)
+        if frontier != self._position:
+            action = self._navigate(frontier, direction)
+            if action is not None:
+                return action
+        turn = _turn_toward(direction, frontier_direction)
+        return _RIGHT if turn is None else turn
+
+    def _reachable_distances(self) -> dict[Position, int]:
+        queue: deque[Position] = deque((self._position,))
+        distances = {self._position: 0}
+        while queue:
+            current = queue.popleft()
+            for _, neighbor in _neighbors(current):
+                if neighbor in distances or not self._traversable(neighbor):
+                    continue
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+        return distances
+
+    def _traversable(self, position: Position) -> bool:
+        cell = self._grid.get(position)
+        return bool(
+            cell is not None
+            and (
+                cell[0]
+                in {
+                    self._objects["empty"],
+                    self._objects["floor"],
+                    self._objects["goal"],
+                }
+                or (
+                    cell[0] == self._objects["door"]
+                    and cell[2] == self._states["open"]
+                )
+            )
+        )
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    values = context.environment_parameters
+    objects = values.get("object_encoding")
+    colors = values.get("color_encoding")
+    states = values.get("state_encoding")
+    view_size = values.get("view_size")
+    agent_position = values.get("agent_view_position")
+    object_names = {
+        "unseen",
+        "empty",
+        "wall",
+        "floor",
+        "door",
+        "key",
+        "ball",
+        "box",
+        "goal",
+        "lava",
+        "agent",
+    }
+    if (
+        type(objects) is not dict
+        or set(objects) != object_names
+        or any(type(value) is not int for value in objects.values())
+    ):
+        raise ValueError("object_encoding is invalid")
+    if (
+        type(colors) is not dict
+        or set(colors)
+        != {"red", "green", "blue", "purple", "yellow", "grey"}
+        or any(type(value) is not int for value in colors.values())
+    ):
+        raise ValueError("color_encoding is invalid")
+    if (
+        type(states) is not dict
+        or set(states) != {"open", "closed", "locked"}
+        or any(type(value) is not int for value in states.values())
+    ):
+        raise ValueError("state_encoding is invalid")
+    if type(view_size) is not int or view_size != 7:
+        raise ValueError("view_size is invalid")
+    if type(agent_position) is not list or agent_position != [3, 6]:
+        raise ValueError("agent_view_position is invalid")
+    return BaselinePolicy(
+        object_encoding={
+            key: cast(int, value) for key, value in objects.items()
+        },
+        color_encoding={
+            key: cast(int, value) for key, value in colors.items()
+        },
+        state_encoding={
+            key: cast(int, value) for key, value in states.items()
+        },
+        view_size=view_size,
+        agent_view_position=(3, 6),
+    )
+
+
+def _neighbors(position: Position) -> tuple[tuple[int, Position], ...]:
+    return tuple(
+        (
+            direction,
+            (position[0] + delta[0], position[1] + delta[1]),
+        )
+        for direction, delta in enumerate(_VECTORS)
+    )
+
+
+def _direction_between(start: Position, end: Position) -> int:
+    delta = (end[0] - start[0], end[1] - start[1])
+    try:
+        return _VECTORS.index(delta)
+    except ValueError as error:
+        raise ValueError("positions must be cardinally adjacent") from error
+
+
+def _turn_toward(current: int, target: int) -> int | None:
+    delta = (target - current) % 4
+    if delta == 0:
+        return None
+    return _LEFT if delta == 3 else _RIGHT
+
+
+def _reconstruct(
+    previous: dict[Position, Position | None],
+    destination: Position,
+) -> tuple[Position, ...]:
+    path: list[Position] = []
+    current: Position | None = destination
+    while current is not None:
+        path.append(current)
+        current = previous[current]
+    path.reverse()
+    return tuple(path[1:])

--- a/environments/minigrid/minigrid/unlock_pickup/tests/test_unlock_pickup.py
+++ b/environments/minigrid/minigrid/unlock_pickup/tests/test_unlock_pickup.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeRecord,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from minigrid_unlock_pickup import UnlockPickupBenchmark, baseline_program
+
+
+class UnlockPickupTests(unittest.TestCase):
+    def test_spec_and_split_planning(self) -> None:
+        benchmark = UnlockPickupBenchmark()
+        self.assertEqual(
+            benchmark.spec.id,
+            "minigrid/UnlockPickup-v0/success-rate-v1",
+        )
+        self.assertEqual(benchmark.spec.max_episode_steps, 288)
+        train = tuple(benchmark.episodes("train", seed=7, count=10))
+        test = tuple(benchmark.episodes("test", seed=7, count=10))
+        self.assertTrue(
+            {item.environment_seed for item in train}.isdisjoint(
+                item.environment_seed for item in test
+            )
+        )
+
+    def test_environment_contract_and_invalid_action(self) -> None:
+        benchmark = UnlockPickupBenchmark()
+        report = check_benchmark(
+            benchmark,
+            fixtures=(
+                BenchmarkFixture(
+                    episode=EpisodeSpec(environment_seed=123),
+                    actions=(0, 1, 2, 5, 6),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, dict)
+            assert isinstance(observation, dict)
+            self.assertIsInstance(observation["image"], TensorValue)
+            with self.assertRaises(InvalidAction):
+                environment.step(7)
+        finally:
+            environment.close()
+
+    def test_scenario_and_feedback_privacy(self) -> None:
+        with self.assertRaises(ValueError):
+            UnlockPickupBenchmark().make_environment(
+                EpisodeSpec(environment_seed=1, scenario={"size": 8})
+            )
+        failed = EpisodeRecord(
+            episode=EpisodeSpec(environment_seed=11),
+            policy_seed=21,
+            initial_observation=_empty_observation(),
+            transitions=(),
+            policy_failure="invalid_action",
+        )
+        trace = (
+            UnlockPickupBenchmark()
+            .feedback((failed,))
+            .artifacts[0]
+            .read_bytes()
+        )
+        self.assertNotIn(b"environment_seed", trace)
+        self.assertNotIn(b"policy_seed", trace)
+
+    def test_baseline_solves_task(self) -> None:
+        result = evaluate(
+            baseline_program(),
+            UnlockPickupBenchmark(),
+            execution=ProcessExecution.unsafe(),
+            config=EvaluationConfig(
+                split="validation",
+                episodes=12,
+                seed=5,
+                episode_timeout_seconds=10,
+            ),
+        )
+        self.assertEqual(result.feedback.score, 1.0)
+        self.assertIsInstance(result.feedback.content, dict)
+        assert isinstance(result.feedback.content, dict)
+        for name in (
+            "key_picked_up_rate",
+            "door_opened_rate",
+            "target_found_rate",
+        ):
+            self.assertEqual(result.feedback.content[name], 1.0)
+
+
+def _empty_observation() -> dict[str, PolicyValue]:
+    return {
+        "image": TensorValue(
+            dtype="uint8",
+            shape=(7, 7, 3),
+            data=bytes(147),
+        ),
+        "direction": 0,
+        "mission": "pick up the purple box",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/minigrid/minigrid/unlock_pickup/uv.lock
+++ b/environments/minigrid/minigrid/unlock_pickup/uv.lock
@@ -1,0 +1,243 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-minigrid-unlock-pickup"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "minigrid" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "minigrid", specifier = ">=3.1.0,<4" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "minigrid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/1d/4d44d1b30dbd33ce1de24846cc0153d78974d80cbcdfcf95e5230fa75d0b/minigrid-3.1.0.tar.gz", hash = "sha256:6b3980015a7fa99d6a7d4597d54f18d943f78309bfb75056d79e80af3bc356ae", size = 106784, upload-time = "2026-05-11T09:08:31.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/78/c9c3ea97f2abc21d180d4b8443a7c2841b6de92036678ec995453ec76fa0/minigrid-3.1.0-py3-none-any.whl", hash = "sha256:e8365f99d9369dd854bee08cef6352841b66ca16e2bf0eaa6218f02bcfb1c457", size = 140068, upload-time = "2026-05-11T09:08:30.551Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
## Purpose

Add the standard MiniGrid collection as independently installable EvoPolicyGym
Benchmark distributions. This is stack 1 of 5.

## Changes

- adds 21 MiniGrid family packages under `environments/minigrid/minigrid/`
- exposes typed Host-selected profiles through the public authoring SPI
- includes public Feedback, baseline Programs, lockfiles, package documentation,
  and conformance tests
- keeps the Kernel package unchanged

## Validation

- all 21 package test suites passed against real upstream reset/step behavior
- Ruff and strict mypy passed for every package
- all wheels and sdists built successfully
- repository-level Ruff, strict mypy, and 88 Kernel tests passed
- `git diff --check` passed

## Stack

Base: `main`

Next: `agent/minigrid-suites`
