### PR TITLE
run: add indexed training episode pool

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,6 +13,9 @@ not design inputs for this version.
   configured Benchmark before Evaluation. Their canonical digest distinguishes
   otherwise identical Benchmark IDs with different task configurations.
 - An `Evaluation` runs one Program through a bounded set of Episodes.
+- A training Episode pool is one immutable Run-local tuple of trusted
+  `EpisodeSpec` and Policy-seed pairs, addressed publicly only by integer
+  indices.
 - A `Submission` commits one Program and its public Feedback.
 - A finished candidate set is an ordered, bounded tuple of published
   Submissions handed from the Agent to the Host in one atomic request.
@@ -52,12 +55,14 @@ evopolicygym/
 │
 ├── evaluation/                 complete direct-Evaluation use case
 │   ├── __init__.py             EvaluationConfig and evaluate()
+│   ├── _plan.py                exact trusted Episode and Policy-seed inputs
 │   └── _service.py             Episode rules and narrow runtime contracts
 │
 ├── run/                        complete Program-Evolution use case
 │   ├── __init__.py             Run/Validation/Assessment configs and run()
 │   ├── progress.py             public Run events, observer, and console reporter
 │   ├── _service.py             Run coordination and process-setting assembly
+│   ├── _episode_pool.py        fixed training pool and seed derivation
 │   ├── _session.py             Submission budget and atomic finish admission
 │   ├── _validation.py          post-Agent candidate evaluation and selection
 │   ├── _assessment.py          held-out final-Program measurement
@@ -170,8 +175,9 @@ The rules are:
 - `evaluation/_service.py` declares the Policy-runtime capabilities it
   consumes and never selects an execution setting or Agent provider;
 - `run/_session.py` owns budgets, admission, publication ordering, and the
-  atomic transfer of an ordered candidate set without depending on an
-  execution setting or provider;
+  mapping from submitted public Episode indices to the fixed training pool,
+  plus the atomic transfer of an ordered candidate set, without depending on
+  an execution setting or provider;
 - `run/_validation.py` owns deterministic final selection. It starts only
   after the Agent runner has reaped the process tree and the Session gateway
   has closed;
@@ -213,7 +219,7 @@ root.
 
 ```text
 Agent search
-  submit → public Feedback → edit → ... → finish(candidate IDs)
+  submit(Episode indices) → public Feedback → edit → ... → finish(candidate IDs)
                                              │
                                              ▼
                               close Session and reap Agent
@@ -231,7 +237,23 @@ Agent search
                                         Run commit
 ```
 
-`finish` uses `agent-session/v2` and accepts a non-empty
+Before Agent execution, the Host derives one training-pool seed from
+`RunConfig.seed` under `evopolicygym/training-pool/v1`, asks the Benchmark for
+exactly `episode_pool_size` `EpisodeSpec` values once, and derives one stable
+Policy seed per index under `evopolicygym/training-policy/v1`. The default pool
+size equals `episode_budget`, but callers may configure a larger selectable
+pool without increasing total authority.
+
+`submit` uses `agent-session/v3` and carries an explicit, non-empty,
+strictly-increasing `episode_indices` list. The CLI expands singleton and
+half-open range unions such as `"0:2,4:8"` to
+`[0, 1, 4, 5, 6, 7]`. Duplicate, overlapping, malformed, out-of-pool, and
+over-budget selections are rejected before Program capture. Reusing an index
+across Submissions is valid and consumes budget again. The mapping is fixed
+for the Run, while Evaluation still creates a fresh Environment, Policy
+process, Policy instance, and scratch directory for every selected index.
+
+`finish` also uses `agent-session/v3` and accepts a non-empty
 `submission_ids` list. The Host rejects malformed, duplicate, unknown, or
 over-limit candidates before changing Session state. A successful request
 closes Agent authority; it does not select a final Program inside the Session.
@@ -253,10 +275,13 @@ The Agent-visible `workspace/` contains only editable `program/`, public
 under `skills/`. `validation/` and `assessment/` are not created until after
 Agent cleanup. Successful phases retain only aggregate scores and
 Policy-failure counts in their reports; private Episodes, seeds, cases, traces,
-and execution evidence do not cross into Feedback. `run.json` uses
-`evopolicygym/run-record/v5`, retains the public Environment parameters and
-canonical digest beside the Benchmark ID, records selected Skill names,
-digests, and snapshot paths, and references the available aggregate reports.
+and execution evidence do not cross into Feedback. Submission Feedback uses
+`evopolicygym/feedback/v2` and maps every public Episode summary to its
+Run-local training index. `run.json` uses
+`evopolicygym/run-record/v6`, retains the pool size and derivation protocol,
+the public Environment parameters and canonical digest beside the Benchmark
+ID, selected index sets, selected Skill names, digests, and snapshot paths,
+and references the available aggregate reports.
 
 This is a logical lifecycle and publication boundary, not a security boundary:
 `ProcessExecution` remains non-isolated. A Benchmark that requires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Added a deterministic, Host-owned indexed training Episode pool. Agents now
+  select arbitrary singleton and half-open range unions through
+  `agent-session/v3`; repeated indices preserve Episode and Policy seeds across
+  Submissions while every use still creates fresh runtimes and consumes
+  budget.
+- Added `RunConfig.episode_pool_size`, indexed `SubmissionResult` and Feedback
+  records, `evopolicygym/feedback/v2`, and `evopolicygym/run-record/v6`.
 - Added first-class public Environment parameters to `BenchmarkSpec`, the
   `policy/v2` `PolicyContext`, Coding Agent tasks, Evaluation identity, and
   `run-record/v4`.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ result = run(
     config=RunConfig(
         max_submissions=16,
         episode_budget=48,
+        episode_pool_size=96,
         max_episodes_per_submission=3,
         validation=ValidationConfig(
             split="validation",
@@ -205,9 +206,26 @@ During the Run, the agent evaluates immutable submissions and hands candidates
 to the Host with:
 
 ```console
-evopolicygym submit program --episodes 3
+evopolicygym submit program --episodes "0:2,4:8"
 evopolicygym finish submission-000002 submission-000007
 ```
+
+`RunConfig.seed` deterministically creates one fixed Host-owned training
+Episode pool before the Agent starts. `episode_pool_size` defaults to the total
+Episode budget. The Agent selects public Run-local indices from
+`0..episode_pool_size-1`; ranges are half-open and comma-separated items form a
+union. The example selects indices `0, 1, 4, 5, 6, 7`. A selection must be
+non-empty, strictly increasing, and contain no duplicate or overlapping
+indices.
+
+The same index always binds the same trusted `EpisodeSpec` and Policy seed
+within one Run, so the Agent can compare Program revisions on matched
+conditions. Every evaluation still creates a fresh Environment, Policy
+process, Policy instance, and scratch directory. Reusing an index in a later
+Submission is allowed and consumes another Episode budget unit. Actual
+Environment seeds and scenarios are not published to the Agent; Validation
+and Assessment use separate Host-only Episode plans that cannot be selected
+through `submit`.
 
 `finish` atomically hands an ordered candidate set to the Host and closes Agent
 authority. With `ValidationConfig`, the Host waits for the Agent process to be
@@ -228,7 +246,8 @@ separate Agent logs, and—when configured—aggregate
 `validation/report.json` and `assessment/report.json` records. Benchmark
 authors control the public Feedback content and may publish bounded traces,
 replays, diagnostics, images, or reports without exposing private seeds,
-paths, or execution evidence.
+paths, or execution evidence. Submission Feedback includes the selected
+Run-local Episode index beside each public Episode summary.
 
 `ProcessExecution` is **not a sandbox**. The Agent and Policy processes run
 with the authority of the current operating-system user. Use it only with

--- a/scripts/run_balatro_codex.py
+++ b/scripts/run_balatro_codex.py
@@ -57,6 +57,7 @@ def main(arguments: list[str] | None = None) -> int:
             split=namespace.split,
             max_submissions=namespace.max_submissions,
             episode_budget=namespace.episode_budget,
+            episode_pool_size=namespace.episode_pool_size,
             max_episodes_per_submission=(
                 namespace.max_episodes_per_submission
             ),
@@ -132,6 +133,9 @@ def main(arguments: list[str] | None = None) -> int:
                     {
                         "submission_id": submission.submission_id,
                         "score": submission.feedback.score,
+                        "episode_indices": list(
+                            submission.episode_indices
+                        ),
                         "episodes_used": submission.episodes_used,
                     }
                     for submission in result.submissions
@@ -167,6 +171,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--max-submissions", type=int, default=16)
     parser.add_argument("--episode-budget", type=int, default=48)
+    parser.add_argument(
+        "--episode-pool-size",
+        type=int,
+        help="fixed selectable training Episode pool size; defaults to budget",
+    )
     parser.add_argument("--max-episodes-per-submission", type=int)
     parser.add_argument(
         "--validation-episodes-per-candidate",

--- a/scripts/run_balatro_skill_ab.py
+++ b/scripts/run_balatro_skill_ab.py
@@ -17,7 +17,7 @@ from typing import Any
 _REPOSITORY = Path(__file__).resolve().parents[1]
 _SINGLE_RUNNER = _REPOSITORY / "scripts" / "run_balatro_codex.py"
 _BALATRO_SKILL = _REPOSITORY / "skills" / "optimize-balatro-policy"
-_RESULT_SCHEMA = "evopolicygym/balatro-skill-ab/v3"
+_RESULT_SCHEMA = "evopolicygym/balatro-skill-ab/v4"
 
 
 class ExperimentError(RuntimeError):
@@ -76,6 +76,7 @@ def main(arguments: list[str] | None = None) -> int:
         "config": {
             "max_submissions": namespace.max_submissions,
             "episode_budget": namespace.episode_budget,
+            "episode_pool_size": namespace.episode_pool_size,
             "max_episodes_per_submission": (
                 namespace.max_episodes_per_submission
             ),
@@ -129,8 +130,6 @@ def _run_arm(
         str(namespace.max_submissions),
         "--episode-budget",
         str(namespace.episode_budget),
-        "--max-episodes-per-submission",
-        str(namespace.max_episodes_per_submission),
         "--validation-episodes-per-candidate",
         str(namespace.validation_episodes_per_candidate),
         "--validation-split",
@@ -151,6 +150,19 @@ def _run_arm(
         "--reasoning-effort",
         namespace.reasoning_effort,
     ]
+    if namespace.episode_pool_size is not None:
+        command.extend(
+            (
+                "--episode-pool-size",
+                str(namespace.episode_pool_size),
+            )
+        )
+    command.extend(
+        (
+            "--max-episodes-per-submission",
+            str(namespace.max_episodes_per_submission),
+        )
+    )
     if use_skill:
         command.extend(("--skill", str(_BALATRO_SKILL)))
 
@@ -338,6 +350,11 @@ def _parser() -> argparse.ArgumentParser:
         "--episode-budget",
         type=_positive_int,
         default=48,
+    )
+    parser.add_argument(
+        "--episode-pool-size",
+        type=_positive_int,
+        help="fixed selectable pool size; defaults to the Episode budget",
     )
     parser.add_argument(
         "--max-episodes-per-submission",

--- a/scripts/run_cartpole_codex.py
+++ b/scripts/run_cartpole_codex.py
@@ -48,6 +48,7 @@ def main(arguments: list[str] | None = None) -> int:
             split=namespace.split,
             max_submissions=namespace.max_submissions,
             episode_budget=namespace.episode_budget,
+            episode_pool_size=namespace.episode_pool_size,
             max_episodes_per_submission=(
                 namespace.max_episodes_per_submission
             ),
@@ -123,6 +124,9 @@ def main(arguments: list[str] | None = None) -> int:
                     {
                         "submission_id": submission.submission_id,
                         "score": submission.feedback.score,
+                        "episode_indices": list(
+                            submission.episode_indices
+                        ),
                         "episodes_used": submission.episodes_used,
                     }
                     for submission in result.submissions
@@ -158,6 +162,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--max-submissions", type=int, default=2)
     parser.add_argument("--episode-budget", type=int, default=6)
+    parser.add_argument(
+        "--episode-pool-size",
+        type=int,
+        help="fixed selectable training Episode pool size; defaults to budget",
+    )
     parser.add_argument("--max-episodes-per-submission", type=int)
     parser.add_argument(
         "--validation-episodes-per-candidate",

--- a/site/src/content/docs/en/concepts.md
+++ b/site/src/content/docs/en/concepts.md
@@ -63,16 +63,19 @@ next Program or finish(selected submission)
 ```
 
 A `RunConfig` fixes the split, maximum submissions, total Episode budget,
-optional per-Submission Episode cap, seeds, and timeouts. The optional cap
-defaults to `None`, so the Agent normally chooses its own allocation without
-extending the total authority.
+fixed training Episode-pool size, optional per-Submission Episode cap, seed,
+and timeouts. The pool size defaults to the total budget. The Agent selects
+public Run-local indices from that pool; the same index preserves its hidden
+Episode specification and Policy seed across Submissions, while each use
+creates fresh runtime state and consumes budget again. The optional
+per-Submission cap defaults to `None`.
 
 ## Trust boundary
 
 | Trusted Host and Benchmark own | Policy can observe |
 | --- | --- |
 | Environment parameter selection | Public `environment_parameters` fixed before Evaluation |
-| Episode scenario and Environment seed | `PolicyContext` without Case identity |
+| Episode scenario, Environment seed, and pool mapping | `PolicyContext` without a pool index or Case identity |
 | Environment state and transitions | Public observations |
 | Action validation | Its own Episode-local state |
 | Rewards, scoring, and private metrics | Committed public Feedback only |

--- a/site/src/content/docs/en/evaluation.md
+++ b/site/src/content/docs/en/evaluation.md
@@ -80,6 +80,7 @@ result = run(
         split="train",
         max_submissions=20,
         episode_budget=1_000,
+        episode_pool_size=2_000,
         seed=42,
     ),
 )
@@ -88,9 +89,19 @@ result = run(
 The Host owns the Agent task, workspace rules, budget, submit and finish
 commands, process supervision, and publication. A provider translates the
 Host task into a validated invocation; it does not redefine Run semantics.
-The Agent chooses how many of the remaining Episode units to spend on each
-submission by default. Set `max_episodes_per_submission` to a positive integer
-only when the Host needs an additional cap; its default is `None`.
+Before Agent execution, the Host deterministically builds one fixed training
+Episode pool from `RunConfig.seed`. The Agent submits public Run-local
+singleton and half-open range unions such as:
+
+```console
+evopolicygym submit program --episodes "0:2,4:8"
+```
+
+That selector expands to indices `0, 1, 4, 5, 6, 7`. The same index preserves
+its hidden Episode specification and Policy seed across Submissions, but every
+use creates a fresh Environment and Policy runtime and consumes budget again.
+`episode_pool_size` defaults to `episode_budget`. Set
+`max_episodes_per_submission` only when the Host needs an additional cap.
 
 Agent Skills are independent Run inputs rather than Benchmark properties.
 Freeze each selected directory with
@@ -106,9 +117,11 @@ strategy development, and Policy hardening.
 One accepted submission:
 
 1. freezes the current `workspace/program/` tree into a `Program`;
-2. reserves and deducts the requested Episode budget;
+2. validates the selected training indices, then reserves and deducts one
+   Episode budget unit per index;
 3. evaluates that immutable snapshot;
-4. atomically retains Program, Feedback, Episode summaries, and artifacts;
+4. atomically retains Program, selected indices, Feedback, Episode summaries,
+   and artifacts;
 5. publishes an independent Agent-visible copy under `workspace/feedback/`;
 6. admits the Submission ID as a possible final selection.
 

--- a/site/src/content/docs/zh/concepts.md
+++ b/site/src/content/docs/zh/concepts.md
@@ -60,16 +60,18 @@ Coding Agent reads workspace/feedback/
 next Program or finish(selected submission)
 ```
 
-`RunConfig` 固定 split、最大 submissions、总 Episode 预算、可选的单次
-Submission Episode 上限、seeds 与 timeouts。该上限默认为 `None`，因此 Agent
-通常自行分配预算，但不能扩展总权限。
+`RunConfig` 固定 split、最大 submissions、总 Episode 预算、训练 Episode 池大小、
+可选的单次 Submission Episode 上限、seed 与 timeouts。池大小默认等于总预算。
+Agent 从池中选择公开的 Run-local 编号；同一编号在不同 Submission 中保持隐藏
+Episode specification 与 Policy seed 不变，但每次使用仍创建全新的 runtime 状态并
+再次扣除预算。单次上限默认为 `None`。
 
 ## 信任边界
 
 | 可信 Host 与 Benchmark 持有 | Policy 可以观察 |
 | --- | --- |
 | Environment 参数选择 | Evaluation 前固定的公开 `environment_parameters` |
-| Episode scenario 与 Environment seed | 不含 Case identity 的 `PolicyContext` |
+| Episode scenario、Environment seed 与池映射 | 不含池编号或 Case identity 的 `PolicyContext` |
 | Environment 状态与 transitions | 公开 Observations |
 | Action 校验 | 自己的 Episode 内状态 |
 | Rewards、评分与私有 metrics | 仅已提交的公开 Feedback |

--- a/site/src/content/docs/zh/evaluation.md
+++ b/site/src/content/docs/zh/evaluation.md
@@ -78,6 +78,7 @@ result = run(
         split="train",
         max_submissions=20,
         episode_budget=1_000,
+        episode_pool_size=2_000,
         seed=42,
     ),
 )
@@ -86,9 +87,18 @@ result = run(
 Host 拥有 Agent task、workspace rules、预算、submit/finish commands、进程监督
 与 publication。Provider 只把 Host task 转换为经过验证的 invocation，不重新定义
 Run 语义。
-默认由 Agent 自主决定每次 Submission 使用多少剩余 Episode 预算。
-`max_episodes_per_submission` 默认为 `None`；只有 Host 需要额外限制时才设置
-正整数上限。
+Agent 执行前，Host 根据 `RunConfig.seed` 确定性地构建一个固定训练 Episode 池。
+Agent 使用公开的 Run-local 单点与半开区间并集提交，例如：
+
+```console
+evopolicygym submit program --episodes "0:2,4:8"
+```
+
+该选择器展开为编号 `0, 1, 4, 5, 6, 7`。同一编号在不同 Submission 中保持隐藏
+Episode specification 与 Policy seed 不变，但每次使用仍会创建全新的 Environment
+与 Policy runtime，并再次消耗预算。`episode_pool_size` 默认等于
+`episode_budget`。只有 Host 需要额外限制时才设置
+`max_episodes_per_submission`。
 
 Agent Skill 是独立的 Run 输入，而不是 Benchmark 属性。调用者使用
 `AgentSkill.from_directory("skills/<name>")` 冻结明确选择的目录，并通过
@@ -102,9 +112,9 @@ Policy process。仓库中的 Balatro Skill 是用于证据分配、策略开发
 一次被接受的 Submission：
 
 1. 将当前 `workspace/program/` tree 冻结为 `Program`；
-2. 预留并扣除请求的 Episode 预算；
+2. 校验所选训练编号，并为每个编号预留、扣除一个 Episode 预算单位；
 3. 评估该不可变快照；
-4. 原子保留 Program、Feedback、Episode summaries 与 artifacts；
+4. 原子保留 Program、所选编号、Feedback、Episode summaries 与 artifacts；
 5. 在 `workspace/feedback/` 发布独立的 Agent-visible copy；
 6. 将 Submission ID 加入可选最终结果集合。
 

--- a/skills/use-evopolicygym/SKILL.md
+++ b/skills/use-evopolicygym/SKILL.md
@@ -82,6 +82,9 @@ authority.
   cleanup before spending a Coding Agent budget.
 - Set explicit finite budgets. For trace-heavy Benchmarks, prefer an explicit
   `max_episodes_per_submission` documented as safe by that Benchmark.
+- Choose an `episode_pool_size` for the fixed selectable training pool. It
+  defaults to `episode_budget`; increasing it expands the matched conditions
+  available to the Agent without increasing total spend.
 - Use a new `record_to` path whose parent already exists. Never reuse or
   pre-create the Run directory.
 - Capture each desired task-specific Skill explicitly with
@@ -91,9 +94,13 @@ authority.
   Policy.
 - Add `ConsoleProgress()` when interactive progress is useful.
 - Require the Agent to publish candidates through
-  `evopolicygym submit program --episodes N` and finish by handing the Host
-  one or more published IDs with
+  `evopolicygym submit program --episodes "0:2,4:8"` and finish by handing the
+  Host one or more published IDs with
   `evopolicygym finish SUBMISSION_ID [SUBMISSION_ID ...]`.
+- Treat submit selectors as public Run-local Episode indices: comma joins
+  singleton or half-open range items, each request is strictly increasing and
+  duplicate-free, and reusing an index in a later Submission consumes budget
+  again while preserving its Episode specification and Policy seed.
 - Use `ValidationConfig` when the Host should compare multiple candidates.
   Give every candidate the same split, derived seed, Episode count, and Policy
   seeds. Its Episode allocation is separate from the Agent search budget.
@@ -112,6 +119,8 @@ authority.
 - Assume only that Feedback has a finite scalar score, Benchmark-defined
   public content, and zero or more bounded public Artifacts.
 - Read `feedback/latest.json`, then follow its relative Artifact paths.
+- Use each Feedback Episode's `episode_index` to compare Program revisions on
+  matched training conditions.
 - Let the Benchmark define trace, diagnostics, replay, image, or report
   formats. Do not impose a Kernel-wide trace schema.
 - Keep scoring based on every evaluated Episode even when a Benchmark retains

--- a/skills/use-evopolicygym/references/api.md
+++ b/skills/use-evopolicygym/references/api.md
@@ -67,6 +67,7 @@ result = run(
         split="train",
         max_submissions=16,
         episode_budget=48,
+        episode_pool_size=96,
         max_episodes_per_submission=4,
         validation=ValidationConfig(
             split="validation",
@@ -104,9 +105,17 @@ repository discovery or attach a Skill to `BenchmarkSpec`.
 During search, the Agent uses:
 
 ```console
-evopolicygym submit program --episodes 4
+evopolicygym submit program --episodes "0:2,4:6"
 evopolicygym finish submission-000003 submission-000011
 ```
+
+The submit selector addresses the fixed Run-local training Episode pool.
+Singletons and half-open ranges may be joined by commas, must expand to a
+strictly increasing duplicate-free index list, and consume one budget unit per
+selected index. Reusing an index in a later Submission preserves the hidden
+Episode specification and Policy seed while still creating fresh runtime
+state and consuming budget again. `episode_pool_size` defaults to
+`episode_budget`.
 
 `finish` atomically accepts an ordered candidate list. With
 `ValidationConfig`, the Host closes Agent authority, reaps the Agent, evaluates

--- a/src/evopolicygym/_protocol/session.py
+++ b/src/evopolicygym/_protocol/session.py
@@ -2,8 +2,9 @@
 
 from ._framing import JsonFrameCodec
 
-SESSION_PROTOCOL = "agent-session/v2"
+SESSION_PROTOCOL = "agent-session/v3"
 SESSION_MAX_FRAME_BYTES = 64 * 1024
+SESSION_MAX_EPISODE_INDICES = 2_048
 
 SESSION_FRAMES = JsonFrameCodec(
     label="Session",

--- a/src/evopolicygym/cli.py
+++ b/src/evopolicygym/cli.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import socket
 import sys
 from pathlib import Path
 from typing import cast
 
-from ._protocol.session import SESSION_PROTOCOL
+from ._protocol.session import (
+    SESSION_MAX_EPISODE_INDICES,
+    SESSION_PROTOCOL,
+)
 from ._version import __version__
 from .run._socket import (
     receive_session_message,
@@ -19,6 +23,8 @@ from .run._socket import (
 
 _SESSION_SOCKET_VARIABLE = "EVOPOLICYGYM_SESSION_SOCKET"
 _WORKSPACE_VARIABLE = "EVOPOLICYGYM_WORKSPACE"
+_UNSIGNED_DECIMAL = re.compile(r"[0-9]+")
+_MAX_EPISODE_INDEX = 2**64 - 1
 
 
 def main(arguments: list[str] | None = None) -> int:
@@ -75,7 +81,13 @@ def _parser() -> argparse.ArgumentParser:
         "program",
         help="must resolve to $EVOPOLICYGYM_WORKSPACE/program",
     )
-    submit.add_argument("--episodes", type=int, default=1)
+    submit.add_argument(
+        "--episodes",
+        type=_parse_episode_selector,
+        required=True,
+        metavar="SELECTOR",
+        help='Run-local Episode indices, for example "0:2,4:8"',
+    )
 
     finish = subcommands.add_parser(
         "finish",
@@ -95,7 +107,9 @@ def _request(namespace: argparse.Namespace) -> dict[str, object]:
         return {
             "protocol": SESSION_PROTOCOL,
             "method": "submit",
-            "episodes": cast(int, namespace.episodes),
+            "episode_indices": list(
+                cast(tuple[int, ...], namespace.episodes)
+            ),
         }
     if namespace.command == "finish":
         return {
@@ -128,6 +142,75 @@ def _required_path(variable: str) -> Path:
     if not raw:
         raise RuntimeError(f"{variable} is not set; no Agent Session is active")
     return Path(raw)
+
+
+def _parse_episode_selector(value: str) -> tuple[int, ...]:
+    if not value or any(character.isspace() for character in value):
+        raise argparse.ArgumentTypeError(
+            "Episode selector must not be empty or contain whitespace"
+        )
+    indices: list[int] = []
+    for item in value.split(","):
+        if not item:
+            raise argparse.ArgumentTypeError(
+                "Episode selector contains an empty item"
+            )
+        parts = item.split(":")
+        if len(parts) == 1:
+            index = _parse_unsigned(parts[0], endpoint=False)
+            _append_index(indices, index)
+            continue
+        if len(parts) != 2:
+            raise argparse.ArgumentTypeError(
+                "Episode ranges must use START:END"
+            )
+        start = _parse_unsigned(parts[0], endpoint=False)
+        end = _parse_unsigned(parts[1], endpoint=True)
+        if start >= end:
+            raise argparse.ArgumentTypeError(
+                "Episode ranges must be non-empty and increasing"
+            )
+        count = end - start
+        if count > SESSION_MAX_EPISODE_INDICES - len(indices):
+            raise argparse.ArgumentTypeError(
+                "Episode selector contains too many indices"
+            )
+        if indices and start <= indices[-1]:
+            raise argparse.ArgumentTypeError(
+                "Episode selector must be strictly increasing without overlap"
+            )
+        indices.extend(range(start, end))
+    if len(indices) > SESSION_MAX_EPISODE_INDICES:
+        raise argparse.ArgumentTypeError(
+            "Episode selector contains too many indices"
+        )
+    return tuple(indices)
+
+
+def _parse_unsigned(value: str, *, endpoint: bool) -> int:
+    if _UNSIGNED_DECIMAL.fullmatch(value) is None:
+        raise argparse.ArgumentTypeError(
+            "Episode indices must use unsigned decimal integers"
+        )
+    parsed = int(value)
+    limit = 2**64 if endpoint else _MAX_EPISODE_INDEX
+    if parsed > limit:
+        raise argparse.ArgumentTypeError(
+            "Episode index exceeds the unsigned 64-bit range"
+        )
+    return parsed
+
+
+def _append_index(indices: list[int], index: int) -> None:
+    if len(indices) == SESSION_MAX_EPISODE_INDICES:
+        raise argparse.ArgumentTypeError(
+            "Episode selector contains too many indices"
+        )
+    if indices and index <= indices[-1]:
+        raise argparse.ArgumentTypeError(
+            "Episode selector must be strictly increasing without overlap"
+        )
+    indices.append(index)
 
 
 if __name__ == "__main__":

--- a/src/evopolicygym/evaluation/_plan.py
+++ b/src/evopolicygym/evaluation/_plan.py
@@ -1,0 +1,27 @@
+"""Trusted exact Episode inputs shared by Evaluation and Run rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..authoring import EpisodeSpec
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedEpisode:
+    """One exact Episode specification and its Policy random seed."""
+
+    episode: EpisodeSpec
+    policy_seed: int
+
+    def __post_init__(self) -> None:
+        if type(self.episode) is not EpisodeSpec:
+            raise TypeError("episode must be EpisodeSpec")
+        if (
+            type(self.policy_seed) is not int
+            or not 0 <= self.policy_seed <= 2**64 - 1
+        ):
+            raise ValueError("policy_seed must be an unsigned 64-bit integer")
+
+
+__all__: list[str] = []

--- a/src/evopolicygym/evaluation/_service.py
+++ b/src/evopolicygym/evaluation/_service.py
@@ -26,6 +26,7 @@ from ..results import (
     PolicyFailureCode,
 )
 from . import EvaluationConfig
+from ._plan import PlannedEpisode
 
 _POLICY_SEED_DOMAIN = b"evopolicygym/policy-seed/v1\0"
 
@@ -96,21 +97,89 @@ class EvaluationService:
             )
         except Exception:
             raise EvaluationError("Benchmark could not plan Episodes") from None
+        if type(spec) is not BenchmarkSpec:
+            raise EvaluationError(
+                "Benchmark returned an invalid specification"
+            )
         if len(planned) != config.episodes:
             raise EvaluationError("Benchmark returned the wrong Episode count")
         if any(type(episode) is not EpisodeSpec for episode in planned):
             raise EvaluationError("Benchmark returned an invalid Episode plan")
 
+        exact_plan = tuple(
+            PlannedEpisode(
+                episode=episode,
+                policy_seed=_derive_policy_seed(config.seed, index),
+            )
+            for index, episode in enumerate(planned)
+        )
+        return self._evaluate_planned(
+            program,
+            benchmark,
+            exact_plan,
+            spec=spec,
+            episode_timeout_seconds=config.episode_timeout_seconds,
+            episode_completed=episode_completed,
+        )
+
+    def evaluate_episodes(
+        self,
+        program: Program,
+        benchmark: Benchmark,
+        episodes: tuple[PlannedEpisode, ...],
+        *,
+        episode_timeout_seconds: float,
+        episode_completed: (
+            Callable[[int, int, EpisodeSummary], None] | None
+        ) = None,
+    ) -> EvaluationResult:
+        """Evaluate an exact Host-owned Episode plan."""
+
+        if type(episodes) is not tuple or not episodes or any(
+            type(episode) is not PlannedEpisode for episode in episodes
+        ):
+            raise EvaluationError("Exact Episode plan is invalid")
+        try:
+            spec = benchmark.spec
+        except Exception:
+            raise EvaluationError(
+                "Benchmark specification is unavailable"
+            ) from None
+        if type(spec) is not BenchmarkSpec:
+            raise EvaluationError(
+                "Benchmark returned an invalid specification"
+            )
+        return self._evaluate_planned(
+            program,
+            benchmark,
+            episodes,
+            spec=spec,
+            episode_timeout_seconds=episode_timeout_seconds,
+            episode_completed=episode_completed,
+        )
+
+    def _evaluate_planned(
+        self,
+        program: Program,
+        benchmark: Benchmark,
+        planned: tuple[PlannedEpisode, ...],
+        *,
+        spec: BenchmarkSpec,
+        episode_timeout_seconds: float,
+        episode_completed: (
+            Callable[[int, int, EpisodeSummary], None] | None
+        ),
+    ) -> EvaluationResult:
         records: list[EpisodeRecord] = []
-        for index, episode in enumerate(planned):
+        for index, planned_episode in enumerate(planned):
             record = self._evaluate_episode(
                 program,
                 benchmark,
-                episode,
+                planned_episode.episode,
                 spec=spec,
-                policy_seed=_derive_policy_seed(config.seed, index),
+                policy_seed=planned_episode.policy_seed,
                 max_steps=spec.max_episode_steps,
-                timeout_seconds=config.episode_timeout_seconds,
+                timeout_seconds=episode_timeout_seconds,
             )
             records.append(record)
             if episode_completed is not None:

--- a/src/evopolicygym/results.py
+++ b/src/evopolicygym/results.py
@@ -130,6 +130,7 @@ class SubmissionResult:
 
     submission_id: str
     program: Program
+    episode_indices: tuple[int, ...]
     episodes_used: int
     episodes_remaining: int
     feedback: Feedback
@@ -139,12 +140,33 @@ class SubmissionResult:
         _non_empty_text(self.submission_id, "submission_id")
         if type(self.program) is not Program:
             raise TypeError("program must be Program")
+        episode_indices = tuple(self.episode_indices)
+        if any(
+            type(index) is not int or not 0 <= index <= 2**64 - 1
+            for index in episode_indices
+        ):
+            raise ValueError(
+                "episode_indices must contain unsigned 64-bit integers"
+            )
+        if any(
+            previous >= current
+            for previous, current in zip(
+                episode_indices,
+                episode_indices[1:],
+                strict=False,
+            )
+        ):
+            raise ValueError("episode_indices must be strictly increasing")
         for name in ("episodes_used", "episodes_remaining"):
             value = getattr(self, name)
             if type(value) is not int or value < 0:
                 raise ValueError(f"{name} must be a non-negative integer")
         if self.episodes_used == 0:
             raise ValueError("episodes_used must be positive")
+        if len(episode_indices) != self.episodes_used:
+            raise ValueError(
+                "episode_indices must match episodes_used"
+            )
         if type(self.feedback) is not Feedback:
             raise TypeError("feedback must be Feedback")
         episodes = tuple(self.episodes)
@@ -152,6 +174,7 @@ class SubmissionResult:
             raise ValueError("episodes must match episodes_used")
         if any(type(episode) is not EpisodeSummary for episode in episodes):
             raise TypeError("episodes must contain EpisodeSummary values")
+        object.__setattr__(self, "episode_indices", episode_indices)
         object.__setattr__(self, "episodes", episodes)
 
     @property

--- a/src/evopolicygym/run/__init__.py
+++ b/src/evopolicygym/run/__init__.py
@@ -59,6 +59,7 @@ class RunConfig:
     split: str = "train"
     max_submissions: int = 20
     episode_budget: int = 1_000
+    episode_pool_size: int | None = None
     max_episodes_per_submission: int | None = None
     validation: ValidationConfig | None = None
     assessment: AssessmentConfig | None = None
@@ -76,6 +77,14 @@ class RunConfig:
             value = getattr(self, name)
             if type(value) is not int or value <= 0:
                 raise ValueError(f"{name} must be a positive integer")
+        pool_size = self.episode_pool_size
+        if pool_size is None:
+            pool_size = self.episode_budget
+            object.__setattr__(self, "episode_pool_size", pool_size)
+        elif type(pool_size) is not int or pool_size <= 0:
+            raise ValueError(
+                "episode_pool_size must be a positive integer or None"
+            )
         submission_limit = self.max_episodes_per_submission
         if submission_limit is not None:
             if type(submission_limit) is not int or submission_limit <= 0:
@@ -85,6 +94,11 @@ class RunConfig:
             if submission_limit > self.episode_budget:
                 raise ValueError(
                     "max_episodes_per_submission cannot exceed episode_budget"
+                )
+            if submission_limit > pool_size:
+                raise ValueError(
+                    "max_episodes_per_submission cannot exceed "
+                    "episode_pool_size"
                 )
         if self.validation is not None:
             if type(self.validation) is not ValidationConfig:

--- a/src/evopolicygym/run/_directory.py
+++ b/src/evopolicygym/run/_directory.py
@@ -21,10 +21,14 @@ from ..program import Program
 from ..results import RunResult
 from ..skills import AgentSkill
 from . import RunConfig
+from ._episode_pool import (
+    TRAINING_POLICY_DERIVATION,
+    TRAINING_POOL_DERIVATION,
+)
 from ._json import encode_public_json_value
 from .progress import RunEvent, RunEventValue, RunObserver
 
-_RUN_RECORD_SCHEMA = "evopolicygym/run-record/v5"
+_RUN_RECORD_SCHEMA = "evopolicygym/run-record/v6"
 _RUN_EVENT_SCHEMA = "evopolicygym/run-event/v1"
 _INVOCATION_SCHEMA = "evopolicygym/agent-invocation/v1"
 _VALIDATION_REPORT_SCHEMA = "evopolicygym/validation-report/v1"
@@ -308,6 +312,7 @@ def _write_run_manifest(
         {
             "submission_id": item.submission_id,
             "program_digest": item.program_digest,
+            "episode_indices": list(item.episode_indices),
             "episodes_used": item.episodes_used,
             "episodes_remaining": item.episodes_remaining,
             "score": item.feedback.score,
@@ -357,6 +362,7 @@ def _write_run_manifest(
                 "seed": config.seed,
                 "max_submissions": config.max_submissions,
                 "episode_budget": config.episode_budget,
+                "episode_pool_size": config.episode_pool_size,
                 "max_episodes_per_submission": (
                     config.max_episodes_per_submission
                 ),
@@ -383,6 +389,11 @@ def _write_run_manifest(
                         "episodes": config.assessment.episodes,
                     }
                 ),
+            },
+            "training_episode_pool": {
+                "size": config.episode_pool_size,
+                "episode_derivation": TRAINING_POOL_DERIVATION,
+                "policy_seed_derivation": TRAINING_POLICY_DERIVATION,
             },
             "agent": {
                 **agent_identity,

--- a/src/evopolicygym/run/_episode_pool.py
+++ b/src/evopolicygym/run/_episode_pool.py
@@ -1,0 +1,78 @@
+"""Host-owned deterministic training Episode pool construction."""
+
+from __future__ import annotations
+
+import hashlib
+
+from ..authoring import EpisodeSpec
+from ..benchmark import Benchmark
+from ..errors import EvaluationError
+from ..evaluation._plan import PlannedEpisode
+from . import RunConfig
+
+TRAINING_POOL_DERIVATION = "evopolicygym/training-pool/v1"
+TRAINING_POLICY_DERIVATION = "evopolicygym/training-policy/v1"
+
+_TRAINING_POOL_SEED_DOMAIN = b"evopolicygym/training-pool/v1\0"
+_TRAINING_POLICY_SEED_DOMAIN = b"evopolicygym/training-policy/v1\0"
+
+
+def build_training_episode_pool(
+    benchmark: Benchmark,
+    config: RunConfig,
+) -> tuple[PlannedEpisode, ...]:
+    """Plan the fixed Run-local training pool before Agent execution."""
+
+    pool_size = config.episode_pool_size
+    assert pool_size is not None
+    training_seed = _derive_seed(
+        config.seed,
+        _TRAINING_POOL_SEED_DOMAIN,
+    )
+    try:
+        episodes = tuple(
+            benchmark.episodes(
+                config.split,
+                seed=training_seed,
+                count=pool_size,
+            )
+        )
+    except Exception:
+        raise EvaluationError(
+            "Benchmark could not plan the training Episode pool"
+        ) from None
+    if len(episodes) != pool_size:
+        raise EvaluationError(
+            "Benchmark returned the wrong training Episode count"
+        )
+    if any(type(episode) is not EpisodeSpec for episode in episodes):
+        raise EvaluationError(
+            "Benchmark returned an invalid training Episode pool"
+        )
+    return tuple(
+        PlannedEpisode(
+            episode=episode,
+            policy_seed=_derive_seed(
+                config.seed,
+                _TRAINING_POLICY_SEED_DOMAIN,
+                index,
+            ),
+        )
+        for index, episode in enumerate(episodes)
+    )
+
+
+def _derive_seed(
+    run_seed: int,
+    domain: bytes,
+    index: int | None = None,
+) -> int:
+    digest = hashlib.sha256()
+    digest.update(domain)
+    digest.update(run_seed.to_bytes(8, "big"))
+    if index is not None:
+        digest.update(index.to_bytes(8, "big"))
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
+__all__: list[str] = []

--- a/src/evopolicygym/run/_feedback.py
+++ b/src/evopolicygym/run/_feedback.py
@@ -13,7 +13,7 @@ from ..artifacts import Artifact
 from ..results import EpisodeSummary, SubmissionResult
 from ._json import encode_public_json_value
 
-_FEEDBACK_SCHEMA = "evopolicygym/feedback/v1"
+_FEEDBACK_SCHEMA = "evopolicygym/feedback/v2"
 
 
 class FilesystemSubmissionPublisher:
@@ -138,11 +138,19 @@ def _materialize_feedback(
         "schema": _FEEDBACK_SCHEMA,
         "submission_id": result.submission_id,
         "program_digest": result.program_digest,
+        "episode_indices": list(result.episode_indices),
         "episodes_used": result.episodes_used,
         "episodes_remaining": result.episodes_remaining,
         "score": result.feedback.score,
         "content": encode_public_json_value(result.feedback.content),
-        "episodes": [_episode_document(item) for item in result.episodes],
+        "episodes": [
+            _episode_document(index, item)
+            for index, item in zip(
+                result.episode_indices,
+                result.episodes,
+                strict=True,
+            )
+        ],
         "artifacts": artifacts,
     }
     _write_json(submission_root / "feedback.json", feedback_document)
@@ -174,8 +182,12 @@ def _materialize_artifacts(
     return documents
 
 
-def _episode_document(episode: EpisodeSummary) -> dict[str, object]:
+def _episode_document(
+    episode_index: int,
+    episode: EpisodeSummary,
+) -> dict[str, object]:
     return {
+        "episode_index": episode_index,
         "status": episode.status,
         "reward": episode.reward,
         "steps": episode.steps,

--- a/src/evopolicygym/run/_service.py
+++ b/src/evopolicygym/run/_service.py
@@ -331,6 +331,7 @@ def run_process_agent(
         remove_control_directory,
         retain_agent_invocation,
     )
+    from ._episode_pool import build_training_episode_pool
     from ._feedback import FilesystemSubmissionPublisher
     from ._session import SubmissionSession
     from ._socket import UnixSessionGateway
@@ -351,6 +352,7 @@ def run_process_agent(
     selected_spec = _benchmark_spec(benchmark) if spec is None else spec
     if type(selected_spec) is not BenchmarkSpec:
         raise TypeError("spec must be BenchmarkSpec or None")
+    episode_pool = build_training_episode_pool(benchmark, config)
 
     paths = prepare_run_directory(
         run_directory,
@@ -383,6 +385,7 @@ def run_process_agent(
                 spec=selected_spec,
                 config=config,
                 recorder=recorder,
+                episode_pool=episode_pool,
             )
             gateway = UnixSessionGateway(paths.socket, session)
             runner = ProcessAgentRunner(

--- a/src/evopolicygym/run/_session.py
+++ b/src/evopolicygym/run/_session.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-import hashlib
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Protocol
 
+from .._protocol.session import SESSION_MAX_EPISODE_INDICES
 from ..benchmark import Benchmark, BenchmarkSpec
 from ..errors import EvaluationError, ProgramError
-from ..evaluation import EvaluationConfig
+from ..evaluation._plan import PlannedEpisode
 from ..program import Program
 from ..results import (
     EpisodeSummary,
@@ -18,8 +18,6 @@ from ..results import (
     SubmissionResult,
 )
 from . import RunConfig
-
-_SUBMISSION_SEED_DOMAIN = b"evopolicygym/submission-seed/v1\0"
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,6 +41,7 @@ class SubmissionReceipt:
     submission_id: str
     program_digest: str
     score: float
+    episode_indices: tuple[int, ...]
     episodes_used: int
     episodes_remaining: int
 
@@ -64,12 +63,13 @@ class ProgramSource(Protocol):
 
 
 class ProgramEvaluator(Protocol):
-    def evaluate(
+    def evaluate_episodes(
         self,
         program: Program,
         benchmark: Benchmark,
-        config: EvaluationConfig,
+        episodes: tuple[PlannedEpisode, ...],
         *,
+        episode_timeout_seconds: float,
         episode_completed: (
             Callable[[int, int, EpisodeSummary], None] | None
         ) = None,
@@ -104,9 +104,25 @@ class SubmissionSession:
         spec: BenchmarkSpec,
         config: RunConfig,
         recorder: EventRecorder,
+        episode_pool: tuple[PlannedEpisode, ...],
     ) -> None:
         if type(spec) is not BenchmarkSpec:
             raise TypeError("spec must be BenchmarkSpec")
+        if (
+            type(episode_pool) is not tuple
+            or not episode_pool
+            or any(
+                type(episode) is not PlannedEpisode
+                for episode in episode_pool
+            )
+        ):
+            raise TypeError(
+                "episode_pool must be a non-empty tuple of PlannedEpisode values"
+            )
+        if len(episode_pool) != config.episode_pool_size:
+            raise ValueError(
+                "episode_pool must match config.episode_pool_size"
+            )
         self._programs = programs
         self._evaluator = evaluator
         self._publisher = publisher
@@ -114,6 +130,7 @@ class SubmissionSession:
         self._spec = spec
         self._config = config
         self._recorder = recorder
+        self._episode_pool = episode_pool
         self._episodes_remaining = config.episode_budget
         self._submissions: list[SubmissionResult] = []
         self._candidate_submission_ids: tuple[str, ...] | None = None
@@ -145,11 +162,42 @@ class SubmissionSession:
             or len(self._submissions) >= self._config.max_submissions
         )
 
-    def submit(self, episodes: object) -> SubmissionOutcome:
+    def submit(self, episode_indices: object) -> SubmissionOutcome:
         if self.agent_authority_closed:
             return _error("session_closed", "the Agent Session is already closed")
-        if type(episodes) is not int or episodes <= 0:
-            return _error("invalid_request", "episodes must be a positive integer")
+        if type(episode_indices) is not list or not episode_indices:
+            return _error(
+                "invalid_request",
+                "episode_indices must be a non-empty list",
+            )
+        if any(
+            type(index) is not int
+            or not 0 <= index < len(self._episode_pool)
+            for index in episode_indices
+        ):
+            return _error(
+                "invalid_request",
+                "episode_indices contains an invalid pool index",
+            )
+        selected_indices = tuple(episode_indices)
+        if any(
+            previous >= current
+            for previous, current in zip(
+                selected_indices,
+                selected_indices[1:],
+                strict=False,
+            )
+        ):
+            return _error(
+                "invalid_request",
+                "episode_indices must be strictly increasing",
+            )
+        episodes = len(selected_indices)
+        if episodes > SESSION_MAX_EPISODE_INDICES:
+            return _error(
+                "episode_limit",
+                "episode_indices exceeds the Session protocol limit",
+            )
         if len(self._submissions) >= self._config.max_submissions:
             return _error("submission_limit", "the submission limit is exhausted")
         submission_limit = self._config.max_episodes_per_submission
@@ -182,6 +230,7 @@ class SubmissionSession:
                 "submission_id": submission_id,
                 "program_digest": program.digest,
                 "episodes": episodes,
+                "episode_indices": _render_indices(selected_indices),
                 "episodes_remaining": self._episodes_remaining,
             },
         )
@@ -197,19 +246,19 @@ class SubmissionSession:
                         "submission_id": submission_id,
                         "completed": completed,
                         "total": total,
+                        "episode_index": selected_indices[completed - 1],
                         "status": summary.status,
                     },
                 )
 
-            evaluation = self._evaluator.evaluate(
+            evaluation = self._evaluator.evaluate_episodes(
                 program,
                 self._benchmark,
-                EvaluationConfig(
-                    split=self._config.split,
-                    episodes=episodes,
-                    seed=_submission_seed(self._config.seed, ordinal),
-                    episode_timeout_seconds=self._config.episode_timeout_seconds,
+                tuple(
+                    self._episode_pool[index]
+                    for index in selected_indices
                 ),
+                episode_timeout_seconds=self._config.episode_timeout_seconds,
                 episode_completed=episode_completed,
             )
             if (
@@ -240,6 +289,7 @@ class SubmissionSession:
         result = SubmissionResult(
             submission_id=submission_id,
             program=program,
+            episode_indices=selected_indices,
             episodes_used=episodes,
             episodes_remaining=self._episodes_remaining,
             feedback=evaluation.feedback,
@@ -275,6 +325,7 @@ class SubmissionSession:
             submission_id=submission_id,
             program_digest=program.digest,
             score=result.feedback.score,
+            episode_indices=selected_indices,
             episodes_used=episodes,
             episodes_remaining=self._episodes_remaining,
         )
@@ -352,12 +403,8 @@ class SubmissionSession:
         return _error(code, message)
 
 
-def _submission_seed(run_seed: int, ordinal: int) -> int:
-    digest = hashlib.sha256()
-    digest.update(_SUBMISSION_SEED_DOMAIN)
-    digest.update(run_seed.to_bytes(8, "big"))
-    digest.update(ordinal.to_bytes(8, "big"))
-    return int.from_bytes(digest.digest()[:8], "big")
+def _render_indices(indices: tuple[int, ...]) -> str:
+    return ",".join(str(index) for index in indices)
 
 
 def _error(code: str, message: str) -> SessionError:

--- a/src/evopolicygym/run/_socket.py
+++ b/src/evopolicygym/run/_socket.py
@@ -118,9 +118,9 @@ def _handle_request(
         return _error("protocol_mismatch", "unsupported Agent Session protocol")
     method = request.get("method")
     if method == "submit":
-        if set(request) != {"protocol", "method", "episodes"}:
+        if set(request) != {"protocol", "method", "episode_indices"}:
             return _error("invalid_request", "submit request fields are invalid")
-        submit_outcome = session.submit(request["episodes"])
+        submit_outcome = session.submit(request["episode_indices"])
         if isinstance(submit_outcome, SessionError):
             return _error(submit_outcome.code, submit_outcome.message)
         assert isinstance(submit_outcome, SubmissionReceipt)
@@ -131,6 +131,9 @@ def _handle_request(
                 "submission_id": submit_outcome.submission_id,
                 "program_digest": submit_outcome.program_digest,
                 "score": submit_outcome.score,
+                "episode_indices": list(
+                    submit_outcome.episode_indices
+                ),
                 "episodes_used": submit_outcome.episodes_used,
                 "episodes_remaining": submit_outcome.episodes_remaining,
                 "feedback": (

--- a/src/evopolicygym/run/_task.py
+++ b/src/evopolicygym/run/_task.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 
+from .._protocol.session import SESSION_MAX_EPISODE_INDICES
 from ..agents import AgentTask
 from ..benchmark import BenchmarkSpec
 from ..skills import AgentSkill
@@ -19,17 +20,31 @@ def build_agent_task(
     """Build the provider-independent instructions for one development Run."""
 
     submission_limit = config.max_episodes_per_submission
+    pool_size = config.episode_pool_size
+    assert pool_size is not None
+    effective_submission_limit = min(
+        SESSION_MAX_EPISODE_INDICES,
+        pool_size,
+        (
+            SESSION_MAX_EPISODE_INDICES
+            if submission_limit is None
+            else submission_limit
+        ),
+    )
     if submission_limit is None:
         episode_guidance = (
-            "Choose any positive N no greater than the remaining Episode budget. "
-            "You decide how to allocate it. The whole Run has "
+            "Choose any non-empty, strictly increasing set of indices with no "
+            f"more than {effective_submission_limit} entries and no more than "
+            "the remaining Episode budget. You decide how to allocate it. "
+            "The whole Run has "
             f"{config.episode_budget} Episode units and at most "
             f"{config.max_submissions} submissions."
         )
     else:
         episode_guidance = (
-            f"Choose a positive N no greater than {submission_limit} and no greater "
-            "than the remaining Episode budget. You decide how to allocate it. "
+            "Choose any non-empty, strictly increasing set of indices with no "
+            f"more than {effective_submission_limit} entries and no more than "
+            "the remaining Episode budget. You decide how to allocate it. "
             f"The whole Run has {config.episode_budget} Episode units and at most "
             f"{config.max_submissions} submissions."
         )
@@ -109,11 +124,20 @@ The Host publishes authorized evaluation data under:
 
 Do not modify feedback/. Evaluate the current Program with:
 
-    evopolicygym submit program --episodes N
+    evopolicygym submit program --episodes "{_selector_example(pool_size)}"
 
-{episode_guidance} Small submissions support fast iteration; larger submissions
+The available Run-local training Episode indices are 0 through
+{pool_size - 1}. A singleton like "7" selects one index; START:END is a
+half-open range, and comma-separated items form a union. Repeated or overlapping
+indices in one submission are rejected. You may deliberately reuse an index in
+a later submission; that index has the same hidden Episode specification and
+Policy seed, while the Host still creates a fresh Environment and fresh Policy
+runtime. Every selected index consumes one Episode budget unit on every use.
+
+{episode_guidance} Small selections support fast iteration; larger selections
 provide more evidence. Read feedback/latest.json and the referenced Feedback
-and Artifact files after every successful submission. The Feedback document's
+and Artifact files after every successful submission. The Feedback document
+maps each public Episode result back to its selected Run-local index. Its
 content field and all Artifact contents are defined by the Benchmark. Inspect
 their structure, names, media types, and contents to understand the available
 development evidence.
@@ -156,6 +180,18 @@ Benchmark specification, current observations, and legal Actions as
 authoritative.
 
 """
+
+
+def _selector_example(pool_size: int) -> str:
+    if pool_size >= 8:
+        return "0:2,4:8"
+    if pool_size >= 5:
+        return f"0:2,4:{pool_size}"
+    if pool_size >= 3:
+        return f"0:2,{pool_size - 1}"
+    if pool_size == 2:
+        return "0:2"
+    return "0"
 
 
 __all__: list[str] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import unittest
+
+from evopolicygym._protocol.session import SESSION_MAX_EPISODE_INDICES
+from evopolicygym.cli import _parse_episode_selector
+
+
+class EpisodeSelectorTests(unittest.TestCase):
+    def test_ranges_and_singletons_expand_to_a_canonical_union(self) -> None:
+        self.assertEqual(
+            _parse_episode_selector("0:2,4:8"),
+            (0, 1, 4, 5, 6, 7),
+        )
+        self.assertEqual(
+            _parse_episode_selector("0,2,5"),
+            (0, 2, 5),
+        )
+        self.assertEqual(
+            _parse_episode_selector("0:2,2:4"),
+            (0, 1, 2, 3),
+        )
+
+    def test_malformed_duplicate_and_overlapping_selectors_are_rejected(
+        self,
+    ) -> None:
+        for selector in (
+            "",
+            "0,",
+            ",0",
+            "0 1",
+            "-1",
+            "0:0",
+            "2:1",
+            "0::1",
+            "0,0",
+            "0:3,2:4",
+            "2,1",
+            str(2**64),
+            f"0:{2**64 + 1}",
+        ):
+            with self.subTest(selector=selector):
+                with self.assertRaises(argparse.ArgumentTypeError):
+                    _parse_episode_selector(selector)
+
+    def test_selector_has_a_protocol_expansion_limit(self) -> None:
+        accepted = _parse_episode_selector(
+            f"0:{SESSION_MAX_EPISODE_INDICES}"
+        )
+        self.assertEqual(len(accepted), SESSION_MAX_EPISODE_INDICES)
+        with self.assertRaises(argparse.ArgumentTypeError):
+            _parse_episode_selector(
+                f"0:{SESSION_MAX_EPISODE_INDICES + 1}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_episode_pool.py
+++ b/tests/test_episode_pool.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import unittest
+from collections.abc import Sequence
+
+from evopolicygym.authoring import (
+    BenchmarkSpec,
+    Environment,
+    EpisodeRecord,
+    EpisodeSpec,
+    Feedback,
+)
+from evopolicygym.errors import EvaluationError
+from evopolicygym.run import RunConfig
+from evopolicygym.run._episode_pool import build_training_episode_pool
+
+
+class PoolBenchmark:
+    def __init__(self, *, count_delta: int = 0) -> None:
+        self.count_delta = count_delta
+        self.calls: list[tuple[str, int, int]] = []
+
+    @property
+    def spec(self) -> BenchmarkSpec:
+        return BenchmarkSpec(
+            id="example/pool-v1",
+            description="Episode pool fixture.",
+            observation_space=None,
+            action_space=None,
+            metadata={},
+            max_episode_steps=1,
+            primary_metric="reward",
+            score_direction="maximize",
+        )
+
+    def episodes(
+        self,
+        split: str,
+        *,
+        seed: int,
+        count: int,
+    ) -> Sequence[EpisodeSpec]:
+        self.calls.append((split, seed, count))
+        returned = count + self.count_delta
+        return tuple(
+            EpisodeSpec(
+                environment_seed=(seed + index) % 2**64,
+                scenario={"pool_offset": index},
+            )
+            for index in range(max(returned, 0))
+        )
+
+    def make_environment(self, episode: EpisodeSpec) -> Environment:
+        del episode
+        raise AssertionError("pool construction must not make Environments")
+
+    def feedback(self, episodes: Sequence[EpisodeRecord]) -> Feedback:
+        del episodes
+        raise AssertionError("pool construction must not produce Feedback")
+
+
+class TrainingEpisodePoolTests(unittest.TestCase):
+    def test_v1_derivation_is_stable_and_plans_the_pool_once(self) -> None:
+        benchmark = PoolBenchmark()
+        config = RunConfig(
+            split="train",
+            seed=42,
+            episode_budget=3,
+            episode_pool_size=6,
+        )
+
+        pool = build_training_episode_pool(benchmark, config)
+
+        self.assertEqual(
+            benchmark.calls,
+            [("train", 18_379_659_693_720_673_948, 6)],
+        )
+        self.assertEqual(
+            tuple(item.policy_seed for item in pool),
+            (
+                14_800_640_075_610_612_724,
+                18_417_242_732_802_892_877,
+                4_899_245_222_503_671_816,
+                4_992_441_726_760_788_367,
+                15_637_959_876_430_147_121,
+                17_254_460_676_015_203_078,
+            ),
+        )
+        self.assertEqual(
+            tuple(item.episode.scenario for item in pool),
+            tuple({"pool_offset": index} for index in range(6)),
+        )
+
+    def test_wrong_benchmark_count_is_a_trusted_evaluation_failure(self) -> None:
+        with self.assertRaisesRegex(
+            EvaluationError,
+            "wrong training Episode count",
+        ):
+            build_training_episode_pool(
+                PoolBenchmark(count_delta=-1),
+                RunConfig(episode_budget=3),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_filesystem_publication.py
+++ b/tests/test_filesystem_publication.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import stat
 import tempfile
@@ -29,6 +30,7 @@ def make_submission(root: Path) -> SubmissionResult:
     return SubmissionResult(
         submission_id="submission-000001",
         program=Program.from_directory(source),
+        episode_indices=(0,),
         episodes_used=1,
         episodes_remaining=0,
         feedback=Feedback(score=1.0, content="fixture"),
@@ -75,6 +77,18 @@ class FilesystemSubmissionPublisherTests(unittest.TestCase):
                     (destination / "feedback.json").stat().st_mode
                 ),
                 0o444,
+            )
+            feedback = json.loads(
+                (destination / "feedback.json").read_text()
+            )
+            self.assertEqual(
+                feedback["schema"],
+                "evopolicygym/feedback/v2",
+            )
+            self.assertEqual(feedback["episode_indices"], [0])
+            self.assertEqual(
+                feedback["episodes"][0]["episode_index"],
+                0,
             )
 
     def test_freeze_failure_removes_published_and_temporary_trees(self) -> None:

--- a/tests/test_program_evolution.py
+++ b/tests/test_program_evolution.py
@@ -260,6 +260,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
             submission = SubmissionResult(
                 submission_id="submission-000001",
                 program=program,
+                episode_indices=(0,),
                 episodes_used=1,
                 episodes_remaining=0,
                 feedback=Feedback(score=1.0),
@@ -327,6 +328,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
             submission = SubmissionResult(
                 submission_id="submission-000001",
                 program=program,
+                episode_indices=(0,),
                 episodes_used=1,
                 episodes_remaining=0,
                 feedback=Feedback(score=1.0),
@@ -375,6 +377,7 @@ class ProgramEvolutionRunTests(unittest.TestCase):
             submission = SubmissionResult(
                 submission_id="submission-000001",
                 program=program,
+                episode_indices=(0,),
                 episodes_used=1,
                 episodes_remaining=0,
                 feedback=Feedback(score=1.0),

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -10,6 +10,7 @@ from evopolicygym._protocol.policy import (
 )
 from evopolicygym._protocol.session import (
     SESSION_FRAMES,
+    SESSION_MAX_EPISODE_INDICES,
     SESSION_MAX_FRAME_BYTES,
     SESSION_PROTOCOL,
 )
@@ -48,6 +49,19 @@ class PolicyProtocolTests(unittest.TestCase):
 
 
 class AgentSessionProtocolTests(unittest.TestCase):
+    def test_v3_submit_carries_explicit_episode_indices(self) -> None:
+        self.assertEqual(SESSION_PROTOCOL, "agent-session/v3")
+        message: dict[str, object] = {
+            "protocol": SESSION_PROTOCOL,
+            "method": "submit",
+            "episode_indices": [0, 1, 4, 5, 6, 7],
+        }
+        self.assertEqual(
+            SESSION_FRAMES.decode(SESSION_FRAMES.encode(message)),
+            message,
+        )
+        self.assertEqual(SESSION_MAX_EPISODE_INDICES, 2_048)
+
     def test_session_frame_round_trip_and_boundaries(self) -> None:
         message: dict[str, object] = {
             "protocol": SESSION_PROTOCOL,

--- a/tests/test_public_contract.py
+++ b/tests/test_public_contract.py
@@ -442,9 +442,11 @@ description: Improve counter policies.
         self.assertEqual(evaluation.episodes, 2)
         self.assertEqual(run.max_submissions, 4)
         self.assertEqual(run.episode_budget, 20)
+        self.assertEqual(run.episode_pool_size, 20)
         self.assertIsNone(run.max_episodes_per_submission)
         capped = RunConfig(
             episode_budget=20,
+            episode_pool_size=12,
             max_episodes_per_submission=5,
             validation=ValidationConfig(
                 episodes_per_candidate=7,
@@ -455,6 +457,7 @@ description: Improve counter policies.
             ),
         )
         self.assertEqual(capped.max_episodes_per_submission, 5)
+        self.assertEqual(capped.episode_pool_size, 12)
         self.assertEqual(
             capped.validation,
             ValidationConfig(
@@ -472,6 +475,14 @@ description: Improve counter policies.
         with self.assertRaises(ValueError):
             RunConfig(
                 episode_budget=2,
+                max_episodes_per_submission=3,
+            )
+        with self.assertRaises(ValueError):
+            RunConfig(episode_pool_size=0)
+        with self.assertRaises(ValueError):
+            RunConfig(
+                episode_budget=10,
+                episode_pool_size=2,
                 max_episodes_per_submission=3,
             )
         with self.assertRaises(ValueError):
@@ -509,6 +520,7 @@ description: Improve counter policies.
         submission = SubmissionResult(
             submission_id="submission-1",
             program=program,
+            episode_indices=(0,),
             episodes_used=1,
             episodes_remaining=2,
             feedback=feedback,
@@ -543,6 +555,7 @@ class ProgramTests(unittest.TestCase):
             submission = SubmissionResult(
                 submission_id="submission-1",
                 program=first,
+                episode_indices=(0,),
                 episodes_used=1,
                 episodes_remaining=0,
                 feedback=Feedback(score=1.0, content="complete"),
@@ -584,6 +597,7 @@ class ProgramTests(unittest.TestCase):
             submission = SubmissionResult(
                 submission_id="submission-000001",
                 program=program,
+                episode_indices=(0,),
                 episodes_used=1,
                 episodes_remaining=0,
                 feedback=Feedback(
@@ -1034,13 +1048,17 @@ def call(*arguments):
     return json.loads(completed.stdout)
 
 
-first = call("submit", "program", "--episodes", "1")
+first = call("submit", "program", "--episodes", "0")
 latest = json.loads((workspace / "feedback" / "latest.json").read_text())
 feedback = json.loads(
     (workspace / "feedback" / latest["feedback"]).read_text()
 )
 assert first["result"]["submission_id"] == "submission-000001"
+assert first["result"]["episode_indices"] == [0]
 assert first["result"]["episodes_remaining"] == 1
+assert feedback["schema"] == "evopolicygym/feedback/v2"
+assert feedback["episode_indices"] == [0]
+assert feedback["episodes"][0]["episode_index"] == 0
 assert feedback["episodes"][0]["failure"] == "invalid_action"
 assert feedback["content"] == {{"status": "complete", "completed": 0}}
 assert not (workspace / "events.jsonl").exists()
@@ -1050,7 +1068,7 @@ assert not (workspace / "agent").exists()
     {improved_source!r},
     encoding="utf-8",
 )
-second = call("submit", "program", "--episodes", "1")
+second = call("submit", "program", "--episodes", "0")
 latest = json.loads((workspace / "feedback" / "latest.json").read_text())
 feedback = json.loads(
     (workspace / "feedback" / latest["feedback"]).read_text()
@@ -1059,6 +1077,9 @@ artifact = workspace / "feedback" / "submissions" / (
     second["result"]["submission_id"]
 ) / feedback["artifacts"][0]["path"]
 assert feedback["score"] == 1.0
+assert second["result"]["episode_indices"] == [0]
+assert feedback["episode_indices"] == [0]
+assert feedback["episodes"][0]["episode_index"] == 0
 assert feedback["content"] == {{"status": "complete", "completed": 1}}
 assert artifact.read_text() == "completed=1\\n"
 (workspace / "program" / "policy.py").write_text(
@@ -1201,7 +1222,25 @@ print("fake-agent-finished")
             [event.name for event in observer.events],
             [event["event"] for event in events],
         )
-        self.assertEqual(manifest["schema"], "evopolicygym/run-record/v5")
+        self.assertEqual(manifest["schema"], "evopolicygym/run-record/v6")
+        self.assertEqual(manifest["config"]["episode_pool_size"], 2)
+        self.assertEqual(
+            manifest["training_episode_pool"],
+            {
+                "size": 2,
+                "episode_derivation": "evopolicygym/training-pool/v1",
+                "policy_seed_derivation": (
+                    "evopolicygym/training-policy/v1"
+                ),
+            },
+        )
+        self.assertEqual(
+            [
+                submission["episode_indices"]
+                for submission in manifest["submissions"]
+            ],
+            [[0], [0]],
+        )
         self.assertEqual(manifest["skills"], [])
         self.assertEqual(
             manifest["benchmark"],
@@ -1309,7 +1348,7 @@ subprocess.run(
         "submit",
         "program",
         "--episodes",
-        "2",
+        "0:2",
     ],
     check=False,
 )
@@ -1451,7 +1490,7 @@ prompt = arguments[-1]
 assert "program/" in prompt
 assert "feedback/" in prompt
 assert "skills/improve-counter/SKILL.md" in prompt
-assert "evopolicygym submit program --episodes N" in prompt
+assert 'evopolicygym submit program --episodes "0"' in prompt
 assert "evopolicygym finish SUBMISSION_ID" in prompt
 assert os.environ["CODEX_API_KEY"] == {api_key!r}
 assert "EVOPOLICYGYM_TEST_SECRET" not in os.environ
@@ -1474,7 +1513,7 @@ def call(*arguments):
     return json.loads(completed.stdout)
 
 
-submission = call("submit", "program", "--episodes", "1")
+submission = call("submit", "program", "--episodes", "0")
 latest = json.loads((workspace / "feedback" / "latest.json").read_text())
 feedback = json.loads(
     (workspace / "feedback" / latest["feedback"]).read_text()

--- a/tests/test_run_assessment.py
+++ b/tests/test_run_assessment.py
@@ -143,6 +143,7 @@ def make_submission(root: Path) -> SubmissionResult:
     return SubmissionResult(
         submission_id="submission-000001",
         program=Program.from_directory(source),
+        episode_indices=(0,),
         episodes_used=1,
         episodes_remaining=0,
         feedback=Feedback(score=1.0),

--- a/tests/test_run_validation.py
+++ b/tests/test_run_validation.py
@@ -154,6 +154,7 @@ def make_submission(
     return SubmissionResult(
         submission_id=f"submission-{ordinal:06d}",
         program=Program.from_directory(source),
+        episode_indices=(0,),
         episodes_used=1,
         episodes_remaining=10 - ordinal,
         feedback=Feedback(score=float(ordinal)),

--- a/tests/test_submission_session.py
+++ b/tests/test_submission_session.py
@@ -13,7 +13,7 @@ from evopolicygym.authoring import (
     EpisodeSpec,
 )
 from evopolicygym.errors import EvaluationError, ProgramSourceError
-from evopolicygym.evaluation import EvaluationConfig
+from evopolicygym.evaluation._plan import PlannedEpisode
 from evopolicygym.program import Program
 from evopolicygym.results import (
     EpisodeSummary,
@@ -88,28 +88,30 @@ class FakeEvaluator:
     ) -> None:
         self.fail = fail
         self.mismatch_environment = mismatch_environment
-        self.configs: list[EvaluationConfig] = []
+        self.plans: list[tuple[PlannedEpisode, ...]] = []
 
-    def evaluate(
+    def evaluate_episodes(
         self,
         program: Program,
         benchmark: Benchmark,
-        config: EvaluationConfig,
+        episodes: tuple[PlannedEpisode, ...],
         *,
+        episode_timeout_seconds: float,
         episode_completed: (
             Callable[[int, int, EpisodeSummary], None] | None
         ) = None,
     ) -> EvaluationResult:
-        self.configs.append(config)
+        del episode_timeout_seconds
+        self.plans.append(episodes)
         if self.fail:
             raise EvaluationError("trusted fixture failure")
-        episodes = tuple(
+        summaries = tuple(
             EpisodeSummary(status="completed", reward=1.0, steps=1)
-            for _ in range(config.episodes)
+            for _ in episodes
         )
         if episode_completed is not None:
-            for index, episode in enumerate(episodes, start=1):
-                episode_completed(index, len(episodes), episode)
+            for index, summary in enumerate(summaries, start=1):
+                episode_completed(index, len(summaries), summary)
         return EvaluationResult(
             benchmark_id="example/session-v1",
             environment_digest=(
@@ -119,10 +121,10 @@ class FakeEvaluator:
             ),
             program_digest=program.digest,
             feedback=Feedback(
-                score=float(config.episodes),
+                score=float(len(episodes)),
                 content="fixture",
             ),
-            episodes=episodes,
+            episodes=summaries,
         )
 
 
@@ -175,13 +177,14 @@ class SubmissionSessionTests(unittest.TestCase):
                 episode_budget=7,
             )
 
-            submitted = session.submit(7)
+            submitted = session.submit(list(range(7)))
 
         self.assertIsInstance(submitted, SubmissionReceipt)
         assert isinstance(submitted, SubmissionReceipt)
         self.assertEqual(submitted.episodes_used, 7)
+        self.assertEqual(submitted.episode_indices, tuple(range(7)))
         self.assertEqual(submitted.episodes_remaining, 0)
-        self.assertEqual(evaluator.configs[0].episodes, 7)
+        self.assertEqual(len(evaluator.plans[0]), 7)
 
     def test_optional_submission_cap_rejects_only_oversized_requests(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -194,8 +197,8 @@ class SubmissionSessionTests(unittest.TestCase):
                 max_episodes_per_submission=3,
             )
 
-            rejected = session.submit(4)
-            accepted = session.submit(3)
+            rejected = session.submit(list(range(4)))
+            accepted = session.submit(list(range(3)))
 
         self.assertIsInstance(rejected, SessionError)
         assert isinstance(rejected, SessionError)
@@ -215,8 +218,8 @@ class SubmissionSessionTests(unittest.TestCase):
                 episode_budget=3,
             )
 
-            rejected = session.submit(3)
-            accepted = session.submit(3)
+            rejected = session.submit(list(range(3)))
+            accepted = session.submit(list(range(3)))
 
         self.assertIsInstance(rejected, SessionError)
         assert isinstance(rejected, SessionError)
@@ -237,8 +240,8 @@ class SubmissionSessionTests(unittest.TestCase):
                 episode_budget=5,
             )
 
-            failed = session.submit(3)
-            closed = session.submit(1)
+            failed = session.submit(list(range(3)))
+            closed = session.submit([0])
 
         self.assertIsInstance(failed, SessionError)
         assert isinstance(failed, SessionError)
@@ -265,7 +268,7 @@ class SubmissionSessionTests(unittest.TestCase):
                 episode_budget=5,
             )
 
-            submitted = session.submit(2)
+            submitted = session.submit([0, 1])
             assert isinstance(submitted, SubmissionReceipt)
             finished = session.finish([submitted.submission_id])
 
@@ -294,12 +297,14 @@ class SubmissionSessionTests(unittest.TestCase):
                     "submission_id": "submission-000001",
                     "completed": 1,
                     "total": 2,
+                    "episode_index": 0,
                     "status": "completed",
                 },
                 {
                     "submission_id": "submission-000001",
                     "completed": 2,
                     "total": 2,
+                    "episode_index": 1,
                     "status": "completed",
                 },
             ],
@@ -315,7 +320,7 @@ class SubmissionSessionTests(unittest.TestCase):
                 publisher,
             )
 
-            outcome = session.submit(1)
+            outcome = session.submit([0])
 
         self.assertIsInstance(outcome, SessionError)
         assert isinstance(outcome, SessionError)
@@ -333,7 +338,7 @@ class SubmissionSessionTests(unittest.TestCase):
                 FakePublisher(fail=True),
             )
 
-            outcome = session.submit(1)
+            outcome = session.submit([0])
 
         self.assertIsInstance(outcome, SessionError)
         assert isinstance(outcome, SessionError)
@@ -375,8 +380,8 @@ class SubmissionSessionTests(unittest.TestCase):
                     max_candidates=2,
                 ),
             )
-            first = session.submit(1)
-            second = session.submit(1)
+            first = session.submit([0])
+            second = session.submit([0])
             assert isinstance(first, SubmissionReceipt)
             assert isinstance(second, SubmissionReceipt)
 
@@ -397,7 +402,7 @@ class SubmissionSessionTests(unittest.TestCase):
             accepted = session.finish(
                 [second.submission_id, first.submission_id]
             )
-            closed = session.submit(1)
+            closed = session.submit([0])
 
         for outcome, code in (
             (malformed, "invalid_request"),
@@ -429,8 +434,8 @@ class SubmissionSessionTests(unittest.TestCase):
                 FakeEvaluator(),
                 FakePublisher(),
             )
-            first = session.submit(1)
-            second = session.submit(1)
+            first = session.submit([0])
+            second = session.submit([0])
             assert isinstance(first, SubmissionReceipt)
             assert isinstance(second, SubmissionReceipt)
 
@@ -442,6 +447,59 @@ class SubmissionSessionTests(unittest.TestCase):
         assert isinstance(outcome, SessionError)
         self.assertEqual(outcome.code, "candidate_limit")
         self.assertFalse(session.agent_authority_closed)
+
+    def test_arbitrary_indices_select_the_exact_fixed_pool_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            program = make_program(Path(temporary))
+            evaluator = FakeEvaluator()
+            session = self._session(
+                FakeProgramSource(program),
+                evaluator,
+                FakePublisher(),
+                episode_budget=12,
+            )
+
+            first = session.submit([0, 1, 4, 5, 6, 7])
+            second = session.submit([1, 4])
+
+        self.assertIsInstance(first, SubmissionReceipt)
+        self.assertIsInstance(second, SubmissionReceipt)
+        self.assertEqual(
+            tuple(item.episode.environment_seed for item in evaluator.plans[0]),
+            (0, 1, 4, 5, 6, 7),
+        )
+        self.assertEqual(evaluator.plans[0][1], evaluator.plans[1][0])
+        self.assertEqual(evaluator.plans[0][2], evaluator.plans[1][1])
+
+    def test_invalid_index_sets_do_not_capture_or_consume_budget(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            program = make_program(Path(temporary))
+            source = FakeProgramSource(program)
+            evaluator = FakeEvaluator()
+            session = self._session(
+                source,
+                evaluator,
+                FakePublisher(),
+                episode_budget=5,
+            )
+
+            outcomes = (
+                session.submit([]),
+                session.submit([0, 0]),
+                session.submit([2, 1]),
+                session.submit([5]),
+                session.submit([True]),
+            )
+            accepted = session.submit([0, 2, 4])
+
+        for outcome in outcomes:
+            self.assertIsInstance(outcome, SessionError)
+            assert isinstance(outcome, SessionError)
+            self.assertEqual(outcome.code, "invalid_request")
+        self.assertIsInstance(accepted, SubmissionReceipt)
+        assert isinstance(accepted, SubmissionReceipt)
+        self.assertEqual(accepted.episodes_remaining, 2)
+        self.assertEqual(len(evaluator.plans), 1)
 
     def _session(
         self,
@@ -455,18 +513,29 @@ class SubmissionSessionTests(unittest.TestCase):
         validation: ValidationConfig | None = None,
     ) -> SubmissionSession:
         benchmark = StubBenchmark()
+        config = RunConfig(
+            episode_budget=episode_budget,
+            max_episodes_per_submission=max_episodes_per_submission,
+            validation=validation,
+        )
+        pool_size = config.episode_pool_size
+        assert pool_size is not None
+        episode_pool = tuple(
+            PlannedEpisode(
+                EpisodeSpec(environment_seed=index),
+                policy_seed=10_000 + index,
+            )
+            for index in range(pool_size)
+        )
         return SubmissionSession(
             programs=source,
             evaluator=evaluator,
             publisher=publisher,
             benchmark=benchmark,
             spec=benchmark.spec,
-            config=RunConfig(
-                episode_budget=episode_budget,
-                max_episodes_per_submission=max_episodes_per_submission,
-                validation=validation,
-            ),
+            config=config,
             recorder=FakeRecorder() if recorder is None else recorder,
+            episode_pool=episode_pool,
         )
 
 


### PR DESCRIPTION
## Summary

- derive one fixed Host-owned training Episode pool from `RunConfig.seed`
- let Coding Agents submit strictly increasing Run-local Episode index unions through `agent-session/v3`
- retain selected indices in public Feedback and Host Run records while keeping Validation and Assessment independent
- document the pool, budget, selector, and reproducibility semantics in the SDK, Agent Skill, scripts, and bilingual site docs

## Why

Per-Submission seed derivation made Program revisions run on different training conditions. A fixed indexed pool gives the Agent explicit control over evidence reuse and enables matched comparisons without weakening fresh Environment and Policy-runtime guarantees.

## Impact

`evopolicygym submit --episodes` now accepts singleton and half-open range selectors such as `"0:2,4:8"`. The Session protocol is `agent-session/v3`, Feedback is `evopolicygym/feedback/v2`, and Run records are `evopolicygym/run-record/v6`.

## Validation

- `uv run ruff check src tests scripts/run_cartpole_codex.py scripts/run_balatro_codex.py scripts/run_balatro_skill_ab.py`
- `uv run mypy`
- `uv run python -m unittest discover -s tests` (99 tests)
- `uv build`
