### PR TITLE
ci: test expanded environment catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,101 @@ jobs:
           uv run mypy
           uv run python -m unittest discover -s tests
           uv build
+
+  minigrid:
+    name: MiniGrid ${{ matrix.benchmark }} Benchmark (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        benchmark:
+          - blocked_unlock_pickup
+          - crossing
+          - dist_shift
+          - doorkey
+          - dynamic_obstacles
+          - empty
+          - fetch
+          - four_rooms
+          - go_to_door
+          - go_to_object
+          - keycorridor
+          - lava_gap
+          - locked_room
+          - memory
+          - multiroom
+          - obstructed_maze
+          - playground
+          - put_near
+          - red_blue_doors
+          - unlock
+          - unlock_pickup
+          - wfc
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv and Python 3.12
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.16"
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Sync locked Benchmark environment
+        run: >-
+          uv sync
+          --project environments/minigrid/minigrid/${{ matrix.benchmark }}
+          --locked
+          --extra dev
+
+      - name: Check and test external Benchmark
+        working-directory: environments/minigrid/minigrid/${{ matrix.benchmark }}
+        run: |
+          uv run ruff check src tests
+          uv run mypy
+          uv run python -m unittest discover -s tests
+          uv build
+
+  environment-suites:
+    name: ${{ matrix.project }} Benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - environments/ale/atari
+          - environments/gymnasium_robotics/robotics
+          - environments/highway_env/highway_env
+          - environments/metaworld/metaworld
+          - environments/minigrid/babyai
+          - environments/stable_retro/airstriker
+          - environments/vizdoom/vizdoom
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv and Python 3.12
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.16"
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Sync locked Benchmark environment
+        run: uv sync --project ${{ matrix.project }} --locked --extra dev
+
+      - name: Check, test, and build external Benchmark
+        working-directory: ${{ matrix.project }}
+        run: |
+          uv run ruff check src tests
+          uv run mypy
+          uv run python -m unittest discover -s tests
+          uv build


### PR DESCRIPTION
## Purpose

Run conformance checks for the expanded environment catalog in GitHub Actions.
This is stack 5 of 5 and contains no Benchmark implementation changes.

## Changes

- adds a MiniGrid matrix covering all 21 standard families and WFC
- adds suite jobs for BabyAI, HighwayEnv, Gymnasium-Robotics, MetaWorld, ALE,
  ViZDoom, and Stable-Retro
- runs locked sync, Ruff, strict mypy, unit tests, and package builds
- preserves the existing Kernel, CartPole, and Gymnasium collection jobs

## Validation

- workflow YAML parsed successfully
- every referenced project path has a checked lockfile
- all referenced package checks and builds passed locally
- `git diff --check` passed

## Stack

Base: `agent/pixel-environments`
