### PR TITLE
agents: require Codex reasoning effort

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,6 +197,9 @@ The rules are:
   Skill to direct Evaluation or the Policy boundary;
 - provider packages translate the task into their own invocation but do not
   author the task or start and supervise the process themselves;
+- provider-specific experiment inputs such as the Codex model and reasoning
+  effort belong to the provider selection and retained Agent identity, not
+  `RunConfig` or `BenchmarkSpec`;
 - a small provider integration remains one cohesive module until its own
   responsibilities justify a package;
 - `_protocol` is pure bytes/value transformation and performs no I/O;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   snapshots. Runs may compose multiple Skills under read-only
   `workspace/skills/`, and `run-record/v5` retains their names and digests
   without coupling them to `BenchmarkSpec` or Policy processes.
+- Added required Codex `reasoning_effort` selection, deterministic CLI
+  translation, and retention in the Agent identity.
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,10 @@ from evopolicygym.skills import AgentSkill
 result = run(
     baseline_program(),
     CartPoleBenchmark(),
-    agent=Codex(model="gpt-5.6-luna"),
+    agent=Codex(
+        model="gpt-5.6-luna",
+        reasoning_effort="high",
+    ),
     execution=ProcessExecution.unsafe(),
     record_to="runs/cartpole-001",
     skills=(
@@ -185,6 +188,11 @@ result = run(
     observer=ConsoleProgress(),
 )
 ```
+
+`Codex.reasoning_effort` is a required provider-specific experiment input.
+The provider passes it to the Codex CLI as `model_reasoning_effort` and
+retains it in the Run's Agent identity. Supported values are model-dependent
+and are validated authoritatively by the installed Codex CLI.
 
 An `AgentSkill` is a pathless, content-addressed snapshot containing
 `SKILL.md` and any referenced files, scripts, or assets. A Run accepts up to

--- a/scripts/run_balatro_codex.py
+++ b/scripts/run_balatro_codex.py
@@ -47,6 +47,7 @@ def main(arguments: list[str] | None = None) -> int:
         BalatroBenchmark(),
         agent=Codex(
             model=namespace.model,
+            reasoning_effort=namespace.reasoning_effort,
             executable=namespace.codex_executable,
         ),
         execution=ProcessExecution.unsafe(),
@@ -148,6 +149,14 @@ def _parser() -> argparse.ArgumentParser:
         description="Run a real Codex Agent against the Balatro Benchmark.",
     )
     parser.add_argument("--model", required=True)
+    parser.add_argument(
+        "--reasoning-effort",
+        required=True,
+        help=(
+            "set the selected Codex model's reasoning effort "
+            "(for example: high or xhigh)"
+        ),
+    )
     parser.add_argument("--codex-executable", default="codex")
     parser.add_argument("--record-to", type=Path, required=True)
     parser.add_argument(

--- a/scripts/run_balatro_skill_ab.py
+++ b/scripts/run_balatro_skill_ab.py
@@ -17,7 +17,7 @@ from typing import Any
 _REPOSITORY = Path(__file__).resolve().parents[1]
 _SINGLE_RUNNER = _REPOSITORY / "scripts" / "run_balatro_codex.py"
 _BALATRO_SKILL = _REPOSITORY / "skills" / "optimize-balatro-policy"
-_RESULT_SCHEMA = "evopolicygym/balatro-skill-ab/v2"
+_RESULT_SCHEMA = "evopolicygym/balatro-skill-ab/v3"
 
 
 class ExperimentError(RuntimeError):
@@ -70,6 +70,7 @@ def main(arguments: list[str] | None = None) -> int:
         "schema": _RESULT_SCHEMA,
         "record_root": str(record_root),
         "model": namespace.model,
+        "reasoning_effort": namespace.reasoning_effort,
         "seed": namespace.seed,
         "order": namespace.order,
         "config": {
@@ -147,6 +148,8 @@ def _run_arm(
         "--progress",
         namespace.progress,
         "--allow-unsafe-process",
+        "--reasoning-effort",
+        namespace.reasoning_effort,
     ]
     if use_skill:
         command.extend(("--skill", str(_BALATRO_SKILL)))
@@ -302,6 +305,13 @@ def _parser() -> argparse.ArgumentParser:
         )
     )
     parser.add_argument("--model", required=True)
+    parser.add_argument(
+        "--reasoning-effort",
+        required=True,
+        help=(
+            "use the same Codex reasoning effort for both experiment arms"
+        ),
+    )
     parser.add_argument("--codex-executable", default="codex")
     parser.add_argument(
         "--record-root",

--- a/scripts/run_cartpole_codex.py
+++ b/scripts/run_cartpole_codex.py
@@ -39,6 +39,7 @@ def main(arguments: list[str] | None = None) -> int:
         CartPoleBenchmark(),
         agent=Codex(
             model=namespace.model,
+            reasoning_effort=namespace.reasoning_effort,
             executable=namespace.codex_executable,
         ),
         execution=ProcessExecution.unsafe(),
@@ -139,6 +140,14 @@ def _parser() -> argparse.ArgumentParser:
         description="Run a real Codex Agent against the CartPole Benchmark.",
     )
     parser.add_argument("--model", required=True)
+    parser.add_argument(
+        "--reasoning-effort",
+        required=True,
+        help=(
+            "set the selected Codex model's reasoning effort "
+            "(for example: high or xhigh)"
+        ),
+    )
     parser.add_argument("--codex-executable", default="codex")
     parser.add_argument("--record-to", type=Path, required=True)
     parser.add_argument(

--- a/site/src/content/docs/en/evaluation.md
+++ b/site/src/content/docs/en/evaluation.md
@@ -70,7 +70,10 @@ from cartpole import CartPoleBenchmark
 result = run(
     Program.from_directory("policy/"),
     CartPoleBenchmark(),
-    agent=Codex(model="gpt-5.5"),
+    agent=Codex(
+        model="gpt-5.5",
+        reasoning_effort="high",
+    ),
     execution=ProcessExecution.unsafe(),
     record_to="runs/cartpole-001",
     config=RunConfig(

--- a/site/src/content/docs/zh/evaluation.md
+++ b/site/src/content/docs/zh/evaluation.md
@@ -68,7 +68,10 @@ from cartpole import CartPoleBenchmark
 result = run(
     Program.from_directory("policy/"),
     CartPoleBenchmark(),
-    agent=Codex(model="gpt-5.5"),
+    agent=Codex(
+        model="gpt-5.5",
+        reasoning_effort="high",
+    ),
     execution=ProcessExecution.unsafe(),
     record_to="runs/cartpole-001",
     config=RunConfig(

--- a/skills/use-evopolicygym/references/api.md
+++ b/skills/use-evopolicygym/references/api.md
@@ -54,7 +54,10 @@ from evopolicygym.skills import AgentSkill
 result = run(
     baseline_program(),
     ExampleBenchmark(),
-    agent=Codex(model="MODEL_ID"),
+    agent=Codex(
+        model="MODEL_ID",
+        reasoning_effort="high",
+    ),
     execution=ProcessExecution.unsafe(),
     record_to="runs/example-001",
     skills=(

--- a/src/evopolicygym/agents/codex.py
+++ b/src/evopolicygym/agents/codex.py
@@ -27,9 +27,10 @@ _CODEX_ENVIRONMENT_ALLOWLIST = (
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class Codex:
-    """Select the Codex model and CLI executable used by a Run."""
+    """Select the Codex model, reasoning effort, and CLI used by a Run."""
 
     model: str
+    reasoning_effort: str
     executable: str = "codex"
 
     def __post_init__(self) -> None:
@@ -41,6 +42,25 @@ class Codex:
             or "\0" in self.model
         ):
             raise ValueError("model must be a non-empty bounded identifier")
+        if (
+            type(self.reasoning_effort) is not str
+            or not self.reasoning_effort
+            or len(
+                self.reasoning_effort.encode("utf-8", errors="strict")
+            )
+            > 64
+            or any(
+                not character.isascii()
+                or not (
+                    character.isalnum()
+                    or character in {"-", "_"}
+                )
+                for character in self.reasoning_effort
+            )
+        ):
+            raise ValueError(
+                "reasoning_effort must be a non-empty bounded identifier"
+            )
         if (
             type(self.executable) is not str
             or not self.executable
@@ -61,6 +81,8 @@ class Codex:
             resolved_executable,
             "--ask-for-approval",
             "never",
+            "--config",
+            f'model_reasoning_effort="{self.reasoning_effort}"',
             "exec",
             "--ephemeral",
             "--json",
@@ -74,13 +96,15 @@ class Codex:
             "--color",
             "never",
         )
+        identity = {
+            "provider": "codex",
+            "model": self.model,
+            "reasoning_effort": self.reasoning_effort,
+        }
         return AgentInvocation(
             command=(*command_prefix, task.instructions),
             recorded_command=(*command_prefix, "@agent/instructions.md"),
-            identity={
-                "provider": "codex",
-                "model": self.model,
-            },
+            identity=identity,
             instructions=task.instructions,
             inherited_environment=_CODEX_ENVIRONMENT_ALLOWLIST,
             stdout_media_type="application/x-ndjson",

--- a/tests/test_codex_integration.py
+++ b/tests/test_codex_integration.py
@@ -4,7 +4,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from evopolicygym.agents import Codex, CodingAgent, resolve_executable
+from evopolicygym.agents import (
+    Codex,
+    CodingAgent,
+    resolve_executable,
+)
 from evopolicygym.authoring import BenchmarkSpec
 from evopolicygym.run import AssessmentConfig, RunConfig, ValidationConfig
 from evopolicygym.run._task import build_agent_task
@@ -49,19 +53,30 @@ class CodexIntegrationTests(unittest.TestCase):
             )
             invocation = Codex(
                 model="fixture-model",
+                reasoning_effort="xhigh",
                 executable=str(executable),
             ).build_invocation(task)
 
         self.assertIsInstance(
-            Codex(model="fixture-model"),
+            Codex(
+                model="fixture-model",
+                reasoning_effort="medium",
+            ),
             CodingAgent,
         )
         self.assertEqual(invocation.instructions, task.instructions)
         self.assertEqual(invocation.identity["provider"], "codex")
         self.assertEqual(invocation.identity["model"], "fixture-model")
+        self.assertEqual(invocation.identity["reasoning_effort"], "xhigh")
         self.assertEqual(invocation.stdout_media_type, "application/x-ndjson")
         self.assertIn("--ephemeral", invocation.command)
         self.assertIn("--ignore-user-config", invocation.command)
+        self.assertEqual(
+            invocation.command[
+                invocation.command.index("--config") + 1
+            ],
+            'model_reasoning_effort="xhigh"',
+        )
         self.assertEqual(
             invocation.command[
                 invocation.command.index("--sandbox") + 1
@@ -86,6 +101,18 @@ class CodexIntegrationTests(unittest.TestCase):
             invocation.recorded_command[-1],
             "@agent/instructions.md",
         )
+
+    def test_codex_rejects_invalid_reasoning_effort_identifiers(self) -> None:
+        for invalid in ("", "extra high", "high\n", "x" * 65):
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "reasoning_effort",
+                ):
+                    Codex(
+                        model="fixture-model",
+                        reasoning_effort=invalid,
+                    )
 
     def test_agent_skills_are_explicitly_selected_per_run(self) -> None:
         spec = BenchmarkSpec(

--- a/tests/test_public_contract.py
+++ b/tests/test_public_contract.py
@@ -434,7 +434,10 @@ description: Improve counter policies.
             max_submissions=4,
             episode_budget=20,
         )
-        agent = Codex(model="gpt-5")
+        agent = Codex(
+            model="gpt-5",
+            reasoning_effort="medium",
+        )
 
         self.assertEqual(evaluation.episodes, 2)
         self.assertEqual(run.max_submissions, 4)
@@ -1426,7 +1429,13 @@ assert os.environ["EVOPOLICYGYM_SESSION_SOCKET"] == os.path.join(
     "..", "control", "session.sock"
 )
 assert shutil.which("evopolicygym") is not None
-assert arguments[:3] == ["--ask-for-approval", "never", "exec"]
+assert arguments[:5] == [
+    "--ask-for-approval",
+    "never",
+    "--config",
+    'model_reasoning_effort="high"',
+    "exec",
+]
 for flag in (
     "--ephemeral",
     "--json",
@@ -1506,6 +1515,7 @@ print(json.dumps({{"type": "turn.completed"}}))
                     RecordingBenchmark(),
                     agent=Codex(
                         model="fake-model",
+                        reasoning_effort="high",
                         executable=str(fake_codex),
                     ),
                     execution=ProcessExecution.unsafe(),
@@ -1564,7 +1574,11 @@ print(json.dumps({{"type": "turn.completed"}}))
         )
         self.assertEqual(
             invocation["agent"],
-            {"provider": "codex", "model": "fake-model"},
+            {
+                "provider": "codex",
+                "model": "fake-model",
+                "reasoning_effort": "high",
+            },
         )
         self.assertEqual(invocation["cwd"], "workspace")
         self.assertEqual(invocation["command"][-1], "@agent/instructions.md")
@@ -1580,6 +1594,7 @@ print(json.dumps({{"type": "turn.completed"}}))
         )
         self.assertEqual(manifest["agent"]["provider"], "codex")
         self.assertEqual(manifest["agent"]["model"], "fake-model")
+        self.assertEqual(manifest["agent"]["reasoning_effort"], "high")
         self.assertEqual(
             manifest["workspace"]["program"],
             "workspace/program",


### PR DESCRIPTION
## Purpose

Make Codex reasoning effort an explicit, reproducible Agent experiment input.

## Changes

- require `reasoning_effort` when selecting the first-party `Codex` provider
- translate it deterministically to the Codex CLI `model_reasoning_effort` setting
- retain it alongside the model in Agent invocation and Run identity
- expose the required setting in CartPole, Balatro, and Balatro Skill A/B scripts
- update the README, architecture, changelog, project Skill reference, bilingual site docs, and representative tests

## Impact

Every Codex-backed Run now pins both model and reasoning effort. The setting
remains provider-owned and does not enter `RunConfig`, `BenchmarkSpec`, or the
Policy boundary. Supported effort values remain model-dependent and are
validated by the installed Codex CLI.

## Validation

- `uv run python -m unittest discover -s tests` — 91 tests passed
- `uv run ruff check src tests scripts`
- `uv run mypy`
- fake-Codex end-to-end Run retention test
- local Codex CLI argument parsing

No real Codex or Benchmark Run was performed.
