### PR TITLE
benchmarks: add portable pixel suites

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,16 +11,18 @@ updates:
           - "*"
 
   - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      python:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "uv"
-    directory: "/environments/gymnasium/classic_control/cartpole"
+    directories:
+      - "/"
+      - "/environments/ale/*"
+      - "/environments/gymnasium/*/*"
+      - "/environments/gymnasium_robotics/*"
+      - "/environments/highway_env/*"
+      - "/environments/jackdaw/*"
+      - "/environments/metaworld/*"
+      - "/environments/minigrid/babyai"
+      - "/environments/minigrid/minigrid/*"
+      - "/environments/stable_retro/*"
+      - "/environments/vizdoom/*"
     schedule:
       interval: "weekly"
     groups:

--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ with a compatible Agent skill manager and invoke it as `$use-evopolicygym`.
 ## Environments
 
 Environment distributions are independent packages that depend only on the
-public EvoPolicyGym SDK. The Gymnasium collection covers all 23 current tasks
-in its four documented built-in suites; registered parameter variants are
-selected through each Benchmark's typed environment configuration.
+public EvoPolicyGym SDK. The catalog now spans Gymnasium, MiniGrid and BabyAI,
+HighwayEnv, Gymnasium-Robotics, MetaWorld, ALE, ViZDoom, Stable-Retro, and
+Balatro. Registered task, size, and difficulty variants are selected through
+each Benchmark's typed environment configuration. See the
+[complete integration ledger](environments/STATUS.md) for exact coverage and
+the environments intentionally deferred by ABI, runtime, or asset boundaries.
 
 | Collection | Contents | Description |
 | --- | --- | --- |
@@ -48,6 +51,13 @@ selected through each Benchmark's typed environment configuration.
 | [Gymnasium Classic Control](environments/gymnasium/classic_control/) | CartPole, Acrobot, both Mountain Car variants, and Pendulum | Five independently installable control Benchmarks with semantic observations and public traces |
 | [Gymnasium MuJoCo](environments/gymnasium/mujoco/) | All eleven current `v5` tasks | Parameterized continuous-control physics using official packaged models and semantic nested observations |
 | [Gymnasium Toy Text](environments/gymnasium/toy_text/) | Blackjack, CliffWalking, FrozenLake, and Taxi | All four standard Toy Text tasks with typed rule and dynamics parameters |
+| [MiniGrid](environments/minigrid/) | 21 standard families, all 22 WFC presets, and 40 requested BabyAI tasks | Partially observable language-conditioned navigation, procedural layouts, compositional instructions, and Episode-local memory |
+| [HighwayEnv](environments/highway_env/) | All ten canonical single-agent tasks | Discrete and continuous autonomous-driving profiles |
+| [Gymnasium-Robotics](environments/gymnasium_robotics/) | 21 Fetch, Maze, Adroit, Shadow Hand, and FrankaKitchen profiles | Goal-conditioned manipulation, navigation, touch sensing, and long-horizon robotics |
+| [MetaWorld](environments/metaworld/) | All 50 MT1 tasks, MT10, MT50, and custom collections | Host-selected single-task and multi-task manipulation |
+| [ALE](environments/ale/) | Redistributable Tetris profile | Atari RGB control without an external ROM dependency |
+| [ViZDoom](environments/vizdoom/) | 12 wheel-bundled standard scenarios | First-person RGB, game-variable, audio, and hybrid-action control |
+| [Stable-Retro](environments/stable_retro/) | Redistributable Airstriker Level 1 profile | Console RGB control without an external ROM dependency |
 | [Jackdaw](environments/jackdaw/) | Balatro | Unofficial long-horizon Red Deck, White Stake Benchmark powered by a pinned Jackdaw engine |
 | [Core16](https://linzwcs.github.io/EvoPolicyGym/results/) | [`v0.1.0` paper archive](https://github.com/Linzwcs/EvoPolicyGym/tree/v0.1.0) | The 16 control, navigation, driving, and robotics tasks used in the paper |
 

--- a/environments/README.md
+++ b/environments/README.md
@@ -6,36 +6,32 @@ upstream suite:
 
 ```text
 environments/
+├── ale/
+│   └── atari/
 ├── gymnasium/
 │   ├── box2d/
-│   │   ├── bipedal_walker/
-│   │   ├── car_racing/
-│   │   └── lunar_lander/
 │   ├── classic_control/
-│   │   ├── cartpole/
-│   │   ├── acrobot/
-│   │   ├── mountain_car/
-│   │   ├── mountain_car_continuous/
-│   │   └── pendulum/
 │   ├── mujoco/
-│   │   ├── ant/
-│   │   ├── half_cheetah/
-│   │   ├── hopper/
-│   │   ├── humanoid/
-│   │   ├── humanoid_standup/
-│   │   ├── inverted_double_pendulum/
-│   │   ├── inverted_pendulum/
-│   │   ├── pusher/
-│   │   ├── reacher/
-│   │   ├── swimmer/
-│   │   └── walker2d/
 │   └── toy_text/
-│       ├── blackjack/
-│       ├── cliff_walking/
-│       ├── frozen_lake/
-│       └── taxi/
-└── jackdaw/
-    └── balatro/
+├── gymnasium_robotics/
+│   └── robotics/
+├── highway_env/
+│   └── highway_env/
+├── jackdaw/
+│   └── balatro/
+├── metaworld/
+│   └── metaworld/
+├── minigrid/
+│   ├── babyai/
+│   └── minigrid/
+│       ├── blocked_unlock_pickup/
+│       ├── crossing/
+│       ├── ... 18 additional standard families ...
+│       └── wfc/
+├── stable_retro/
+│   └── airstriker/
+└── vizdoom/
+    └── vizdoom/
 ```
 
 Only leaf directories are Python projects. Collection directories do not own a
@@ -46,6 +42,11 @@ public Feedback, baseline Program, lockfile, and tests.
 
 The taxonomy describes source ownership and dependency provenance. It does not
 change public Python imports, distribution names, or Benchmark IDs.
+
+The [integration ledger](STATUS.md) records every planned environment,
+including exact task/profile coverage and the environments deferred because a
+multi-agent, Trial, browser, runtime, or redistributable-asset boundary is
+still absent.
 
 | Collection | Distribution | Import | Benchmark ID |
 | --- | --- | --- | --- |
@@ -73,6 +74,35 @@ change public Python imports, distribution names, or Benchmark IDs.
 | [Gymnasium / Toy Text](gymnasium/toy_text/) | `evopolicygym-benchmark-frozen-lake` | `frozen_lake` | `gymnasium/FrozenLake-v1/success-rate-v1` |
 | [Gymnasium / Toy Text](gymnasium/toy_text/) | `evopolicygym-benchmark-taxi` | `taxi` | `gymnasium/Taxi-v4/mean-return-v1` |
 | [Jackdaw / Balatro](jackdaw/) | `evopolicygym-benchmark-balatro` | `balatro` | `jackdaw/Balatro/red-deck-white-stake/run-score-v2` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/) | `evopolicygym-benchmark-minigrid-doorkey` | `minigrid_doorkey` | `minigrid/DoorKey-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/) | `evopolicygym-benchmark-minigrid-keycorridor` | `minigrid_keycorridor` | `minigrid/KeyCorridor-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/) | `evopolicygym-benchmark-minigrid-memory` | `minigrid_memory` | `minigrid/Memory-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/blocked_unlock_pickup/) | `evopolicygym-benchmark-minigrid-blocked-unlock-pickup` | `minigrid_blocked_unlock_pickup` | `minigrid/BlockedUnlockPickup-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/crossing/) | `evopolicygym-benchmark-minigrid-crossing` | `minigrid_crossing` | `minigrid/Crossing-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/dist_shift/) | `evopolicygym-benchmark-minigrid-dist-shift` | `minigrid_dist_shift` | `minigrid/DistShift-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/dynamic_obstacles/) | `evopolicygym-benchmark-minigrid-dynamic-obstacles` | `minigrid_dynamic_obstacles` | `minigrid/DynamicObstacles-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/empty/) | `evopolicygym-benchmark-minigrid-empty` | `minigrid_empty` | `minigrid/Empty-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/fetch/) | `evopolicygym-benchmark-minigrid-fetch` | `minigrid_fetch` | `minigrid/Fetch-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/four_rooms/) | `evopolicygym-benchmark-minigrid-four-rooms` | `minigrid_four_rooms` | `minigrid/FourRooms-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/go_to_door/) | `evopolicygym-benchmark-minigrid-go-to-door` | `minigrid_go_to_door` | `minigrid/GoToDoor-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/go_to_object/) | `evopolicygym-benchmark-minigrid-go-to-object` | `minigrid_go_to_object` | `minigrid/GoToObject-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/lava_gap/) | `evopolicygym-benchmark-minigrid-lava-gap` | `minigrid_lava_gap` | `minigrid/LavaGap-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/locked_room/) | `evopolicygym-benchmark-minigrid-locked-room` | `minigrid_locked_room` | `minigrid/LockedRoom-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/multiroom/) | `evopolicygym-benchmark-minigrid-multiroom` | `minigrid_multiroom` | `minigrid/MultiRoom-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/obstructed_maze/) | `evopolicygym-benchmark-minigrid-obstructed-maze` | `minigrid_obstructed_maze` | `minigrid/ObstructedMaze-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/playground/) | `evopolicygym-benchmark-minigrid-playground` | `minigrid_playground` | `minigrid/Playground-v0/room-coverage-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/put_near/) | `evopolicygym-benchmark-minigrid-put-near` | `minigrid_put_near` | `minigrid/PutNear-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/red_blue_doors/) | `evopolicygym-benchmark-minigrid-red-blue-doors` | `minigrid_red_blue_doors` | `minigrid/RedBlueDoors-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/unlock/) | `evopolicygym-benchmark-minigrid-unlock` | `minigrid_unlock` | `minigrid/Unlock-v0/success-rate-v1` |
+| [MiniGrid / MiniGrid](minigrid/minigrid/unlock_pickup/) | `evopolicygym-benchmark-minigrid-unlock-pickup` | `minigrid_unlock_pickup` | `minigrid/UnlockPickup-v0/success-rate-v1` |
+| [MiniGrid / WFC](minigrid/minigrid/wfc/) | `evopolicygym-benchmark-minigrid-wfc` | `minigrid_wfc` | `minigrid/WFC-v0/success-rate-v1` |
+| [MiniGrid / BabyAI](minigrid/babyai/) | `evopolicygym-benchmark-minigrid-babyai` | `minigrid_babyai` | `minigrid/BabyAI-{family}-v0/success-rate-v1` |
+| [HighwayEnv](highway_env/highway_env/) | `evopolicygym-benchmark-highway-env` | `highway_benchmarks` | `highway-env/{environment_id}/mean-return-v1` |
+| [Gymnasium-Robotics](gymnasium_robotics/robotics/) | `evopolicygym-benchmark-gymnasium-robotics` | `robotics_benchmarks` | `gymnasium-robotics/{environment_id}/success-rate-v1` |
+| [MetaWorld](metaworld/metaworld/) | `evopolicygym-benchmark-metaworld` | `metaworld_benchmarks` | `metaworld/{collection}/success-rate-v1` |
+| [ALE Atari](ale/atari/) | `evopolicygym-benchmark-atari` | `atari_benchmarks` | `ale/Tetris-v5/mean-return-v1` |
+| [ViZDoom](vizdoom/vizdoom/) | `evopolicygym-benchmark-vizdoom` | `vizdoom_benchmarks` | `vizdoom/{environment_id}/mean-return-v1` |
+| [Stable-Retro](stable_retro/airstriker/) | `evopolicygym-benchmark-airstriker` | `airstriker` | `stable-retro/Airstriker-Genesis-v0/mean-score-delta-v1` |
 
 From the repository root, select one leaf project explicitly:
 

--- a/environments/STATUS.md
+++ b/environments/STATUS.md
@@ -1,0 +1,55 @@
+# Environment integration status
+
+This ledger covers the planned environment expansion. “Integrated” means an
+independently installable Benchmark distribution exists, uses only the public
+authoring SPI, owns a lockfile and tests, and has passed a real upstream
+`reset()`/`step()` smoke test. “Deferred” means the requested environment
+requires a Kernel capability that the current single-Policy ABI intentionally
+does not claim. “Unavailable” means upstream runtime or redistributable assets
+are absent; metadata-only registrations are not presented as runnable profiles.
+
+Profiles are public, typed Benchmark configuration selected by the Host before
+a Run. A selected profile is fixed for that Run, visible to the Coding Agent
+and Policy through `environment_parameters`, and contributes to the
+environment digest. Episode seeds and private scenario identity are not
+profiles and never cross the Policy boundary.
+
+## Integrated
+
+| Ecosystem | Coverage | Distribution layout |
+| --- | --- | --- |
+| Standard MiniGrid | 19 requested tasks across 18 families: Fetch, MultiRoom, DynamicObstacles, ObstructedMazeFull and ObstructedMazeDlhb, PutNear, RedBlueDoors, BlockedUnlockPickup, UnlockPickup, Unlock, LockedRoom, Crossing, LavaGap, DistShift, GoToObject, GoToDoor, FourRooms, Playground, and Empty | One leaf distribution per family under [`minigrid/minigrid/`](minigrid/minigrid/); registered sizes and difficulty variants are profiles |
+| MiniGrid WFC | All 22 requested presets: MazeSimple, DungeonMazeScaled, RoomsFabric, ObstaclesBlackdots, ObstaclesAngular, ObstaclesHogs2, ObstaclesHogs3, MazeKnot, MazeWall, Maze, MazeSpirals, MazePaths, Mazelike, RoomsOffice, RoomsMagicOffice, Dungeon, DungeonRooms, DungeonLessRooms, DungeonSpirals, Skew2, SkewCave, and SkewLake | [`minigrid/minigrid/wfc/`](minigrid/minigrid/wfc/) |
+| BabyAI | All 40 requested tasks: GoToRedBallGrey, GoToRedBall, GoToRedBallNoDists, GoToObj, GoToLocal, GoTo, GoToImpUnlock, GoToSeq, GoToRedBlueBall, GoToDoor, GoToObjDoor, Open, OpenRedDoor, OpenDoor, OpenTwoDoors, OpenDoorsOrder, Pickup, UnblockPickup, PickupLoc, PickupDist, PickupAbove, PutNextLocal, PutNext, Unlock, UnlockLocal, KeyInBox, UnlockPickup, BlockedUnlockPickup, UnlockToUnlock, ActionObjDoor, FindObj, KeyCorridor, OneRoom, MoveTwoAcross, Synth, SynthLoc, SynthSeq, MiniBossLevel, BossLevel, and BossLevelNoUnlock | [`minigrid/babyai/`](minigrid/babyai/) |
+| HighwayEnv | Highway, Merge, Roundabout, Intersection, TwoWay, Exit, UTurn, Parking, Racetrack, and LaneKeeping | [`highway_env/highway_env/`](highway_env/highway_env/) |
+| Gymnasium-Robotics | FetchReach, FetchPush, FetchSlide, FetchPickAndPlace, PointMaze, AntMaze, four Adroit Hand tasks, HandReach, Block/Egg/Pen manipulation with base, boolean-touch, and continuous-touch profiles, and FrankaKitchen (21 profiles) | [`gymnasium_robotics/robotics/`](gymnasium_robotics/robotics/) |
+| MetaWorld | All 50 MT1 `*-v3` tasks, MT10, MT50, and fixed custom MT collections | [`metaworld/metaworld/`](metaworld/metaworld/) |
+| ALE Atari | The wheel's redistributable Tetris ROM, RGB observations, and the minimal action set | [`ale/atari/`](ale/atari/) |
+| ViZDoom | 12 standard scenarios whose configs and WADs ship in ViZDoom: Basic, Audio, Notifications, DeadlyCorridor, Deathmatch, DefendCenter, DefendLine, HealthGathering, HealthGatheringSupreme, MyWayHome, PredictPosition, and TakeCover | [`vizdoom/vizdoom/`](vizdoom/vizdoom/) |
+| Stable-Retro | The wheel's redistributable Airstriker Level 1 ROM/state and restricted discrete controller actions | [`stable_retro/airstriker/`](stable_retro/airstriker/) |
+
+## Deferred by an explicit Kernel boundary
+
+| Requested environments | Required capability | Why they are not represented as single-agent profiles |
+| --- | --- | --- |
+| MaMuJoCo | Multi-agent lifecycle and joint-action ABI | One Policy action and one observation cannot faithfully encode independently addressed agents |
+| MPE2: Simple, SimpleAdversary, SimpleCrypto, SimpleFormation, SimpleLine, SimplePush, SimpleReference, SimpleSpeakerListener, SimpleSpread, SimpleTag, SimpleWorldComm, CollectTreasure | Multi-agent lifecycle and joint-action ABI | Parallel agents, per-agent observations/actions, termination, and rewards need a first-class contract |
+| PettingZoo Classic: TicTacToe, ConnectFour, Chess, Go, RockPaperScissors, LeducHoldem, TexasHoldem, TexasHoldemNoLimit, GinRummy, Hanabi | AEC/parallel multi-agent ABI | Flattening turn ownership into the current action ABI would hide invalid-action and lifecycle semantics |
+| PettingZoo Butterfly/SISL: CooperativePong, KnightsArchersZombies, Pistonball, Multiwalker, Pursuit | Parallel multi-agent ABI | Joint actions and per-agent termination/reward semantics are required |
+| MetaWorld ML1, ML10, ML45 | Trial abstraction | Meta-learning support/query phases must not be confused with ordinary independent Episodes |
+| MiniWoB++ original, no-delay, transfer, email, flight, and hidden-test suites | Whole-Run virtualization and a browser execution profile | Browser processes, web assets, and hidden server state need Host-owned lifecycle and isolation |
+
+## Unavailable in the current portable runtime
+
+| Requested environments | Result of integration attempt |
+| --- | --- |
+| Procgen's 16 games: BigFish, BossFight, CaveFlyer, Chaser, Climber, CoinRun, Dodgeball, FruitBot, Heist, Jumper, Leaper, Maze, Miner, Ninja, Plunder, and StarPilot | The currently published `procgen2` artifacts do not support this repository's Python 3.12/macOS ARM runtime (the available wheel is CPython 3.11 Linux x86-64 and no source distribution is published). Revisit with a maintained runtime or Docker execution profile. |
+| Remaining ALE registrations | ALE 0.12.0 registers 104 environments, but its current wheel supplies a directly runnable ROM only for Tetris. The other 103 registrations fail without separately obtained ROMs. |
+| Commercial ViZDoom maps | ViZDoom does not distribute commercial Doom/Doom II IWADs. Metadata or a Host-local WAD path is not a portable Benchmark distribution. |
+| Remaining Stable-Retro integrations | Stable-Retro 1.0.1 ships 1,030 integration definitions but a redistributable ROM only for Airstriker. The other integrations require externally supplied ROMs. |
+
+Deferred and unavailable rows have been processed and intentionally skipped;
+they are not compatibility promises. A future implementation should add the
+missing Kernel capability or legal asset provisioning first, then introduce a
+new independent distribution with its own conformance and real-environment
+tests.

--- a/environments/ale/atari/.gitignore
+++ b/environments/ale/atari/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+dist/
+*.egg-info/
+__pycache__/
+*.pyc
+.mypy_cache/
+.ruff_cache/

--- a/environments/ale/atari/README.md
+++ b/environments/ale/atari/README.md
@@ -1,0 +1,20 @@
+# ALE Atari Benchmark
+
+ALE 0.12.0 registers 104 Atari v5 environments, but its current PyPI wheel
+ships a directly runnable ROM only for `Tetris`. This distribution therefore
+exposes exactly that redistributable profile and does not claim that proprietary
+ROMs are installed.
+
+```python
+from atari_benchmarks import AtariBenchmark, AtariConfig
+
+benchmark = AtariBenchmark(AtariConfig(game="Tetris"))
+```
+
+The profile uses RGB observations, the minimal five-action set, four-frame
+action repeat, sticky actions with probability 0.25, and a public 27,000-action
+horizon (108,000 emulator frames). Mean return is the primary metric.
+
+Additional games should become profiles only when their ROM distribution and CI
+availability are explicit. A local ROM directory is not accepted as Benchmark
+configuration because Host paths must not become portable Benchmark identity.

--- a/environments/ale/atari/pyproject.toml
+++ b/environments/ale/atari/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "evopolicygym-benchmark-atari"
+version = "0.1.0"
+description = "The redistributable ALE Atari profile for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "ale-py==0.12.0",
+    "gymnasium>=1.2.3,<2",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/atari_benchmarks"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/ale/atari/src/atari_benchmarks/__init__.py
+++ b/environments/ale/atari/src/atari_benchmarks/__init__.py
@@ -1,0 +1,12 @@
+"""Public redistributable ALE Atari Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import AtariBenchmark
+from .config import ATARI_PROFILES, AtariConfig
+
+__all__ = [
+    "ATARI_PROFILES",
+    "AtariBenchmark",
+    "AtariConfig",
+    "baseline_program",
+]

--- a/environments/ale/atari/src/atari_benchmarks/baseline.py
+++ b/environments/ale/atari/src/atari_benchmarks/baseline.py
@@ -1,0 +1,14 @@
+"""Packaged no-op starting Program for ALE Tetris."""
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    resource = files("atari_benchmarks").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]

--- a/environments/ale/atari/src/atari_benchmarks/benchmark.py
+++ b/environments/ale/atari/src/atari_benchmarks/benchmark.py
@@ -1,0 +1,200 @@
+"""Redistributable ALE Atari Benchmark."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+
+from .config import AtariConfig
+from .environment import AtariEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-ale-atari/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_EPISODE_STEPS = 27_000
+_MAX_TRACED_EPISODES = 4
+
+
+class AtariBenchmark:
+    """Mean return on the redistributable ALE Tetris profile."""
+
+    def __init__(self, config: AtariConfig | None = None) -> None:
+        if config is None:
+            config = AtariConfig()
+        if type(config) is not AtariConfig:
+            raise TypeError("config must be AtariConfig")
+        self._config = config
+        self._spec = _spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self, split: str, *, seed: int, count: int
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return AtariEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        floor = -float(_MAX_EPISODE_STEPS)
+        returns = tuple(
+            r.total_reward if r.policy_failure is None else floor
+            for r in records
+        )
+        score = statistics.fmean(returns)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Mean Tetris return {score:.3f} across "
+                    f"{len(records)} Episodes."
+                ),
+                "mean_return": score,
+                "mean_steps": statistics.fmean(r.steps for r in records),
+                "episodes": len(records),
+                "policy_failures": sum(
+                    r.policy_failure is not None for r in records
+                ),
+                "failure_return": floor,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+            },
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec(config: AtariConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id=f"ale/{config.game}-v5/mean-return-v1",
+        description=(
+            "Play ALE Tetris from RGB observations using the minimal action "
+            "set. Maximize mean Episode return."
+        ),
+        observation_space={
+            "type": "tensor",
+            "dtype": "uint8",
+            "shape": [210, 160, 3],
+            "color_space": "RGB",
+        },
+        action_space={
+            "type": "discrete",
+            "values": [0, 1, 2, 3, 4],
+            "meaning": {
+                "0": "noop",
+                "1": "fire",
+                "2": "right",
+                "3": "left",
+                "4": "down",
+            },
+        },
+        metadata={
+            "environment": f"ALE/{config.game}-v5",
+            "provider": "ALE",
+            "upstream_version": "0.12.0",
+            "failure_return": -float(_MAX_EPISODE_STEPS),
+        },
+        environment_parameters={
+            "game": config.game,
+            "frameskip": 4,
+            "repeat_action_probability": 0.25,
+            "full_action_space": False,
+            "max_emulator_frames": 108_000,
+        },
+        max_episode_steps=_MAX_EPISODE_STEPS,
+        primary_metric="mean_return",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": record.total_reward,
+                    "failure": record.policy_failure,
+                }
+            )
+        )
+        for step_index, transition in enumerate(record.transitions):
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "reward": transition.step.reward,
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["AtariBenchmark"]

--- a/environments/ale/atari/src/atari_benchmarks/config.py
+++ b/environments/ale/atari/src/atari_benchmarks/config.py
@@ -1,0 +1,23 @@
+"""Typed redistributable ALE Atari configuration."""
+
+from dataclasses import dataclass
+
+ATARI_PROFILES = ("Tetris",)
+
+
+@dataclass(frozen=True, slots=True)
+class AtariConfig:
+    """Configuration fixing one redistributable Atari game."""
+
+    game: str = "Tetris"
+
+    def __post_init__(self) -> None:
+        if type(self.game) is not str:
+            raise TypeError("game must be an exact string")
+        if self.game not in ATARI_PROFILES:
+            raise ValueError(
+                "only the ROM-backed Tetris profile is currently portable"
+            )
+
+
+__all__ = ["ATARI_PROFILES", "AtariConfig"]

--- a/environments/ale/atari/src/atari_benchmarks/environment.py
+++ b/environments/ale/atari/src/atari_benchmarks/environment.py
@@ -1,0 +1,121 @@
+"""One fresh strict ALE Tetris instance per Episode."""
+
+from __future__ import annotations
+
+import math
+from typing import SupportsFloat, cast
+
+import ale_py
+import gymnasium
+import numpy
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+from gymnasium.spaces import Discrete
+
+from .config import AtariConfig
+
+gymnasium.register_envs(ale_py)
+
+_OBSERVATION_SHAPE = (210, 160, 3)
+_ACTIONS = frozenset(range(5))
+_MAX_EPISODE_STEPS = 27_000
+
+
+class AtariEnvironment:
+    """Seeded adapter around the redistributable ALE Tetris ROM."""
+
+    def __init__(self, episode: EpisodeSpec, *, config: AtariConfig) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not AtariConfig:
+            raise TypeError("config must be AtariConfig")
+        if episode.scenario is not None:
+            raise ValueError("Atari configuration belongs in AtariConfig")
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            gymnasium.make(
+                f"ALE/{config.game}-v5",
+                frameskip=4,
+                repeat_action_probability=0.25,
+                full_action_space=False,
+            ),
+        )
+        action_space = self._environment.action_space
+        if (
+            not isinstance(action_space, Discrete)
+            or action_space.n != len(_ACTIONS)
+            or action_space.start != 0
+        ):
+            self._environment.close()
+            raise RuntimeError("ALE minimal action space changed incompatibly")
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._steps = 0
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        self._started = True
+        return _observation(observation)
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or action not in _ACTIONS:
+            raise InvalidAction()
+        observation, reward, terminated, truncated, _ = (
+            self._environment.step(action)
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("ALE returned invalid termination flags")
+        self._steps += 1
+        if self._steps >= _MAX_EPISODE_STEPS and not terminated:
+            truncated = True
+        self._done = terminated or truncated
+        return Step(
+            observation=_observation(observation),
+            reward=_number(reward),
+            terminated=terminated,
+            truncated=truncated,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(value: object) -> TensorValue:
+    if (
+        type(value) is not numpy.ndarray
+        or value.dtype != numpy.dtype("uint8")
+        or value.shape != _OBSERVATION_SHAPE
+    ):
+        raise RuntimeError("ALE returned an invalid RGB observation")
+    return TensorValue(
+        dtype="uint8",
+        shape=_OBSERVATION_SHAPE,
+        data=numpy.ascontiguousarray(value).tobytes(order="C"),
+    )
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("ALE returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("ALE returned non-finite reward")
+    return number
+
+
+__all__ = ["AtariEnvironment"]

--- a/environments/ale/atari/src/atari_benchmarks/programs/baseline/policy.py
+++ b/environments/ale/atari/src/atari_benchmarks/programs/baseline/policy.py
@@ -1,0 +1,16 @@
+"""An intentionally weak no-op ALE baseline."""
+
+from evopolicygym.policy import PolicyContext, PolicyValue
+
+
+class BaselinePolicy:
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        del observation
+        return 0
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    game = context.environment_parameters.get("game")
+    if game != "Tetris":
+        raise ValueError("game is invalid")
+    return BaselinePolicy()

--- a/environments/ale/atari/tests/test_atari_benchmark.py
+++ b/environments/ale/atari/tests/test_atari_benchmark.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.policy import TensorValue
+
+from atari_benchmarks import AtariBenchmark, AtariConfig, baseline_program
+
+
+class AtariBenchmarkTests(unittest.TestCase):
+    def test_tetris_resets_and_steps(self) -> None:
+        benchmark = AtariBenchmark()
+        environment = benchmark.make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, TensorValue)
+            assert isinstance(observation, TensorValue)
+            self.assertEqual(observation.shape, (210, 160, 3))
+            step = environment.step(0)
+            self.assertIsInstance(step.reward, float)
+        finally:
+            environment.close()
+            environment.close()
+
+    def test_non_portable_game_and_invalid_action_are_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            AtariConfig(game="Breakout")
+        environment = AtariBenchmark().make_environment(
+            EpisodeSpec(environment_seed=1)
+        )
+        try:
+            environment.reset()
+            with self.assertRaises(InvalidAction):
+                environment.step(True)
+        finally:
+            environment.close()
+
+    def test_baseline_is_packaged(self) -> None:
+        self.assertIn("policy.py", baseline_program().files)
+
+    def test_replay_conformance(self) -> None:
+        report = check_benchmark(
+            AtariBenchmark(),
+            fixtures=(
+                BenchmarkFixture(
+                    EpisodeSpec(environment_seed=123),
+                    (0,),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/ale/atari/uv.lock
+++ b/environments/ale/atari/uv.lock
@@ -1,0 +1,230 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ale-py"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f2/4256e8074df976edd3ba28be9b6a2f4b3fc47632134dabfead41d32b51be/ale_py-0.12.0.tar.gz", hash = "sha256:6030416b6a049d399bf95420ad2fdbf0ea8f83051b502774d27b477a06000dbc", size = 19597784, upload-time = "2026-05-30T22:37:38.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/15/ee091176ea850ca2242420cc9d5f8f94b9e037793926e7c5e6bfecb18684/ale_py-0.12.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b0716abea9ed5e1f0d3c0fd08820226458be1b568d25e9e969b22774a993f3d3", size = 2199417, upload-time = "2026-05-30T22:37:19.222Z" },
+    { url = "https://files.pythonhosted.org/packages/49/22/fb5aeedccc24c23063edbfa6ab135f620211a9da25c2dcbeecd326ee2490/ale_py-0.12.0-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:18ab4d89639c2c39f73cf9e15f7c14de9cde57252deee67964a91261b6ca6181", size = 2074353, upload-time = "2026-05-30T22:37:20.651Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/2a53135d0a4f9bc2f383204e8e076855f9fbcaee6968b898af981f79d60e/ale_py-0.12.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c9f956ba56404c47103f35cfda3333ddd703c43a36589fa95515a08034a33af", size = 2946702, upload-time = "2026-05-30T22:37:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/77/23/7cb1ea63c3694de96c3b3201dcc361c10bb8acf2d81ac8ff31beb25b9241/ale_py-0.12.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e211044d60bed30720b71e71f003e42dabb0b7f0a6c03be6b70d3b4650de0dad", size = 3087155, upload-time = "2026-05-30T22:37:23.224Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e9/7d9dc3ae2e1025b97a28c80fb381ab2c4ce216ac5a09e0268c3a5a915ab9/ale_py-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:847f766c2712d67ab66bb90e1c9ca1fbd0a63e940258bd82c4b4d96c5d950eca", size = 1751212, upload-time = "2026-05-30T22:37:24.641Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-atari"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "ale-py" },
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "ale-py", specifier = "==0.12.0" },
+    { name = "evopolicygym", editable = "../../../" },
+    { name = "gymnasium", specifier = ">=1.2.3,<2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/stable_retro/airstriker/.gitignore
+++ b/environments/stable_retro/airstriker/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+dist/
+*.egg-info/
+__pycache__/
+*.pyc
+.mypy_cache/
+.ruff_cache/

--- a/environments/stable_retro/airstriker/README.md
+++ b/environments/stable_retro/airstriker/README.md
@@ -1,0 +1,17 @@
+# Stable-Retro Airstriker Benchmark
+
+Stable-Retro 1.0.1 provides metadata for 1,030 game integrations, but only
+Airstriker includes a redistributable ROM in the wheel. This distribution
+therefore exposes exactly `Airstriker-Genesis-v0`; it neither accepts Host ROM
+paths nor claims that proprietary games are installed.
+
+```python
+from airstriker import AirstrikerBenchmark
+
+benchmark = AirstrikerBenchmark()
+```
+
+The Policy receives 224 × 320 RGB frames and returns one of Stable-Retro's 126
+restricted discrete controller actions. The Episode starts from the bundled
+Level 1 state, ends on the upstream game-over condition, and has a public
+18,000-frame fallback horizon. Mean score delta is the primary metric.

--- a/environments/stable_retro/airstriker/pyproject.toml
+++ b/environments/stable_retro/airstriker/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "evopolicygym-benchmark-airstriker"
+version = "0.1.0"
+description = "The redistributable Stable-Retro Airstriker Benchmark for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "gymnasium>=1.3.0,<2",
+    "stable-retro==1.0.1",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/airstriker"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/stable_retro/airstriker/src/airstriker/__init__.py
+++ b/environments/stable_retro/airstriker/src/airstriker/__init__.py
@@ -1,0 +1,11 @@
+"""Public redistributable Stable-Retro Airstriker Benchmark."""
+
+from .baseline import baseline_program
+from .benchmark import AirstrikerBenchmark
+from .config import AirstrikerConfig
+
+__all__ = [
+    "AirstrikerBenchmark",
+    "AirstrikerConfig",
+    "baseline_program",
+]

--- a/environments/stable_retro/airstriker/src/airstriker/baseline.py
+++ b/environments/stable_retro/airstriker/src/airstriker/baseline.py
@@ -1,0 +1,14 @@
+"""Packaged no-op starting Program for Stable-Retro Airstriker."""
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    resource = files("airstriker").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]

--- a/environments/stable_retro/airstriker/src/airstriker/benchmark.py
+++ b/environments/stable_retro/airstriker/src/airstriker/benchmark.py
@@ -1,0 +1,211 @@
+"""Redistributable Stable-Retro Airstriker Benchmark."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+
+from .config import AirstrikerConfig
+from .environment import AirstrikerEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-stable-retro-airstriker/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_EPISODE_STEPS = 18_000
+_MAX_TRACED_EPISODES = 4
+
+
+class AirstrikerBenchmark:
+    """Mean score delta on Stable-Retro's redistributable Airstriker game."""
+
+    def __init__(self, config: AirstrikerConfig | None = None) -> None:
+        if config is None:
+            config = AirstrikerConfig()
+        if type(config) is not AirstrikerConfig:
+            raise TypeError("config must be AirstrikerConfig")
+        self._config = config
+        self._spec = _spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self, split: str, *, seed: int, count: int
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return AirstrikerEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        floor = -float(_MAX_EPISODE_STEPS)
+        returns = tuple(
+            record.total_reward
+            if record.policy_failure is None
+            else floor
+            for record in records
+        )
+        score = statistics.fmean(returns)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Mean Airstriker score delta {score:.3f} across "
+                    f"{len(records)} Episodes."
+                ),
+                "mean_score_delta": score,
+                "mean_steps": statistics.fmean(r.steps for r in records),
+                "episodes": len(records),
+                "policy_failures": sum(
+                    r.policy_failure is not None for r in records
+                ),
+                "failure_score": floor,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+            },
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec(config: AirstrikerConfig) -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id="stable-retro/Airstriker-Genesis-v0/mean-score-delta-v1",
+        description=(
+            "Play the bundled Airstriker Level 1 from RGB observations using "
+            "Stable-Retro's restricted discrete controller actions. Maximize "
+            "mean score delta."
+        ),
+        observation_space={
+            "type": "tensor",
+            "dtype": "uint8",
+            "shape": [224, 320, 3],
+            "color_space": "RGB",
+        },
+        action_space={
+            "type": "discrete",
+            "start": 0,
+            "count": 126,
+            "controller_buttons": [
+                "B",
+                "A",
+                "MODE",
+                "START",
+                "UP",
+                "DOWN",
+                "LEFT",
+                "RIGHT",
+                "C",
+                "Y",
+                "X",
+                "Z",
+            ],
+            "restricted_actions": "DISCRETE",
+        },
+        metadata={
+            "environment": config.game,
+            "provider": "Stable-Retro",
+            "upstream_version": "1.0.1",
+            "failure_score": -float(_MAX_EPISODE_STEPS),
+        },
+        environment_parameters={
+            "game": config.game,
+            "state": config.state,
+            "restricted_actions": "DISCRETE",
+            "max_emulator_frames": _MAX_EPISODE_STEPS,
+        },
+        max_episode_steps=_MAX_EPISODE_STEPS,
+        primary_metric="mean_score_delta",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "score_delta": record.total_reward,
+                    "failure": record.policy_failure,
+                }
+            )
+        )
+        for step_index, transition in enumerate(record.transitions):
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "reward": transition.step.reward,
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["AirstrikerBenchmark"]

--- a/environments/stable_retro/airstriker/src/airstriker/config.py
+++ b/environments/stable_retro/airstriker/src/airstriker/config.py
@@ -1,0 +1,24 @@
+"""Typed Stable-Retro Airstriker configuration."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class AirstrikerConfig:
+    """Configuration fixing the one redistributable Stable-Retro game."""
+
+    game: str = "Airstriker-Genesis-v0"
+    state: str = "Level1"
+
+    def __post_init__(self) -> None:
+        if type(self.game) is not str:
+            raise TypeError("game must be an exact string")
+        if self.game != "Airstriker-Genesis-v0":
+            raise ValueError("only the ROM-backed Airstriker game is portable")
+        if type(self.state) is not str:
+            raise TypeError("state must be an exact string")
+        if self.state != "Level1":
+            raise ValueError("only the bundled Level1 state is supported")
+
+
+__all__ = ["AirstrikerConfig"]

--- a/environments/stable_retro/airstriker/src/airstriker/environment.py
+++ b/environments/stable_retro/airstriker/src/airstriker/environment.py
@@ -1,0 +1,126 @@
+"""One fresh strict Stable-Retro Airstriker instance per Episode."""
+
+from __future__ import annotations
+
+import math
+from typing import SupportsFloat, cast
+
+import gymnasium
+import numpy
+import stable_retro  # type: ignore[import-untyped]
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+from gymnasium.spaces import Discrete
+
+from .config import AirstrikerConfig
+
+_OBSERVATION_SHAPE = (224, 320, 3)
+_ACTION_COUNT = 126
+_MAX_EPISODE_STEPS = 18_000
+
+
+class AirstrikerEnvironment:
+    """Seeded adapter around the bundled Airstriker ROM and Level 1 state."""
+
+    def __init__(
+        self,
+        episode: EpisodeSpec,
+        *,
+        config: AirstrikerConfig,
+    ) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not AirstrikerConfig:
+            raise TypeError("config must be AirstrikerConfig")
+        if episode.scenario is not None:
+            raise ValueError("Airstriker configuration belongs in its config")
+        self._seed = episode.environment_seed
+        self._environment = cast(
+            gymnasium.Env[object, int],
+            stable_retro.make(
+                game=config.game,
+                state=config.state,
+                render_mode="rgb_array",
+                use_restricted_actions=stable_retro.Actions.DISCRETE,
+            ),
+        )
+        action_space = self._environment.action_space
+        if (
+            not isinstance(action_space, Discrete)
+            or action_space.n != _ACTION_COUNT
+            or action_space.start != 0
+        ):
+            self._environment.close()
+            raise RuntimeError(
+                "Stable-Retro restricted action space changed incompatibly"
+            )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._steps = 0
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        self._started = True
+        return _observation(observation)
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        if type(action) is not int or not 0 <= action < _ACTION_COUNT:
+            raise InvalidAction()
+        observation, reward, terminated, truncated, _ = (
+            self._environment.step(action)
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("Stable-Retro returned invalid termination flags")
+        self._steps += 1
+        if self._steps >= _MAX_EPISODE_STEPS and not terminated:
+            truncated = True
+        self._done = terminated or truncated
+        return Step(
+            observation=_observation(observation),
+            reward=_number(reward),
+            terminated=terminated,
+            truncated=truncated,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _observation(value: object) -> TensorValue:
+    if (
+        type(value) is not numpy.ndarray
+        or value.dtype != numpy.dtype("uint8")
+        or value.shape != _OBSERVATION_SHAPE
+    ):
+        raise RuntimeError("Stable-Retro returned an invalid RGB observation")
+    return TensorValue(
+        dtype="uint8",
+        shape=_OBSERVATION_SHAPE,
+        data=numpy.ascontiguousarray(value).tobytes(order="C"),
+    )
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("Stable-Retro returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("Stable-Retro returned non-finite reward")
+    return number
+
+
+__all__ = ["AirstrikerEnvironment"]

--- a/environments/stable_retro/airstriker/src/airstriker/programs/baseline/policy.py
+++ b/environments/stable_retro/airstriker/src/airstriker/programs/baseline/policy.py
@@ -1,0 +1,17 @@
+"""An intentionally weak no-op Stable-Retro baseline."""
+
+from evopolicygym.policy import PolicyContext, PolicyValue
+
+
+class BaselinePolicy:
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        del observation
+        return 0
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    game = context.environment_parameters.get("game")
+    state = context.environment_parameters.get("state")
+    if game != "Airstriker-Genesis-v0" or state != "Level1":
+        raise ValueError("Airstriker environment parameters are invalid")
+    return BaselinePolicy()

--- a/environments/stable_retro/airstriker/tests/test_airstriker_benchmark.py
+++ b/environments/stable_retro/airstriker/tests/test_airstriker_benchmark.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.policy import TensorValue
+
+from airstriker import AirstrikerBenchmark, AirstrikerConfig, baseline_program
+
+
+class AirstrikerBenchmarkTests(unittest.TestCase):
+    def test_environment_resets_and_steps(self) -> None:
+        environment = AirstrikerBenchmark().make_environment(
+            EpisodeSpec(environment_seed=123)
+        )
+        try:
+            observation = environment.reset()
+            self.assertIsInstance(observation, TensorValue)
+            assert isinstance(observation, TensorValue)
+            self.assertEqual(observation.shape, (224, 320, 3))
+            step = environment.step(0)
+            self.assertIsInstance(step.reward, float)
+        finally:
+            environment.close()
+            environment.close()
+
+    def test_non_portable_game_and_invalid_action_are_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            AirstrikerConfig(game="SonicTheHedgehog-Genesis-v0")
+        environment = AirstrikerBenchmark().make_environment(
+            EpisodeSpec(environment_seed=1)
+        )
+        try:
+            environment.reset()
+            for invalid in (True, -1, 126):
+                with self.assertRaises(InvalidAction):
+                    environment.step(invalid)
+        finally:
+            environment.close()
+
+    def test_baseline_is_packaged(self) -> None:
+        self.assertIn("policy.py", baseline_program().files)
+
+    def test_replay_conformance(self) -> None:
+        report = check_benchmark(
+            AirstrikerBenchmark(),
+            fixtures=(
+                BenchmarkFixture(
+                    EpisodeSpec(environment_seed=123),
+                    (0,),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/stable_retro/airstriker/uv.lock
+++ b/environments/stable_retro/airstriker/uv.lock
@@ -1,0 +1,238 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-airstriker"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "gymnasium" },
+    { name = "stable-retro" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../" },
+    { name = "gymnasium", specifier = ">=1.3.0,<2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+    { name = "stable-retro", specifier = "==1.0.1" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pyglet"
+version = "1.5.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/c0/59130a7edbcc8f84e35870b00a712538ca05415ff02d17181277b8ef8f05/pyglet-1.5.31.zip", hash = "sha256:a5e422b4c27b0fc99e92103bf493109cca5c18143583b868b3b4631a98ae9417", size = 6900712, upload-time = "2024-12-24T07:10:58.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/43/46aa0ab49f2f5145d201780c7595cf0c305fb4fb5d00d6639792a3d0e770/pyglet-1.5.31-py3-none-any.whl", hash = "sha256:f68413564bbec380e4815898fef0fb7a4a494dc3f8718bfbf28ce2a802634c88", size = 1143660, upload-time = "2024-12-24T07:10:50.769Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "stable-retro"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "farama-notifications" },
+    { name = "gymnasium" },
+    { name = "pyglet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/70/44a58c6fe81aec4d83d85b9ed3d774aebc6e9fb8d81ea3542ea320ecebbb/stable_retro-1.0.1.tar.gz", hash = "sha256:68c43f2211f6314dc0727c2ad6cdefcc1c8621b7a38516c5afe15b523f3efcac", size = 152994540, upload-time = "2026-06-25T16:56:48.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/fa/281c7370d176f98979fb7ab0739c8eb88fb1a0086237983f13d741f880af/stable_retro-1.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:07e62a3a1a6733bbf39540fb7ffbcf3c5bcf488f59d588a39d3febc9fb4d19dc", size = 88644174, upload-time = "2026-06-25T16:56:06.801Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3d/5016f99a3c48ed0d25e3faae63651f811ea8abc9efa3e8a6905896969416/stable_retro-1.0.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:53c180f930b7bafed248064b8467773b980a37bb5b6555f0717c8555143c9d6f", size = 123169757, upload-time = "2026-06-25T16:56:14.219Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/environments/vizdoom/vizdoom/.gitignore
+++ b/environments/vizdoom/vizdoom/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+dist/
+*.egg-info/
+__pycache__/
+*.pyc
+.mypy_cache/
+.ruff_cache/
+_vizdoom.ini

--- a/environments/vizdoom/vizdoom/README.md
+++ b/environments/vizdoom/vizdoom/README.md
@@ -1,0 +1,21 @@
+# ViZDoom Benchmark
+
+This independent distribution exposes the 12 standard ViZDoom 1.3.0 scenarios
+whose WAD/config assets ship in the upstream wheel. The Host fixes one
+`ViZDoomConfig.profile` per Run.
+
+```python
+from vizdoom_benchmarks import ViZDoomBenchmark, ViZDoomConfig
+
+benchmark = ViZDoomBenchmark(ViZDoomConfig(profile="deadly-corridor"))
+```
+
+RGB frames, game variables, optional audio, and notifications cross the Policy
+boundary only as bounded values and canonical tensors. Most profiles use a
+strict discrete action. Deathmatch uses a strict object containing one discrete
+binary-button selection and three continuous delta controls.
+
+The primary metric is mean return. Feedback includes a bounded transition trace
+without frames, seeds, paths, or WAD identity. Commercial Doom/Doom2 map
+registrations are intentionally excluded because their WADs do not ship with
+ViZDoom. FreeDoom campaign maps can be added as a separate suite if desired.

--- a/environments/vizdoom/vizdoom/pyproject.toml
+++ b/environments/vizdoom/vizdoom/pyproject.toml
@@ -1,0 +1,56 @@
+[project]
+name = "evopolicygym-benchmark-vizdoom"
+version = "0.1.0"
+description = "The bundled ViZDoom scenarios for EvoPolicyGym."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = "MIT"
+authors = [{ name = "EvoPolicyGym contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "evopolicygym==0.3.*",
+    "vizdoom==1.3.0",
+]
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[project.optional-dependencies]
+dev = ["mypy==2.3.0", "ruff>=0.12.0"]
+
+[tool.uv]
+required-version = "==0.11.16"
+
+[tool.uv.sources]
+evopolicygym = { path = "../../..", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/vizdoom_benchmarks"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/README.md", "/pyproject.toml", "/src", "/tests"]
+exclude = ["**/__pycache__", "**/*.pyc"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+files = ["src", "tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/__init__.py
+++ b/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/__init__.py
@@ -1,0 +1,12 @@
+"""Public bundled ViZDoom Benchmark distribution."""
+
+from .baseline import baseline_program
+from .benchmark import ViZDoomBenchmark
+from .config import VIZDOOM_PROFILES, ViZDoomConfig
+
+__all__ = [
+    "VIZDOOM_PROFILES",
+    "ViZDoomBenchmark",
+    "ViZDoomConfig",
+    "baseline_program",
+]

--- a/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/baseline.py
+++ b/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/baseline.py
@@ -1,0 +1,14 @@
+"""Packaged no-op starting Program for ViZDoom."""
+
+from importlib.resources import as_file, files
+
+from evopolicygym import Program
+
+
+def baseline_program() -> Program:
+    resource = files("vizdoom_benchmarks").joinpath("programs", "baseline")
+    with as_file(resource) as directory:
+        return Program.from_directory(directory)
+
+
+__all__ = ["baseline_program"]

--- a/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/benchmark.py
+++ b/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/benchmark.py
@@ -1,0 +1,244 @@
+"""Bundled ViZDoom scenarios with bounded public traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    Artifact,
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.policy import PolicyValue
+
+from .config import ViZDoomConfig
+from .environment import ViZDoomEnvironment
+
+_SEED_DOMAIN = b"evopolicygym-vizdoom/episode-seed/v1\0"
+_SPLITS = frozenset({"train", "validation", "test"})
+_MAX_TRACED_EPISODES = 4
+
+
+class ViZDoomBenchmark:
+    """Mean return for one fixed bundled ViZDoom scenario."""
+
+    def __init__(self, config: ViZDoomConfig | None = None) -> None:
+        if config is None:
+            config = ViZDoomConfig()
+        if type(config) is not ViZDoomConfig:
+            raise TypeError("config must be ViZDoomConfig")
+        self._config = config
+        self._spec = _spec(config)
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return self._spec
+
+    def episodes(
+        self, split: str, *, seed: int, count: int
+    ) -> Sequence[EpisodeSpec]:
+        if type(split) is not str or split not in _SPLITS:
+            raise ValueError("split must be 'train', 'validation', or 'test'")
+        if type(seed) is not int or not 0 <= seed <= 2**64 - 1:
+            raise ValueError("seed must be an unsigned 64-bit integer")
+        if type(count) is not int or count <= 0:
+            raise ValueError("count must be a positive integer")
+        return tuple(
+            EpisodeSpec(environment_seed=_seed(split, seed, index))
+            for index in range(count)
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        return ViZDoomEnvironment(episode, config=self._config)
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        records = tuple(episodes)
+        if not records:
+            raise ValueError("episodes must be non-empty")
+        if any(type(record) is not EpisodeRecord for record in records):
+            raise TypeError("episodes must contain EpisodeRecord values")
+        floor = -float(self._config.max_episode_steps)
+        returns = tuple(
+            r.total_reward if r.policy_failure is None else floor
+            for r in records
+        )
+        score = statistics.fmean(returns)
+        traced = records[:_MAX_TRACED_EPISODES]
+        return Feedback(
+            score=score,
+            content={
+                "summary": (
+                    f"Mean return {score:.3f} across {len(records)} "
+                    f"{self._config.profile} Episodes."
+                ),
+                "mean_return": score,
+                "mean_steps": statistics.fmean(r.steps for r in records),
+                "episodes": len(records),
+                "terminated_episodes": sum(_terminated(r) for r in records),
+                "truncated_episodes": sum(_truncated(r) for r in records),
+                "policy_failures": sum(
+                    r.policy_failure is not None for r in records
+                ),
+                "failure_return": floor,
+                "traced_episodes": len(traced),
+                "trace_episodes_omitted": len(records) - len(traced),
+            },
+            artifacts=(_trace(traced),),
+        )
+
+
+def _spec(config: ViZDoomConfig) -> BenchmarkSpec:
+    fields: dict[str, PolicyValue] = {
+        "screen": {
+            "type": "tensor",
+            "dtype": "uint8",
+            "shape": [240, 320, 3],
+        }
+    }
+    if config.audio:
+        fields["audio"] = {
+            "type": "tensor",
+            "dtype": "int16",
+            "shape": [1260, 2],
+        }
+    if config.notifications:
+        fields["notifications"] = {"type": "string"}
+    if config.game_variables:
+        fields["gamevariables"] = {
+            "type": "tensor",
+            "dtype": "float32",
+            "shape": [config.game_variables],
+        }
+    action: PolicyValue
+    if config.hybrid_action:
+        action = {
+            "type": "object",
+            "fields": {
+                "binary": {
+                    "type": "discrete",
+                    "values": list(range(config.action_size)),
+                },
+                "continuous": {
+                    "type": "array",
+                    "shape": [3],
+                    "items": {"type": "finite_float32"},
+                },
+            },
+        }
+    else:
+        action = {
+            "type": "discrete",
+            "values": list(range(config.action_size)),
+        }
+    return BenchmarkSpec(
+        id=f"vizdoom/{config.environment_id}/mean-return-v1",
+        description=(
+            f"Control the agent in ViZDoom's {config.profile} scenario. "
+            "Maximize mean Episode return."
+        ),
+        observation_space={"type": "object", "fields": fields},
+        action_space=action,
+        metadata={
+            "environment": config.environment_id,
+            "provider": "ViZDoom",
+            "upstream_version": "1.3.0",
+            "failure_return": -float(config.max_episode_steps),
+        },
+        environment_parameters={
+            "profile": config.profile,
+            "action_size": config.action_size,
+            "hybrid_action": config.hybrid_action,
+            "rgb_resolution": [320, 240],
+        },
+        max_episode_steps=config.max_episode_steps,
+        primary_metric="mean_return",
+        score_direction="maximize",
+    )
+
+
+def _seed(split: str, seed: int, index: int) -> int:
+    digest = hashlib.sha256()
+    digest.update(_SEED_DOMAIN)
+    digest.update(split.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(seed.to_bytes(8, "big"))
+    digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+def _terminated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.terminated
+    )
+
+
+def _truncated(record: EpisodeRecord) -> bool:
+    return bool(
+        record.policy_failure is None
+        and record.transitions
+        and record.transitions[-1].step.truncated
+    )
+
+
+def _trace(records: Sequence[EpisodeRecord]) -> Artifact:
+    lines: list[bytes] = []
+    for episode_index, record in enumerate(records):
+        lines.append(
+            _json(
+                {
+                    "type": "episode",
+                    "episode_index": episode_index,
+                    "status": (
+                        "completed"
+                        if record.policy_failure is None
+                        else "policy_failed"
+                    ),
+                    "steps": record.steps,
+                    "return": record.total_reward,
+                    "failure": record.policy_failure,
+                }
+            )
+        )
+        for step_index, transition in enumerate(record.transitions):
+            lines.append(
+                _json(
+                    {
+                        "type": "transition",
+                        "episode_index": episode_index,
+                        "step_index": step_index,
+                        "action": transition.action,
+                        "reward": transition.step.reward,
+                        "terminated": transition.step.terminated,
+                        "truncated": transition.step.truncated,
+                    }
+                )
+            )
+    return Artifact(
+        name="trace.jsonl",
+        media_type="application/x-ndjson",
+        content=b"".join(lines),
+    )
+
+
+def _json(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8", errors="strict")
+
+
+__all__ = ["ViZDoomBenchmark"]

--- a/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/config.py
+++ b/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/config.py
@@ -1,0 +1,104 @@
+"""Typed Host-selected ViZDoom scenarios."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class _Profile:
+    environment_id: str
+    max_episode_steps: int
+    action_size: int
+    game_variables: int
+    audio: bool = False
+    notifications: bool = False
+    hybrid_action: bool = False
+
+
+_PROFILES = {
+    "basic": _Profile("VizdoomBasic-v1", 300, 4, 1),
+    "basic-audio": _Profile(
+        "VizdoomBasicAudio-v1", 300, 4, 1, audio=True
+    ),
+    "basic-notifications": _Profile(
+        "VizdoomBasicNotifications-v1",
+        300,
+        4,
+        1,
+        notifications=True,
+    ),
+    "deadly-corridor": _Profile(
+        "VizdoomDeadlyCorridor-v1", 2_100, 8, 1
+    ),
+    "deathmatch": _Profile(
+        "VizdoomDeathmatch-v1",
+        4_200,
+        18,
+        5,
+        hybrid_action=True,
+    ),
+    "defend-center": _Profile(
+        "VizdoomDefendCenter-v1", 2_100, 4, 2
+    ),
+    "defend-line": _Profile("VizdoomDefendLine-v1", 2_100, 4, 2),
+    "health-gathering": _Profile(
+        "VizdoomHealthGathering-v1", 2_100, 4, 1
+    ),
+    "health-gathering-supreme": _Profile(
+        "VizdoomHealthGatheringSupreme-v1", 2_100, 4, 1
+    ),
+    "my-way-home": _Profile("VizdoomMyWayHome-v1", 2_100, 6, 1),
+    "predict-position": _Profile(
+        "VizdoomPredictPosition-v1", 300, 4, 0
+    ),
+    "take-cover": _Profile("VizdoomTakeCover-v1", 2_100, 3, 1),
+}
+
+VIZDOOM_PROFILES = tuple(_PROFILES)
+
+
+@dataclass(frozen=True, slots=True)
+class ViZDoomConfig:
+    """Configuration fixing one bundled ViZDoom scenario."""
+
+    profile: str = "basic"
+
+    def __post_init__(self) -> None:
+        if type(self.profile) is not str:
+            raise TypeError("profile must be an exact string")
+        if self.profile not in _PROFILES:
+            raise ValueError(
+                "profile must be one of: " + ", ".join(VIZDOOM_PROFILES)
+            )
+
+    @property
+    def environment_id(self) -> str:
+        return _PROFILES[self.profile].environment_id
+
+    @property
+    def max_episode_steps(self) -> int:
+        return _PROFILES[self.profile].max_episode_steps
+
+    @property
+    def action_size(self) -> int:
+        return _PROFILES[self.profile].action_size
+
+    @property
+    def game_variables(self) -> int:
+        return _PROFILES[self.profile].game_variables
+
+    @property
+    def audio(self) -> bool:
+        return _PROFILES[self.profile].audio
+
+    @property
+    def notifications(self) -> bool:
+        return _PROFILES[self.profile].notifications
+
+    @property
+    def hybrid_action(self) -> bool:
+        return _PROFILES[self.profile].hybrid_action
+
+
+__all__ = ["VIZDOOM_PROFILES", "ViZDoomConfig"]

--- a/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/environment.py
+++ b/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/environment.py
@@ -1,0 +1,200 @@
+"""One fresh strict ViZDoom scenario per Episode."""
+
+from __future__ import annotations
+
+import math
+from typing import SupportsFloat, cast
+
+import gymnasium
+import numpy
+import vizdoom.gymnasium_wrapper  # noqa: F401  # Registers scenarios.
+from evopolicygym.authoring import EpisodeSpec, InvalidAction, Step
+from evopolicygym.policy import PolicyValue, TensorValue
+
+from .config import ViZDoomConfig
+
+_SCREEN_SHAPE = (240, 320, 3)
+_AUDIO_SHAPE = (1260, 2)
+_CONTINUOUS_LIMIT = float(numpy.finfo(numpy.float32).max)
+
+
+class ViZDoomEnvironment:
+    """Seeded adapter around one bundled ViZDoom scenario."""
+
+    def __init__(self, episode: EpisodeSpec, *, config: ViZDoomConfig) -> None:
+        if type(episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if type(config) is not ViZDoomConfig:
+            raise TypeError("config must be ViZDoomConfig")
+        if episode.scenario is not None:
+            raise ValueError(
+                "ViZDoom configuration belongs in ViZDoomConfig"
+            )
+        self._seed = episode.environment_seed
+        self._config = config
+        self._environment = cast(
+            gymnasium.Env[object, object],
+            gymnasium.make(config.environment_id),
+        )
+        self._started = False
+        self._done = False
+        self._closed = False
+        self._steps = 0
+
+    def reset(self) -> PolicyValue:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if self._started:
+            raise RuntimeError("Environment can be reset only once")
+        observation, _ = self._environment.reset(seed=self._seed)
+        self._started = True
+        return _observation(observation, config=self._config)
+
+    def step(self, action: PolicyValue) -> Step:
+        if self._closed:
+            raise RuntimeError("Environment is closed")
+        if not self._started:
+            raise RuntimeError("Environment must be reset before step")
+        if self._done:
+            raise RuntimeError("Episode is already complete")
+        applied = (
+            _hybrid_action(action, size=self._config.action_size)
+            if self._config.hybrid_action
+            else _discrete_action(action, size=self._config.action_size)
+        )
+        observation, reward, terminated, truncated, _ = (
+            self._environment.step(applied)
+        )
+        if type(terminated) is not bool or type(truncated) is not bool:
+            raise RuntimeError("ViZDoom returned invalid termination flags")
+        self._steps += 1
+        truncated = bool(
+            truncated
+            or (
+                self._steps == self._config.max_episode_steps
+                and not terminated
+            )
+        )
+        self._done = terminated or truncated
+        return Step(
+            observation=_observation(observation, config=self._config),
+            reward=_number(reward),
+            terminated=terminated,
+            truncated=truncated,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._environment.close()
+        self._closed = True
+
+
+def _discrete_action(value: PolicyValue, *, size: int) -> int:
+    if type(value) is not int or not 0 <= value < size:
+        raise InvalidAction()
+    return value
+
+
+def _hybrid_action(value: PolicyValue, *, size: int) -> dict[str, object]:
+    if type(value) is not dict or set(value) != {"binary", "continuous"}:
+        raise InvalidAction()
+    binary = value["binary"]
+    continuous = value["continuous"]
+    if type(binary) is not int or not 0 <= binary < size:
+        raise InvalidAction()
+    if type(continuous) is not list or len(continuous) != 3:
+        raise InvalidAction()
+    controls: list[float] = []
+    for item in continuous:
+        if (
+            type(item) is not float
+            or not math.isfinite(item)
+            or not -_CONTINUOUS_LIMIT <= item <= _CONTINUOUS_LIMIT
+        ):
+            raise InvalidAction()
+        controls.append(item)
+    return {
+        "binary": binary,
+        "continuous": numpy.asarray(controls, dtype=numpy.float32),
+    }
+
+
+def _observation(
+    value: object,
+    *,
+    config: ViZDoomConfig,
+) -> dict[str, PolicyValue]:
+    expected = {"screen"}
+    if config.audio:
+        expected.add("audio")
+    if config.notifications:
+        expected.add("notifications")
+    if config.game_variables:
+        expected.add("gamevariables")
+    if type(value) is not dict or set(value) != expected:
+        raise RuntimeError("ViZDoom returned an invalid observation")
+    public: dict[str, PolicyValue] = {
+        "screen": _tensor(
+            value["screen"],
+            dtype="uint8",
+            shape=_SCREEN_SHAPE,
+            name="screen",
+        )
+    }
+    if config.audio:
+        public["audio"] = _tensor(
+            value["audio"],
+            dtype="int16",
+            shape=_AUDIO_SHAPE,
+            name="audio",
+        )
+    if config.notifications:
+        notifications = value["notifications"]
+        if type(notifications) is not str:
+            raise RuntimeError("ViZDoom returned invalid notifications")
+        public["notifications"] = notifications
+    if config.game_variables:
+        public["gamevariables"] = _tensor(
+            value["gamevariables"],
+            dtype="float32",
+            shape=(config.game_variables,),
+            name="gamevariables",
+        )
+    return public
+
+
+def _tensor(
+    value: object,
+    *,
+    dtype: str,
+    shape: tuple[int, ...],
+    name: str,
+) -> TensorValue:
+    if (
+        type(value) is not numpy.ndarray
+        or value.dtype != numpy.dtype(dtype)
+        or value.shape != shape
+        or (
+            numpy.issubdtype(value.dtype, numpy.floating)
+            and not numpy.isfinite(value).all()
+        )
+    ):
+        raise RuntimeError(f"ViZDoom returned invalid {name}")
+    return TensorValue(
+        dtype=dtype,
+        shape=shape,
+        data=numpy.ascontiguousarray(value).tobytes(order="C"),
+    )
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, SupportsFloat):
+        raise RuntimeError("ViZDoom returned invalid reward")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RuntimeError("ViZDoom returned non-finite reward")
+    return number
+
+
+__all__ = ["ViZDoomEnvironment"]

--- a/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/programs/baseline/policy.py
+++ b/environments/vizdoom/vizdoom/src/vizdoom_benchmarks/programs/baseline/policy.py
@@ -1,0 +1,21 @@
+"""An intentionally weak no-op ViZDoom baseline."""
+
+from evopolicygym.policy import PolicyContext, PolicyValue
+
+
+class BaselinePolicy:
+    def __init__(self, hybrid: bool) -> None:
+        self._hybrid = hybrid
+
+    def act(self, observation: PolicyValue) -> PolicyValue:
+        del observation
+        if self._hybrid:
+            return {"binary": 0, "continuous": [0.0, 0.0, 0.0]}
+        return 0
+
+
+def make_policy(context: PolicyContext) -> BaselinePolicy:
+    hybrid = context.environment_parameters.get("hybrid_action")
+    if type(hybrid) is not bool:
+        raise ValueError("hybrid_action is invalid")
+    return BaselinePolicy(hybrid)

--- a/environments/vizdoom/vizdoom/tests/test_vizdoom_benchmarks.py
+++ b/environments/vizdoom/vizdoom/tests/test_vizdoom_benchmarks.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import unittest
+
+from evopolicygym.authoring import (
+    BenchmarkFixture,
+    EpisodeSpec,
+    InvalidAction,
+    check_benchmark,
+)
+from evopolicygym.policy import PolicyValue
+
+from vizdoom_benchmarks import (
+    VIZDOOM_PROFILES,
+    ViZDoomBenchmark,
+    ViZDoomConfig,
+    baseline_program,
+)
+
+
+class ViZDoomBenchmarkTests(unittest.TestCase):
+    def test_all_bundled_profiles_reset_and_step(self) -> None:
+        self.assertEqual(len(VIZDOOM_PROFILES), 12)
+        for profile in VIZDOOM_PROFILES:
+            with self.subTest(profile=profile):
+                config = ViZDoomConfig(profile=profile)
+                environment = ViZDoomBenchmark(
+                    config
+                ).make_environment(EpisodeSpec(environment_seed=123))
+                try:
+                    observation = environment.reset()
+                    self.assertIsInstance(observation, dict)
+                    action: PolicyValue = (
+                        {
+                            "binary": 0,
+                            "continuous": [0.0, 0.0, 0.0],
+                        }
+                        if config.hybrid_action
+                        else 0
+                    )
+                    step = environment.step(action)
+                    self.assertIsInstance(step.reward, float)
+                finally:
+                    environment.close()
+                    environment.close()
+
+    def test_profile_changes_environment_identity(self) -> None:
+        basic = ViZDoomBenchmark()
+        audio = ViZDoomBenchmark(ViZDoomConfig(profile="basic-audio"))
+        self.assertNotEqual(
+            basic.spec.environment_digest,
+            audio.spec.environment_digest,
+        )
+        self.assertEqual(audio.spec.max_episode_steps, 300)
+
+    def test_invalid_actions_are_rejected(self) -> None:
+        environment = ViZDoomBenchmark().make_environment(
+            EpisodeSpec(environment_seed=1)
+        )
+        try:
+            environment.reset()
+            with self.assertRaises(InvalidAction):
+                environment.step(True)
+        finally:
+            environment.close()
+
+        environment = ViZDoomBenchmark(
+            ViZDoomConfig(profile="deathmatch")
+        ).make_environment(EpisodeSpec(environment_seed=1))
+        try:
+            environment.reset()
+            with self.assertRaises(InvalidAction):
+                environment.step(
+                    {"binary": 0, "continuous": [0, 0, 0]}
+                )
+        finally:
+            environment.close()
+
+    def test_baseline_is_packaged(self) -> None:
+        self.assertIn("policy.py", baseline_program().files)
+
+    def test_replay_conformance(self) -> None:
+        report = check_benchmark(
+            ViZDoomBenchmark(),
+            fixtures=(
+                BenchmarkFixture(
+                    EpisodeSpec(environment_seed=123),
+                    (0,),
+                ),
+            ),
+        )
+        self.assertTrue(report.passed, report.issues)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/vizdoom/vizdoom/uv.lock
+++ b/environments/vizdoom/vizdoom/uv.lock
@@ -1,0 +1,244 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "evopolicygym"
+version = "0.3.0"
+source = { editable = "../../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "evopolicygym-benchmark-vizdoom"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "evopolicygym" },
+    { name = "vizdoom" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "evopolicygym", editable = "../../../" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+    { name = "vizdoom", specifier = "==1.3.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pygame-ce"
+version = "2.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0d/bb6a6fdf1b227c0bb9a44437a70962a3854bcc541533c261e5021a5ee691/pygame_ce-2.5.7.tar.gz", hash = "sha256:86beb797cd73c141299a29b56f7df2b0543fbdc81d428022458329ff694aaa51", size = 5935870, upload-time = "2026-03-02T09:26:59.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/cd305034f505bfa1a1acdafd3d86af54da14b29151a0d99f348306272773/pygame_ce-2.5.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dca2f8ba56bf3b4b8c73c4863d0603773403f4f66bc2fe25784ea74aee3fffc3", size = 17210332, upload-time = "2026-03-02T09:25:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989", size = 12709001, upload-time = "2026-03-02T09:25:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8b/a7886b7bfe874fa381201ee538928af3c1cab2fe3e36927ed08f3f1d0b61/pygame_ce-2.5.7-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:538689d77c44f5dbefc0abeab5b9806d6c90ebc6d64078736c8a4c731f08b37e", size = 13236706, upload-time = "2026-03-02T09:25:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb", size = 12812909, upload-time = "2026-03-02T09:25:59.971Z" },
+    { url = "https://files.pythonhosted.org/packages/40/db/1cfcfb7813ce6d2202919ad87c7e1b278a4f820902ba826df43dc8906e34/pygame_ce-2.5.7-cp312-cp312-win32.whl", hash = "sha256:604207c8813a594919bb7e6d3ed3834f79aa099d2d648e8a8fc3d786ad3fa1c8", size = 9837595, upload-time = "2026-03-02T09:26:02.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/43b006affa13e2f4572aa28a0d1f64c91c330d289c30a022b5416245714c/pygame_ce-2.5.7-cp312-cp312-win_amd64.whl", hash = "sha256:b6b7eec2779fac11ed265a18ab926b3829654120a5c9a07c36eeedeb012b8c3c", size = 10414958, upload-time = "2026-03-02T09:26:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/971a432d8bab8c52031ddbd0e681750a57348213ec0f8a0e0d6713e8df46/pygame_ce-2.5.7-cp312-cp312-win_arm64.whl", hash = "sha256:eb99a8a7185057064163610b3ca3e1d3307f0eb3dfff6e19556fa5132c6bca87", size = 10859829, upload-time = "2026-03-02T09:26:08.06Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "vizdoom"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gymnasium" },
+    { name = "numpy" },
+    { name = "pygame-ce" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/4c/3e8c51147f5da2f598c428d961ec916bda4fa56f9b369190d15359d390e2/vizdoom-1.3.0.tar.gz", hash = "sha256:591f58e3ad3d146c5b4a82eb51da064231a1a43a547c6255e9985eee20dbe601", size = 26687217, upload-time = "2026-02-11T13:33:58.241Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/8d/11cf6e63f17a912235811c554f14eba868bf776def77187dda82fd1f9788/vizdoom-1.3.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:aff3a01d9de4a1742e3f8f6b334ac77a8355f5c9c1dda1bdfd869140695d8025", size = 40776388, upload-time = "2026-02-11T13:33:15.968Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fd/d29eac65da0e87702589e79dc7315e5801d3a8bba215745725d8e89ad5a3/vizdoom-1.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d27c9b20a93a9cdc4331988914e0d75d0d61f1818444ee956948562b49ab4d74", size = 38731123, upload-time = "2026-02-11T13:33:18.777Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fd/34e5f1adf4598396ea229477e8748ed0a6d7b4d075f7e47f22e64eb9d598/vizdoom-1.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ba2524779d1ef0d7dfd773fe71a97afeff2b2d0db52a4d73381a515572c046", size = 38912318, upload-time = "2026-02-11T13:33:22.866Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f2/775cccb4ec637f8c75267edce065abfbea7c05f337303f872444eaf3e068/vizdoom-1.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:dde72da46a05725a4e0aa3a9d7291ae1486c8b7469a1b0a7d2fcc146bd913ae7", size = 26050543, upload-time = "2026-02-11T12:16:44.289Z" },
+]


### PR DESCRIPTION
## Purpose

Add portable pixel-control Benchmarks and publish the complete environment
integration ledger. This is stack 4 of 5.

## Changes

- adds redistributable ALE Tetris, ViZDoom, and Stable-Retro Airstriker packages
- validates the intended minimal/restricted action spaces
- documents exact profile coverage and intentionally deferred environments
- updates the root environment catalog and Dependabot discovery
- keeps the Kernel package unchanged

The GitHub Actions matrix is intentionally isolated in the follow-up
`agent/environment-ci` branch so this PR remains focused on Benchmark code and
catalog metadata.

## Validation

- all three packages passed real upstream reset/step and deterministic replay
  checks
- Ruff, strict mypy, package tests, and wheel/sdist builds passed
- all 29 new environment distributions built successfully
- repository-level Ruff, strict mypy, and 88 Kernel tests passed
- `git diff --check` passed

## Stack

Base: `agent/environment-suites`

Next: `agent/environment-ci`
