### PR TITLE
site: document indexed episode pool

### DIFF
--- a/site/src/content/blog/en/designing-evopolicygym.md
+++ b/site/src/content/blog/en/designing-evopolicygym.md
@@ -91,7 +91,7 @@ This choice makes a Run understandable as a sequence of authored artifacts:
 | Object | Responsibility |
 | --- | --- |
 | `Program` | The executable Policy source being evaluated |
-| `Submission` | One immutable Program paired with committed Feedback |
+| `Submission` | One immutable Program, an explicit training-index selector, and committed Feedback |
 | `Run` | A bounded sequence of submissions and a final handoff |
 | `Validation` | Host-side selection among finished candidates |
 | `Assessment` | Held-out measurement of the selected Program |
@@ -120,14 +120,24 @@ Kernel remains stable and domain-independent.
 
 ## Treat evidence access as part of the experiment
 
-A Run's submission and Episode limits define its experimental condition.
-Sixteen submissions and forty-eight Episodes grant a specific amount of
-evidence from which the agent can improve.
+A Run's submission limit, total Episode budget, fixed training-pool size, and
+optional per-Submission cap define its experimental condition. For example,
+sixteen submissions, forty-eight Episode units, and a pool of ninety-six
+Episode identities grant forty-eight total observations selected from a wider
+set; the larger pool does not increase the interaction budget.
 
-These limits are fixed before the agent starts. Once an Evaluation begins, its
-Episode allocation is consumed. Policy failures and invalid Actions are
-reported as observed behavior, preserving the exact semantics of the submitted
-Program.
+The Host constructs this indexed pool before the agent starts. Each Submission
+names a non-empty set of public Run-local indices. Reusing an index keeps its
+hidden Episode specification and Policy seed fixed, so two immutable Programs
+can be compared on matched evidence. Every use still creates a fresh
+Environment and Policy runtime and consumes budget again. Actual seeds,
+scenarios, and pool construction remain Host-owned.
+
+Once an Evaluation begins, its reserved Episode allocation is consumed. Policy
+failures and invalid Actions are reported as observed behavior, preserving the
+exact semantics of the submitted Program. Feedback maps every sanitized
+Episode outcome back to its public index, while comparisons over different
+selectors remain unmatched evidence.
 
 The agent uses public search Feedback to decide what to try next. When it
 finishes, authority returns to the Host. Private Validation selects among the

--- a/site/src/content/blog/zh/designing-evopolicygym.md
+++ b/site/src/content/blog/zh/designing-evopolicygym.md
@@ -81,7 +81,7 @@ Workspace 支持持续编写。每个被接受的 Submission 都会把当前源�
 | 对象 | 职责 |
 | --- | --- |
 | `Program` | 被评估的可执行 Policy 源码 |
-| `Submission` | 一个不可变 Program 及其已提交 Feedback |
+| `Submission` | 一个不可变 Program、显式训练编号 selector 及其已提交 Feedback |
 | `Run` | 有界的提交序列与最终交接 |
 | `Validation` | Host 在候选之间进行选择 |
 | `Assessment` | 在 held-out 数据上测量所选 Program |
@@ -106,12 +106,20 @@ domain-independent。
 
 ## 将证据访问视为实验条件
 
-Run 的 Submission 与 Episode 上限定义实验条件。16 次提交和 48 个 Episodes
-代表 Agent 可以用于改进的特定证据预算。
+Run 的 Submission 上限、总 Episode 预算、固定训练池大小与可选单次上限共同定义
+实验条件。例如，16 次提交、48 个 Episode 单位与 96 个 Episode identity 的池，
+表示 Agent 可以从更宽的集合中选择并观察总计 48 次；更大的池不会增加交互预算。
 
-这些限制会在 Agent 启动前固定。一旦 Evaluation 开始，对应 Episode 配额就会被
-消耗。Policy failure 与无效 Action 会作为观察到的行为被报告，从而保持提交
-Program 的精确语义。
+Host 会在 Agent 启动前构建这个编号池。每次 Submission 都指定一组非空、公开的
+Run-local 编号。复用编号会保持其隐藏 Episode specification 与 Policy seed 不变，
+因此两个不可变 Program 可以在配对证据上比较；但每次使用仍创建全新的
+Environment 与 Policy runtime，并再次扣除预算。真实 seeds、scenarios 与池构建
+过程仍由 Host 持有。
+
+Evaluation 一旦开始，预留的 Episode 配额就会被消耗。Policy failure 与无效
+Action 会作为观察到的行为被报告，从而保持提交 Program 的精确语义。Feedback
+会把每个经过净化的 Episode 结果映射回公开编号，而不同 selector 之间的比较仍是
+未配对证据。
 
 Agent 利用公开的搜索 Feedback 决定下一次尝试什么。Agent 结束后，控制权回到
 Host：私有 Validation 在交接的候选之间进行选择，held-out Assessment 测量最终

--- a/site/src/content/docs/en/concepts.md
+++ b/site/src/content/docs/en/concepts.md
@@ -21,7 +21,7 @@ status: draft
 | `Evaluation` | One Program evaluated over a finite deterministic Episode plan. |
 | `Feedback` | A Benchmark-defined public projection with one scalar score, bounded content, and optional artifacts. |
 | `Submission` | One Program and the committed Feedback produced when a Coding Agent requests Evaluation. |
-| `ProgramEvolutionRun` | One bounded outer loop in which a Coding Agent edits Programs, submits candidates, reads Feedback, and selects a final Submission. |
+| `ProgramEvolutionRun` | One bounded outer loop in which a Coding Agent edits Programs, submits candidates, reads Feedback, and hands published candidates to Host-side selection. |
 | `Experiment` | Reserved for a future collection of comparable Runs. |
 
 The public SDK uses `Program`, not `ProgramVersion`. A Program retains no Host
@@ -53,22 +53,32 @@ outer Coding Agent authors a new Program.
 ```text
 initial Program
   ↓
+Host fixes indexed training Episode pool
+  ↓
 Coding Agent edits workspace/program/
   ↓
-Submission → Evaluation → committed Feedback
+Submission(selector) → fresh runtimes → committed Feedback
   ↓
-Coding Agent reads workspace/feedback/
+Coding Agent reads indexed outcomes in workspace/feedback/
   ↓
-next Program or finish(selected submission)
+next Program or finish(candidate IDs)
+  ↓
+Host-side final selection
 ```
 
 A `RunConfig` fixes the split, maximum submissions, total Episode budget,
 fixed training Episode-pool size, optional per-Submission Episode cap, seed,
-and timeouts. The pool size defaults to the total budget. The Agent selects
-public Run-local indices from that pool; the same index preserves its hidden
-Episode specification and Policy seed across Submissions, while each use
-creates fresh runtime state and consumes budget again. The optional
-per-Submission cap defaults to `None`.
+and timeouts before the Agent starts. Pool size and budget are different
+limits: the pool controls how many Episode identities are available, while the
+budget controls the total number of selected indices across all Submissions.
+The pool size defaults to the total budget.
+
+The Agent selects public Run-local indices from that pool. The same index
+preserves its hidden Episode specification and Policy seed across Submissions,
+which supports matched Program comparisons. Every use still creates fresh
+runtime state and consumes budget again. Pool indices are experimental handles,
+not Environment seeds, and neither the Agent nor the Policy receives the
+underlying seed. The optional per-Submission cap defaults to `None`.
 
 ## Trust boundary
 

--- a/site/src/content/docs/en/evaluation.md
+++ b/site/src/content/docs/en/evaluation.md
@@ -71,7 +71,7 @@ result = run(
     Program.from_directory("policy/"),
     CartPoleBenchmark(),
     agent=Codex(
-        model="gpt-5.5",
+        model="gpt-5.6-luna",
         reasoning_effort="high",
     ),
     execution=ProcessExecution.unsafe(),
@@ -100,8 +100,21 @@ evopolicygym submit program --episodes "0:2,4:8"
 That selector expands to indices `0, 1, 4, 5, 6, 7`. The same index preserves
 its hidden Episode specification and Policy seed across Submissions, but every
 use creates a fresh Environment and Policy runtime and consumes budget again.
-`episode_pool_size` defaults to `episode_budget`. Set
-`max_episodes_per_submission` only when the Host needs an additional cap.
+Selectors must be non-empty and strictly increasing. Duplicate, overlapping,
+malformed, out-of-pool, and over-budget selections are rejected before Program
+capture.
+
+| Run limit | Meaning |
+| --- | --- |
+| `episode_pool_size` | Number of distinct Run-local Episode identities the Agent may select. Defaults to `episode_budget`. |
+| `episode_budget` | Total selected indices charged across every accepted Submission, including repeated indices. |
+| `max_episodes_per_submission` | Optional additional cap on one selector; defaults to no extra cap. |
+
+Each published `feedback.json` contains the exact `episode_indices` and maps
+every sanitized Episode summary back to its public `episode_index`. Comparing
+two Program revisions on the same selector therefore provides matched
+evidence. Results produced by different selectors are not paired merely
+because they have the same position in their respective arrays.
 
 Agent Skills are independent Run inputs rather than Benchmark properties.
 Freeze each selected directory with
@@ -129,11 +142,21 @@ Invalid Program capture does not consume Episode budget. Once Evaluation
 starts, reserved budget is not refunded. A Policy failure is a committed scored
 result; a trusted Evaluation fault closes the Run as `evaluation_failed`.
 
-## Selecting the final Program
+## Handing off candidates
 
-The Agent finishes by selecting one fully published Submission. The returned
-`RunResult.final_program` is the detached Program retained for that
-Submission—not the possibly modified contents left in the Agent workspace.
+Without `ValidationConfig`, the Agent finishes with exactly one fully published
+Submission and the Host selects that sole candidate after Agent cleanup. With
+Validation configured, `finish` accepts an ordered list of one to
+`validation.max_candidates` published Submission IDs. The successful request
+closes Agent authority; the Host then evaluates every handed-off Program on
+identical private Validation Episodes and selects by primary score, Policy
+failures, and argument order. Validation evidence is never returned to the
+Agent workspace.
+
+The returned `RunResult.final_program`, when available, is the detached Program
+retained for the Host-selected Submission—not the possibly modified contents
+left in the Agent workspace. Optional Assessment measures only that selected
+Program and never changes selection.
 
 Possible terminal reasons are:
 
@@ -142,6 +165,8 @@ Possible terminal reasons are:
 - `budget_exhausted`
 - `agent_failed`
 - `evaluation_failed`
+- `validation_failed`
+- `assessment_failed`
 
 ## Run records
 

--- a/site/src/content/docs/en/getting-started.md
+++ b/site/src/content/docs/en/getting-started.md
@@ -56,17 +56,28 @@ Evaluate the example distribution's packaged Program over five deterministic
 validation Episodes:
 
 ```console
-uv run --project environments/gymnasium/classic_control/cartpole \
-  evopolicygym-cartpole evaluate \
-  --episodes 5 \
-  --allow-unsafe-process
+uv run --project environments/gymnasium/classic_control/cartpole python - <<'PY'
+from cartpole import CartPoleBenchmark, baseline_program
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.execution import ProcessExecution
+
+result = evaluate(
+    baseline_program(),
+    CartPoleBenchmark(),
+    execution=ProcessExecution.unsafe(),
+    config=EvaluationConfig(split="validation", episodes=5, seed=42),
+)
+print(result.feedback.score)
+print(result.feedback.content)
+PY
 ```
 
-The command prints one JSON object containing the Benchmark identity,
-immutable Program digest, scalar score, and public Feedback. Feedback content
-follows the selected Benchmark contract.
+The example prints the scalar score and Benchmark-defined public Feedback.
+`EvaluationResult` also retains the Benchmark identity, immutable Program
+digest, and sanitized Episode summaries.
 
-`--allow-unsafe-process` acknowledges execution under the current local user.
+`ProcessExecution.unsafe()` explicitly acknowledges execution under the
+current local user.
 
 ## Run a Coding Agent (optional)
 
@@ -74,29 +85,50 @@ After authenticating the Codex CLI, let the Agent revise the example Program
 within a small development budget:
 
 ```console
+mkdir -p runs
 uv run --project environments/gymnasium/classic_control/cartpole \
-  evopolicygym-cartpole run \
-  --model gpt-5.5 \
+  python scripts/run_cartpole_codex.py \
+  --model gpt-5.6-luna \
+  --reasoning-effort high \
   --record-to runs/quickstart-001 \
   --max-submissions 3 \
   --episode-budget 30 \
+  --episode-pool-size 60 \
+  --max-episodes-per-submission 10 \
   --allow-unsafe-process
 ```
 
-The Agent chooses the Episode count for each Submission. Its Program workspace
-is `runs/quickstart-001/workspace/program/`, committed Feedback appears under
-`workspace/feedback/`, and Host records remain in the Run directory.
+The Host constructs 60 fixed Run-local training Episode identities before the
+Agent starts. The Agent chooses a non-empty index selector for each Submission
+while spending at most 30 Episode units in total and 10 per Submission. Its
+Program workspace is `runs/quickstart-001/workspace/program/`, committed
+Feedback appears under `workspace/feedback/`, and Host records remain in the
+Run directory.
+
+Inside the active Agent Session, a Submission uses singleton indices and
+half-open ranges:
+
+```console
+evopolicygym submit program --episodes "0:2,4:8"
+```
+
+The selector above evaluates indices `0, 1, 4, 5, 6, 7`. Reusing an index in a
+later Submission provides a matched Episode specification and Policy seed, but
+still creates a fresh Environment and Policy runtime and spends budget again.
+The actual seeds remain hidden.
 
 ## What the Run does
 
 1. The initial Policy directory became an immutable, content-addressed
    `Program`.
-2. The Coding Agent received a fixed workspace, Benchmark specification, and
-   finite submission authority.
-3. Every requested Evaluation planned deterministic Episodes.
-4. Every Episode created a fresh Environment and fresh Policy process.
-5. A completed Submission atomically published its Program, Feedback, Episode
-   summaries, and optional artifacts.
+2. Before Agent execution, the Host built one deterministic indexed training
+   pool from the Run seed.
+3. The Coding Agent received a fixed workspace, Benchmark specification,
+   selectable pool bounds, and finite submission and Episode authority.
+4. Every Submission selected explicit pool indices; every selected index
+   created a fresh Environment and fresh Policy process.
+5. A completed Submission atomically published its Program, selected indices,
+   Feedback, Episode summaries, and optional artifacts.
 6. The Agent selected one fully published Submission as the final Program.
 
 ## Next steps

--- a/site/src/content/docs/zh/concepts.md
+++ b/site/src/content/docs/zh/concepts.md
@@ -21,7 +21,7 @@ status: draft
 | `Evaluation` | 在有限、确定性 Episode plan 上评估一个 Program。 |
 | `Feedback` | 由 Benchmark 定义的公开投影，包含一个标量分数、有界 content 与可选 artifacts。 |
 | `Submission` | Coding Agent 请求 Evaluation 后得到的一组 Program 与已提交 Feedback。 |
-| `ProgramEvolutionRun` | Coding Agent 编辑 Programs、提交候选、读取 Feedback，并选择最终 Submission 的一次有界外层循环。 |
+| `ProgramEvolutionRun` | Coding Agent 编辑 Programs、提交候选、读取 Feedback，并把已发布候选交给 Host 侧选择的一次有界外层循环。 |
 | `Experiment` | 保留给未来由多个可比较 Runs 组成的集合。 |
 
 公共 SDK 使用 `Program`，而不是 `ProgramVersion`。Program 不保留 Host
@@ -51,20 +51,28 @@ Episode。跨 Episode 的改进只能通过外层 Coding Agent 编写新 Program
 ```text
 initial Program
   ↓
+Host fixes indexed training Episode pool
+  ↓
 Coding Agent edits workspace/program/
   ↓
-Submission → Evaluation → committed Feedback
+Submission(selector) → fresh runtimes → committed Feedback
   ↓
-Coding Agent reads workspace/feedback/
+Coding Agent reads indexed outcomes in workspace/feedback/
   ↓
-next Program or finish(selected submission)
+next Program or finish(candidate IDs)
+  ↓
+Host-side final selection
 ```
 
 `RunConfig` 固定 split、最大 submissions、总 Episode 预算、训练 Episode 池大小、
-可选的单次 Submission Episode 上限、seed 与 timeouts。池大小默认等于总预算。
-Agent 从池中选择公开的 Run-local 编号；同一编号在不同 Submission 中保持隐藏
-Episode specification 与 Policy seed 不变，但每次使用仍创建全新的 runtime 状态并
-再次扣除预算。单次上限默认为 `None`。
+可选的单次 Submission Episode 上限、seed 与 timeouts，并且都在 Agent 启动前
+确定。池大小与预算是两个不同的限制：池大小控制可用的 Episode identity 数量，
+预算控制所有 Submissions 累计选择的编号数量。池大小默认等于总预算。
+
+Agent 从池中选择公开的 Run-local 编号。同一编号在不同 Submission 中保持隐藏
+Episode specification 与 Policy seed 不变，从而支持配对比较；但每次使用仍创建
+全新的 runtime 状态并再次扣除预算。池编号是实验句柄，不是 Environment seed；
+Agent 与 Policy 都无法看到底层 seed。单次上限默认为 `None`。
 
 ## 信任边界
 

--- a/site/src/content/docs/zh/evaluation.md
+++ b/site/src/content/docs/zh/evaluation.md
@@ -69,7 +69,7 @@ result = run(
     Program.from_directory("policy/"),
     CartPoleBenchmark(),
     agent=Codex(
-        model="gpt-5.5",
+        model="gpt-5.6-luna",
         reasoning_effort="high",
     ),
     execution=ProcessExecution.unsafe(),
@@ -96,9 +96,19 @@ evopolicygym submit program --episodes "0:2,4:8"
 
 该选择器展开为编号 `0, 1, 4, 5, 6, 7`。同一编号在不同 Submission 中保持隐藏
 Episode specification 与 Policy seed 不变，但每次使用仍会创建全新的 Environment
-与 Policy runtime，并再次消耗预算。`episode_pool_size` 默认等于
-`episode_budget`。只有 Host 需要额外限制时才设置
-`max_episodes_per_submission`。
+与 Policy runtime，并再次消耗预算。Selector 必须非空且严格递增。重复、重叠、
+格式非法、超出池范围或超过预算的选择，会在捕获 Program 之前被拒绝。
+
+| Run 限制 | 含义 |
+| --- | --- |
+| `episode_pool_size` | Agent 可选择的不同 Run-local Episode identity 数量；默认等于 `episode_budget`。 |
+| `episode_budget` | 所有被接受 Submission 累计扣除的所选编号数量；重复编号也会再次计费。 |
+| `max_episodes_per_submission` | 对单个 selector 的可选额外上限；默认不增加限制。 |
+
+每个已发布的 `feedback.json` 都包含精确的 `episode_indices`，并通过公开
+`episode_index` 将每个经过净化的 Episode summary 映射回所选编号。因此，在相同
+selector 上比较两个 Program revision 可以得到配对证据。来自不同 selector 的结果
+不会因为它们在各自数组中的位置相同而自动配对。
 
 Agent Skill 是独立的 Run 输入，而不是 Benchmark 属性。调用者使用
 `AgentSkill.from_directory("skills/<name>")` 冻结明确选择的目录，并通过
@@ -122,11 +132,18 @@ Policy process。仓库中的 Balatro Skill 是用于证据分配、策略开发
 Policy failure 是已提交的计分结果；可信 Evaluation fault 会以
 `evaluation_failed` 关闭 Run。
 
-## 选择最终 Program
+## 交接候选
 
-Agent 通过选择一个完全发布的 Submission 完成 Run。返回的
-`RunResult.final_program` 是该 Submission 保留的脱离路径 Program，而不是 Agent
-workspace 中可能继续变化的内容。
+未配置 `ValidationConfig` 时，Agent 必须以一个完全发布的 Submission 结束，
+Host 会在 Agent 清理完成后选择这个唯一候选。配置 Validation 后，`finish` 接受
+由一至 `validation.max_candidates` 个已发布 Submission ID 组成的有序列表。
+成功请求会关闭 Agent 权限；随后 Host 在完全相同的私有 Validation Episodes 上
+评估所有交接 Program，并按 primary score、Policy failure 数量和参数顺序选择。
+Validation 证据绝不会返回 Agent workspace。
+
+当 `RunResult.final_program` 可用时，它是 Host 所选 Submission 保留的脱离路径
+Program，而不是 Agent workspace 中可能继续变化的内容。可选 Assessment 只测量
+这个已选 Program，绝不会改变选择。
 
 可能的 terminal reason 包括：
 
@@ -135,6 +152,8 @@ workspace 中可能继续变化的内容。
 - `budget_exhausted`
 - `agent_failed`
 - `evaluation_failed`
+- `validation_failed`
+- `assessment_failed`
 
 ## Run records
 

--- a/site/src/content/docs/zh/getting-started.md
+++ b/site/src/content/docs/zh/getting-started.md
@@ -53,42 +53,71 @@ uv sync --project environments/gymnasium/classic_control/cartpole --extra dev
 在 5 个确定性的 validation Episodes 上评估示例 distribution 提供的 Program：
 
 ```console
-uv run --project environments/gymnasium/classic_control/cartpole \
-  evopolicygym-cartpole evaluate \
-  --episodes 5 \
-  --allow-unsafe-process
+uv run --project environments/gymnasium/classic_control/cartpole python - <<'PY'
+from cartpole import CartPoleBenchmark, baseline_program
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.execution import ProcessExecution
+
+result = evaluate(
+    baseline_program(),
+    CartPoleBenchmark(),
+    execution=ProcessExecution.unsafe(),
+    config=EvaluationConfig(split="validation", episodes=5, seed=42),
+)
+print(result.feedback.score)
+print(result.feedback.content)
+PY
 ```
 
-命令输出一个 JSON object，其中包含 Benchmark identity、不可变 Program digest、
-标量分数与公开 Feedback。Feedback 内容遵循所选 Benchmark 契约。
+示例输出标量分数与 Benchmark 定义的公开 Feedback。`EvaluationResult` 还保留
+Benchmark identity、不可变 Program digest 与经过净化的 Episode summaries。
 
-`--allow-unsafe-process` 用于确认以当前本地用户权限执行。
+`ProcessExecution.unsafe()` 明确确认以当前本地用户权限执行。
 
 ## 运行 Coding Agent（可选）
 
 完成 Codex CLI 认证后，让 Agent 在较小的开发预算内修改示例 Program：
 
 ```console
+mkdir -p runs
 uv run --project environments/gymnasium/classic_control/cartpole \
-  evopolicygym-cartpole run \
-  --model gpt-5.5 \
+  python scripts/run_cartpole_codex.py \
+  --model gpt-5.6-luna \
+  --reasoning-effort high \
   --record-to runs/quickstart-001 \
   --max-submissions 3 \
   --episode-budget 30 \
+  --episode-pool-size 60 \
+  --max-episodes-per-submission 10 \
   --allow-unsafe-process
 ```
 
-Agent 自行决定每次 Submission 使用的 Episode 数量。Program workspace 位于
+Host 会在 Agent 启动前构建 60 个固定的 Run-local 训练 Episode identity。Agent
+为每次 Submission 选择非空编号集合，同时遵守总计 30 个 Episode 单位、单次至多
+10 个的预算。Program workspace 位于
 `runs/quickstart-001/workspace/program/`，已提交 Feedback 位于
 `workspace/feedback/`，Host 记录保存在 Run 目录中。
+
+在有效的 Agent Session 内，Submission 使用单点编号与半开区间：
+
+```console
+evopolicygym submit program --episodes "0:2,4:8"
+```
+
+上述 selector 会评估编号 `0, 1, 4, 5, 6, 7`。在后续 Submission 中复用编号可以
+得到相同的 Episode specification 与 Policy seed，用于配对比较；但每次使用仍会
+创建全新的 Environment 与 Policy runtime，并再次扣除预算。真实 seed 始终隐藏。
 
 ## Run 执行的流程
 
 1. 初始 Policy 目录成为不可变、内容寻址的 `Program`。
-2. Coding Agent 获得固定 workspace、Benchmark specification 与有限提交权限。
-3. 每次 Evaluation 都会规划确定性的 Episodes。
-4. 每个 Episode 都创建全新的 Environment 与 Policy 进程。
-5. 完成的 Submission 原子发布 Program、Feedback、Episode summaries 与可选 artifacts。
+2. Agent 执行前，Host 根据 Run seed 构建一个确定性的编号训练池。
+3. Coding Agent 获得固定 workspace、Benchmark specification、可选池边界，以及
+   有限的 Submission 与 Episode 权限。
+4. 每次 Submission 显式选择池编号；每个所选编号都创建全新的 Environment 与
+   Policy 进程。
+5. 完成的 Submission 原子发布 Program、所选编号、Feedback、Episode summaries
+   与可选 artifacts。
 6. Agent 从完全发布的 Submissions 中选择最终 Program。
 
 ## 下一步

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -103,15 +103,26 @@ const environmentFamilies = [
         <p class="academic-label">01 · <Copy en="Start here" zh="从这里开始" /></p>
         <Copy en="Quick start" zh="快速开始" as="h2" id="quickstart-heading" />
         <Copy
-          en="Install the repository and evaluate the packaged CartPole baseline over five Episodes."
-          zh="安装仓库，并在 5 个 Episodes 上评估 package 内置的 CartPole baseline。"
+          en="Install the CartPole Benchmark and directly evaluate its packaged baseline over five Episodes."
+          zh="安装 CartPole Benchmark，并在 5 个 Episodes 上直接评估 package 内置的 baseline。"
           as="p"
         />
         <pre><code>git clone https://github.com/Linzwcs/EvoPolicyGym
 cd EvoPolicyGym
 uv sync --project environments/gymnasium/classic_control/cartpole --extra dev
-uv run --project environments/gymnasium/classic_control/cartpole \
-  evopolicygym-cartpole evaluate --episodes 5 --allow-unsafe-process</code></pre>
+uv run --project environments/gymnasium/classic_control/cartpole python - &lt;&lt;'PY'
+from cartpole import CartPoleBenchmark, baseline_program
+from evopolicygym import EvaluationConfig, evaluate
+from evopolicygym.execution import ProcessExecution
+
+result = evaluate(
+    baseline_program(),
+    CartPoleBenchmark(),
+    execution=ProcessExecution.unsafe(),
+    config=EvaluationConfig(split="validation", episodes=5, seed=42),
+)
+print(result.feedback.score)
+PY</code></pre>
         <a class="text-link" href={withBase("docs/getting-started/")}>
           <Copy en="Full installation and usage guide" zh="完整安装与使用指南" /> →
         </a>

--- a/site/src/pages/runs/index.astro
+++ b/site/src/pages/runs/index.astro
@@ -22,8 +22,8 @@ const toc = [
     <Copy en="Run records" zh="Run 记录" as="h1" />
     <Copy
       class="reference-lead"
-      en="A Program-Evolution Run is a bounded sequence of immutable Program submissions and committed Feedback."
-      zh="一次 Program-Evolution Run 是由不可变 Program 提交与已提交 Feedback 构成的有界序列。"
+      en="A Program-Evolution Run is a bounded sequence of immutable Programs evaluated on Agent-selected indices from one fixed training Episode pool."
+      zh="一次 Program-Evolution Run 是一个有界序列：Agent 从固定训练 Episode 池中选择编号，并评估不可变 Programs。"
       as="p"
     />
   </header>
@@ -31,23 +31,29 @@ const toc = [
   <section id="run-model">
     <Copy en="Run model" zh="Run 模型" as="h2" />
     <Copy
-      en="The Kernel gives a Coding Agent a fixed workspace, submission authority, Episode budget, and Benchmark specification. The Agent edits only the Program workspace, submits candidates, reads committed public feedback, and selects one published Submission as final."
-      zh="Kernel 向 Coding Agent 提供固定 workspace、提交权限、Episode 预算与 Benchmark specification。Agent 只编辑 Program workspace，提交候选、读取已提交的公开反馈，并从已发布的 Submissions 中选择最终结果。"
+      en="Before Agent execution, the Kernel derives one fixed indexed training pool from the Run seed. The Coding Agent receives a workspace, the public pool bounds, submission authority, an Episode budget, and the Benchmark specification. It edits only the Program workspace, submits explicit index selectors, reads committed public Feedback, and hands one or more published candidates back to the Host."
+      zh="Agent 执行前，Kernel 根据 Run seed 派生一个固定的编号训练池。Coding Agent 获得 workspace、公开池边界、提交权限、Episode 预算与 Benchmark specification；它只编辑 Program workspace，提交显式编号 selector，读取已提交的公开 Feedback，并把一个或多个已发布候选交还 Host。"
+      as="p"
+    />
+    <Copy
+      en="Reusing the same index across Submissions keeps the hidden Episode specification and Policy seed fixed for matched comparisons. Every use still creates a fresh Environment and Policy runtime and consumes one budget unit. The index is public; the underlying seeds and scenarios are not."
+      zh="在不同 Submission 中复用同一编号，会为配对比较保持隐藏 Episode specification 与 Policy seed 不变；但每次使用仍创建全新的 Environment 与 Policy runtime，并扣除一个预算单位。编号公开，底层 seeds 与 scenarios 不公开。"
       as="p"
     />
     <div class="reference-flow">
       <div><span>01</span><strong>Program</strong><small>immutable source</small></div>
-      <div><span>02</span><strong>Evaluation</strong><small>bounded Episodes</small></div>
-      <div><span>03</span><strong>Feedback</strong><small>public evidence</small></div>
-      <div><span>04</span><strong>Revision</strong><small>next Program</small></div>
+      <div><span>02</span><strong>Selector</strong><small>Run-local indices</small></div>
+      <div><span>03</span><strong>Evaluation</strong><small>fresh runtimes</small></div>
+      <div><span>04</span><strong>Feedback</strong><small>indexed evidence</small></div>
+      <div><span>05</span><strong>Revision</strong><small>next Program</small></div>
     </div>
   </section>
 
   <section id="record-layout">
     <Copy en="Record layout" zh="记录结构" as="h2" />
     <Copy
-      en="A completed local Run retains the initial Program, every submitted Program, Feedback and artifacts, the Agent invocation, separate logs, workspace state, and a terminal run manifest."
-      zh="完成的本地 Run 会保留初始 Program、每个已提交 Program、Feedback 与 artifacts、Agent invocation、独立日志、workspace 状态以及终态 run manifest。"
+      en="A completed local Run retains the fixed pool configuration and derivation identifiers, every selected index set, the initial and submitted Programs, Feedback and artifacts, the Agent invocation and logs, workspace state, and a terminal manifest."
+      zh="完成的本地 Run 会保留固定池配置与派生协议标识、每组所选编号、初始与已提交 Programs、Feedback 与 artifacts、Agent invocation 与日志、workspace 状态以及终态 manifest。"
       as="p"
     />
     <pre><code>run/
@@ -59,9 +65,24 @@ const toc = [
 │   ├── feedback.json
 │   └── artifacts/
 ├── agent/
+│   ├── invocation.json
+│   ├── stdout.log
+│   └── stderr.log
+├── validation/report.json      # optional, Host-only
+├── assessment/report.json      # optional, Host-only
 └── workspace/
     ├── program/
-    └── feedback/</code></pre>
+    ├── skills/                  # optional, read-only
+    └── feedback/
+        ├── latest.json
+        └── submissions/&lt;id&gt;/
+            ├── feedback.json
+            └── artifacts/</code></pre>
+    <Copy
+      en="Each Feedback document records the selector as episode_indices and labels every sanitized outcome with its matching episode_index. Host-only Validation and Assessment reports, when configured, are created only after the Agent Session closes and are never projected into workspace Feedback."
+      zh="每份 Feedback document 都以 episode_indices 记录 selector，并用对应的 episode_index 标记每个经过净化的结果。配置 Host-only Validation 与 Assessment 时，相关报告只会在 Agent Session 关闭后生成，绝不会投影到 workspace Feedback。"
+      as="p"
+    />
   </section>
 
   <section id="current-records">


### PR DESCRIPTION
## Purpose

Synchronize the v0.3 website with the Kernel's indexed training Episode pool
and current Run semantics.

## Changes

- explain the fixed Run-local training pool, explicit Episode selectors, budget
  accounting, and matched comparisons in the bilingual concepts and Evaluation
  docs
- document `episode_indices` / `episode_index`, candidate handoff, Host-only
  Validation and Assessment, and the current Run record layout
- update the bilingual design article to distinguish pool size from interaction
  budget
- replace the stale `evopolicygym-cartpole` Quickstart command (the CartPole
  distribution exposes no such console entry point) with the supported public
  Python SDK
- update the Coding Agent Quickstart to use the repository's CartPole script
  with reasoning effort and Episode-pool controls

## Impact

Readers can now run the documented CartPole example and understand the exact
evidence and privacy semantics introduced by the latest Kernel.

## Validation

- `npm run build` — 33 static pages built successfully
- CartPole five-Episode public-SDK Quickstart executed successfully
- `scripts/run_cartpole_codex.py --help` confirmed all documented arguments
- `git diff --check`

## Limitations

`ProcessExecution` remains explicitly unsafe for hostile code and provides no
isolation.
