### PR TITLE
site: simplify footer metadata

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,11 +1,6 @@
----
-import { projectMeta } from "../data/project";
----
-
 <footer class="site-footer">
   <div class="footer-bottom">
     <span>MIT License</span>
-    <span>Protocol {projectMeta.protocolVersion}</span>
     <span>© {new Date().getFullYear()} EvoPolicyGym contributors</span>
   </div>
 </footer>


### PR DESCRIPTION
## Purpose

Keep the site footer focused on durable project information.

## Changes

- remove the `Protocol policy/v1` footer label
- remove the now-unused project metadata import

## Impact

The footer now contains only the MIT license and project copyright.

## Validation

- `cd site && npm run build`
- `git diff --check`
