### PR TITLE
balatro: add policy lab and indexed experiments

### DIFF
--- a/environments/future.md
+++ b/environments/future.md
@@ -1,0 +1,158 @@
+# Future Environment Candidates
+
+This note records prospective environments for Coding Agent optimization of
+executable Policy systems. It is a research priority list, not an
+integration-status claim. Runnable and deferred integrations remain
+authoritative in [STATUS.md](STATUS.md).
+
+## Provenance and adoption rule
+
+Candidates are named and organized by their authoritative upstream ecosystem,
+as required by [the environment taxonomy](README.md). EdgeBench is a secondary
+discovery and comparison source: it repackages upstream games, contest
+problems, benchmarks, and APIs as long-running workspace-plus-Judge tasks. An
+EdgeBench task ID identifies that derived task, not the owner of the underlying
+Environment.
+
+EvoPolicyGym will not import, vendor, or depend on EdgeBench task workspaces,
+container images, prompts, baselines, generators, testers, Judge programs,
+hidden cases, score anchors, feedback traces, or SForge. For each candidate we
+instead:
+
+- locate the official upstream specification, repository, release, and assets;
+- verify the upstream code, data, and asset licenses independently;
+- use an official runtime directly when it already exposes interaction;
+- otherwise implement an independent adapter from the public upstream rules;
+  and
+- reject the candidate if no authoritative and redistributable upstream can be
+  established.
+
+EdgeBench's CC BY 4.0 task-metadata license does not establish redistribution
+rights for the upstream software, contest materials, games, ROMs, or datasets
+referenced by a task.
+
+## Verified provenance map
+
+The EdgeBench column documents what EdgeBench changed so that the distinction
+is auditable. Those changes are not implementation inputs for EvoPolicyGym.
+
+| Upstream candidate | Authoritative upstream | EdgeBench-derived task and alteration | EvoPolicyGym decision |
+| --- | --- | --- | --- |
+| BipedalWalker | [Gymnasium `BipedalWalker-v3`](https://gymnasium.farama.org/environments/box2d/bipedal_walker/) | `bipedalwalker_locomotion_rl`: trains a checkpoint and scores only the submitted artifact | Keep the existing direct Gymnasium integration |
+| Treant's Forest | [AtCoder AHC054](https://atcoder.jp/contests/ahc054/tasks/ahc054_a) | `treant_forest`: adds a Python baseline, local tooling, fixed Judge cases, and score normalization | Implement the official interactive rules independently; do not use the EdgeBench workspace |
+| Warehouse Manager | [CodeChef `WAREHOUS`](https://www.codechef.com/problems/WAREHOUS) | `warehouse_forklift_routing`: adds a Python workspace, baseline, local generator/tester, hidden evaluation, and rescaling | Recreate a stepwise simulator only from the official problem contract, after license review |
+| Apple Incremental Game | [AtCoder AHC058](https://atcoder.jp/contests/ahc058/tasks/ahc058_a) | `apple_incremental_game`: packages the contest task with a baseline, local tooling, fixed Judge cases, and rescaling | Implement the public turn dynamics and our own split-scoped Episode generator |
+| NetHack | [NetHack](https://github.com/NetHack/NetHack) and [NLE](https://github.com/facebookresearch/nle) | `nethack_dungeon_agent`: fixes an observation/policy scaffold and scores multiple generated runs | Integrate NLE directly and define EvoPolicyGym-owned observations, Actions, horizons, and scoring |
+| VRPTW | [Solomon VRPTW benchmark](https://www.sintef.no/projectweb/top/vrptw/solomon-benchmark/) | `vehicle_routing_time_windows`: turns solver output into hidden-instance and best-known-solution scoring | Use independently obtained benchmark instances; admit only a genuine constructive interaction design |
+| Molecules | [AtCoder AHC057](https://atcoder.jp/contests/ahc057/tasks/ahc057_a) | `molecular_self_assembly`: adds a Python baseline, local tooling, fixed Judge cases, and rescaling | Implement the public motion and bonding rules with independent Episode generation |
+| Battle for Wesnoth | [Wesnoth Lua AI API](https://wiki.wesnoth.org/LuaAPI/ai) | `wesnoth_tactical_ai`: selects tactical maps, objectives, an opponent, and a scoring Judge | Integrate the official engine/API directly and author independent scenarios |
+| OpenRCT2 | [OpenRCT2](https://github.com/OpenRCT2/OpenRCT2) | `openrct2_theme_park_ai`: defines a JavaScript automation plugin task and hidden scenarios | Defer: the engine is open source but normal play requires separately licensed RCT2 files |
+| OpenTTD | [OpenTTD NoAI API](https://docs.openttd.org/ai-scripting/ai-api/) | `openttd_transport_ai`: defines an AI-script objective, generated maps, and company-value scoring | Integrate the official engine and NoAI API directly with independently defined profiles |
+| Dungeon Crawl Stone Soup | [DCSS](https://github.com/crawl/crawl) | `dcss_dungeon_ai`: fixes a Lua bot interface, character build, time budget, repeated runs, and mean score | Integrate the official game and supported control surface directly |
+
+The public [EdgeBench task metadata](https://huggingface.co/datasets/ByteDance-Seed/EdgeBench)
+and [paper](https://edge-bench.org/paper.pdf) are retained only as evidence of
+the derived task designs.
+
+## Recommended roadmap
+
+| Priority | Upstream candidate | Policy-system value | Main concern |
+| --- | --- | --- | --- |
+| 0 | Gymnasium BipedalWalker | Fast continuous-control calibration; already integrated | Useful as a baseline, not a flagship systems task |
+| 1 | AtCoder AHC054 Treant's Forest | Native turn-by-turn interaction, state tracking, constraint handling, and replanning | Requires an independent tester and a redistribution review |
+| 2 | CodeChef WAREHOUS Warehouse Manager | Long-horizon routing, memory, storage strategy, and recovery | The upstream task emits a complete command string; the Policy form must be stepwise |
+| 3 | AtCoder AHC058 Apple Incremental Game | Investment timing, horizon estimation, and phase-dependent decisions | Must expose one official turn per Policy Action |
+| 4 | NLE NetHack | Partial observability, map memory, exploration, inventory, combat, and risk | Linux-oriented runtime and expensive sparse-reward Episodes |
+| 5 | Solomon VRPTW | Constructive search, feasibility management, and route repair | Risks becoming a one-shot solver benchmark |
+| 6 | AtCoder AHC057 Molecules | Temporal scheduling and constrained constructive planning | Needs useful intermediate observations and bounded diagnostics |
+| Later | Battle for Wesnoth | Tactical planning, centralized multi-unit control, and opponent response | Large state/action surface and engine bridge |
+| Later | OpenTTD | Network design, capital allocation, expansion, and recovery | Very long simulations and substantial engine integration |
+| Later | DCSS | Exploration, combat, inventory, and survival strategy | Long wall-clock Episodes and control-surface validation |
+| Deferred | OpenRCT2 | Hierarchical resource allocation and long-term management | Original RCT2 data files are a separate asset dependency |
+
+Treant's Forest is the strongest first new investigation because its
+authoritative upstream is already an interactive protocol. Warehouse Manager
+remains attractive, but requires more semantic re-authoring from batch command
+output into a Policy loop. NetHack is the strongest flagship candidate once the
+runtime and long-horizon evaluation workflow are ready.
+
+## Suggested capability gradient
+
+```text
+continuous control
+└── Gymnasium BipedalWalker
+
+native online interaction
+└── AtCoder AHC054 Treant's Forest
+
+fast long-horizon decisions
+├── AtCoder AHC058 Apple Incremental Game
+└── CodeChef WAREHOUS Warehouse Manager
+
+constructive planning
+├── Solomon VRPTW
+└── AtCoder AHC057 Molecules
+
+partially observable systems
+├── NLE NetHack
+└── DCSS
+
+hierarchical strategy
+├── Battle for Wesnoth
+└── OpenTTD
+```
+
+This gradient supports experiments on how Coding Agents progress from tuning
+reactive controllers to authoring Policies with explicit memory, search,
+subsystems, and hierarchical planning.
+
+## Conditional and rejected leads
+
+[AtCoder AHC056 Grid Turing Robot](https://atcoder.jp/contests/ahc056/tasks/ahc056_a)
+and [CodeChef `TRICOL`](https://www.codechef.com/problems/TRICOL) are verified
+upstreams for EdgeBench's `grid_turing_robot` and
+`triangulation_coloring_optimization`. They remain conditional because their
+official form grades a completed design. They qualify only if individual
+Actions expose meaningful construction state rather than an artificial
+one-step Episode.
+
+The EdgeBench-only leads `vibrating_path_graph_coloring`,
+`order_addition_permutation_optimization`, and its particular `smt_solver`
+workspace are not candidates without an independently verified upstream. A
+future SMT environment must begin from the official
+[SMT-LIB](https://smt-lib.org/) standards and benchmark ecosystem, not from the
+EdgeBench scaffold.
+
+The text adventures `anchorhead_text_adventure`,
+`trinity_text_adventure`, and `tryst_text_adventure` refer to existing
+interactive-fiction games exposed by EdgeBench through an HTTP wrapper. Any
+reconsideration must start from each game's publisher, distribution rights, and
+interpreter ecosystem. Fixed worlds also make walkthrough hard-coding difficult
+to distinguish from general Policy improvement.
+
+Systems engineering, formal-proof, document-production, and large-workspace
+tasks should not be presented as EvoPolicyGym Environments. They grade
+repositories, proofs, checkpoints, or documents rather than closed-loop
+Policies. Faithful support would require a separate Artifact/Workspace Judge
+use case instead of weakening the current `Environment.reset()` /
+`Environment.step()` contract.
+
+## Integration requirements
+
+Every accepted candidate must be an independent Benchmark distribution using
+the public authoring SPI described in
+[ARCHITECTURE.md](../ARCHITECTURE.md). It must provide:
+
+- a recorded authoritative upstream URL, version or commit, and license;
+- explicit code, data, model, ROM, scenario, and asset provenance;
+- no runtime or build dependency on EdgeBench or SForge;
+- a fresh Environment and Policy lifecycle for every Episode;
+- strict, unrepaired Action validation;
+- deterministic split-scoped Episode generation;
+- a scalar objective plus bounded diagnostic Feedback;
+- private Validation and held-out Assessment coverage; and
+- real upstream smoke tests and cleanup tests.
+
+No `environments/edgebench/` namespace is planned. EdgeBench task IDs appear
+only in the provenance map to document how a secondary benchmark transformed
+the corresponding upstream material.

--- a/human-in-loop/balatro/README.md
+++ b/human-in-loop/balatro/README.md
@@ -1,0 +1,220 @@
+# Balatro human-in-the-loop policy lab
+
+本目录用于从已有 Agent 策略出发，按公开 replay 证据共同迭代出可稳定通关
+Ante 8 的策略。原始策略保持只读：
+
+`runs/balatro-skill-ab-gpt-5.6-sol-retry-20260725-164423/workspace/program`
+
+## 当前基线
+
+这里的“基线”指最初复制进来的 Agent 策略，不是当前候选：
+
+- 最终 digest：`sha256:8ac1c1b...`
+- 相同 digest 的 68 个公开 Episode：0 次通关，平均约 7.37 个 Blind
+- 最佳历史 digest：`sha256:60862b...`，20 个公开 Episode 平均约 8.55 个 Blind
+- 私有 Validation 选择 `submission-000010`，8 个 Episode 平均 6.75 个 Blind
+- 所有候选在公开评估和 Validation 中均为 0 次通关
+
+因此当前策略尚不能依赖小样本均值做局部调参，必须补全中后期成长能力。
+
+## 当前候选
+
+当前 `program/` digest 为
+`sha256:c61ac881f7e642f639335c6391698975fdaf8102c68b97dc6495878aee3febe6`。
+
+早期冻结版本在 64 个未参与调参的 validation Episode 上达到平均
+9.34 个 Blind，并在最终 64 个 test Episode 上达到平均 10.84 个
+Blind、中位数 11、1 次通关。当前 H19 版本在另一批 64 个未见
+validation Episode 上达到平均 9.84、中位数 11。当前 H21 在另一批
+64 个未见 validation Episode 上达到平均 10.33、1 次通关；封存的
+test 未被重新使用。H22 进一步修正 The Needle 的单手弃牌规划，并在
+另一批 64 个未见 validation Episode 上达到平均 9.81、1 次通关。当前
+H24 修复背面牌被错误当成同点数/同花色保留的问题；在全新 64 局 paired
+validation 上从同排程 H22 的 10.63 提升至 10.70，双方均通关 2 次，
+4 个 seed 中 3 个相同、1 个改善、没有下降。当前 H25 在 Ante 2+、弃牌
+耗尽且当前手不致命时，用安全 kicker 增加下一手抽牌吞吐；另一批全新
+64 局 paired validation 上从同排程 H24 的 10.23 提升至 10.45，早死
+从 15 降至 14，双方均未通关。该结果支持平均生存改善，尚不能证明独立
+validation 通关率提高。当前 H26 进一步将主阶段 +Mult 排在主阶段 XMult
+之前；另一批 64 局 paired validation 上从同排程 H25 的 9.78 提升至
+9.89，`≥18` 从 3 增至 5，双方均通关 2 次，4 个 seed 中 2 个改善、
+2 个相同。
+在两个公开确定性 Validation 排程、共 32 个 Episode 上：
+
+- 1/32 通关，胜率 3.125%，Policy failure 为 0；
+- 平均清除 8.875 个 Blind；原始配对基线为 6.656，H2 为 7.406；
+- 胜局清满 24 个 Blind，`won=True`，进入 Ante 9；
+- Ante 8 Boss 最后一手 50,400 分，最终 139,104/100,000。
+
+最终成对评估产物：
+
+- `runs/balatro-human-loop-final-paired16-seed20260726/`
+- `runs/balatro-human-loop-final-paired16-seed20260727/`
+
+Run score 对通关局给 1024 奖励，因此最终平均 Run score 40.125 不等同于平均
+Blind 数；去掉胜局后，其余 31 局平均清除 8.387 个 Blind。
+
+## 已确认的结构性问题
+
+1. **手牌估值严重低估/漏算 Joker。** 当前模型只覆盖少量直接
+   `t_chips`、`t_mult`、`x_mult`，大量依赖打出牌、牌型、顺序、持有牌、
+   retrigger 和动态 `extra` 的效果被当作零。
+2. **弃牌是“保留当前最佳出牌”的静态规则。** 它没有比较 draw 后的期望分数、
+   outs、剩余手数和当前 Blind 缺口，容易弃掉构筑需要的牌或在无望追牌时浪费弃牌。
+3. **商店只会填空槽，不会升级构筑。** Joker 满槽后永不出售或替换，也不 reroll；
+   除 Buffoon 外忽略所有 booster；最终版本还完全不买 voucher。
+4. **消耗牌链路缺失。** 策略从不主动使用已持有的 Tarot/Planet/Spectral，
+   pack 选择也没有为需要目标牌的卡生成目标。
+5. **没有长期构筑状态。** `primary_hand` 实际只是上一手最高估值牌型，会来回漂移；
+   没有角色覆盖（Chips、+Mult、XMult、scaling）、成长速度或切换成本。
+6. **没有 Boss、skip 和 Joker 顺序规划。** 永远选择 Blind，且永远不调整 Joker
+   顺序，无法规避关键 Boss 或正确放置 XMult。
+7. **回放测试只校验 Action 字段。** 它能防非法动作，但无法发现“合法但必输”的
+   决策回归。
+
+公开 replay 中的代表性失败：Ante 4 Big Blind，目标 7500，策略有 `$72` 和满
+Joker 槽，却保留 Smiley Face、Photograph、Abstract Joker、Fortune Teller、
+Seltzer；随后在后两手连续打单张 High Card，最终 4413/7500 失败。这同时暴露了
+商店不花钱、构筑不替换和手牌/Joker 联合估值不足。
+
+## 目标结构
+
+```text
+program/
+  policy.py                 # ABI 与组装
+  policy_system/
+    state.py                # 规范化 StateView 与 EpisodePlan
+    actions.py              # 唯一 Action admission gateway
+    hands.py                # 牌型识别与候选枚举
+    effects.py              # 可见效果 -> 结构化 effect roles
+    scoring.py              # 出牌顺序敏感的分数区间估计
+    draws.py                # outs、抽牌概率、弃牌价值
+    build.py                # 构筑角色覆盖、协同和替换价值
+    economy.py              # 购买、出售、reroll、利息与生存预算
+    strategy.py             # 各 phase 候选生成与统一选择
+  tests/
+    test_actions.py
+    test_replays.py
+    fixtures/               # 精简的关键公开状态
+analysis/
+  replay_report.py          # 只读取公开 replay 的诊断工具
+  evidence.md               # digest/批次/假设/结果台账
+```
+
+核心接口应是：
+
+```text
+observation
+  -> StateView
+  -> BuildPlan
+  -> CandidateIntent[]
+  -> OutcomeEstimate(score range, survival, growth, economy, confidence)
+  -> ActionGateway
+```
+
+## 实施顺序
+
+### P0：建立可靠测量
+
+- 把现有策略复制为 `program/` 起点，但不把它误称为最佳候选。
+- 生成 replay 报告：每局死亡点、每 Blind 实际/预测分数、购买与跳过机会、
+  终局钱、Joker 角色覆盖。
+- 固化至少三类 fixture：弱局、当前最强局、满 Joker 槽且有升级机会的商店。
+
+### P1：修复成长闭环
+
+- 实现结构化 Joker effect roles 和边际构筑价值。
+- 支持 Joker 替换、普通 booster、voucher、reroll 和利息/危险预算。
+- 支持零目标和有目标的 consumable/pack 行为。
+- 先让策略能把钱转化为长期分数，再优化细粒度出牌。
+
+### P2：统一出牌与弃牌
+
+- 枚举 1–5 张牌，并依据真实 scoring cards、增强、edition、seal、Joker
+  激活条件和顺序估计分数区间。
+- 使用 `last_hand.breakdown` 校准模型误差。
+- 弃牌比较“现在打”与“弃牌后各牌型的概率加权价值”，并考虑剩余 hands。
+
+### P3：通关规划
+
+- 稳定追踪 primary/secondary build，而不是复制上一手牌型。
+- 加入 Blind scaling、生存裕量、Boss constraint、skip tag 和 Joker 排序。
+- 优化目标使用“通关率优先，Blinds cleared 次之”，不以单局最高 Ante 选型。
+
+## 第一轮验收标准
+
+- replay 中所有动作严格合法，Policy failure 为 0；
+- 不再出现“高额现金 + 明显弱满槽构筑 + 直接离店”；
+- 每个被购买/保留/出售的 Joker 都能给出角色、激活率和边际价值；
+- 对代表性终局，预测分数误差可从 `last_hand` 被解释和记录；
+- 先在固定公开 replay 上通过语义断言，再运行新 Episode 比较分布。
+
+## 本地命令
+
+从仓库根目录生成默认基线报告：
+
+```console
+python3.12 human-in-loop/balatro/analysis/replay_report.py
+```
+
+也可以分析任意 replay 文件或包含 replay 的目录：
+
+```console
+python3.12 human-in-loop/balatro/analysis/replay_report.py \
+  path/to/replay.jsonl --output /tmp/balatro-report.md
+```
+
+运行 human-in-loop 策略回归：
+
+```console
+cd human-in-loop/balatro/program
+PYTHONPYCACHEPREFIX=/tmp/evopolicygym-pycache \
+  PYTHONPATH=../../../src \
+  python3.12 -m unittest discover -s tests -v
+```
+
+当前默认报告覆盖 `submission-000019` 的 4 局：38 次离店中有 22 次是在
+`$15+` 且仍有可负担库存时直接离开；四局终局现金为 `$49/$89/$31/$72`。
+动作中没有 `sell_joker`、`reroll_shop`、`redeem_voucher` 或
+`use_consumable`。这使 P1 的第一项实现明确为：构筑边际价值、满槽替换和花钱预算。
+
+### H1 实现状态
+
+`effects.py` 现在只依据当前 observation 中公开的 `ability`、
+`rule.parameters`、`rule.summary`、edition 和 debuff，输出 Chips、+Mult、
+XMult、retrigger、scaling、economy、generation、enabler、utility 等角色及
+置信度。`build.py` 用统一价值尺度评估角色缺口、利息储备、购买和满槽替换。
+
+替换是两步事务：先通过当前 `sell_joker` descriptor 卖出，再按稳定的公开 card
+key 记录 Episode-local 购买意图；下一次 observation 重新读取临时 index，并且
+只有 `buy_card` gateway 接纳后才购买。若商品消失或动作不合法，意图会被清除。
+
+在 `submission-000019` 的公开状态上做反事实探针，新模型产生 6 个
+`sell_joker` 触发点，主要针对 Reserved Parking、Odd Todd 和 Fortune Teller；
+这只证明新能力命中了预期状态，不代表反事实轨迹或得分有效。真实收益仍需新
+Episode 测量。
+
+随后进行了两组各 16 局的同 seed 配对 Validation。第一次实现因改变开放槽购买
+而严重回归；根据 replay 定位后，开放槽购买和 pack 排序恢复为基线行为，只在满槽
+时启用 H1 模型。最终候选在 32 个配对 Episode 上从 6.6563 提升至 6.8438，
+平均 `+0.1875` Blind，5 局改善、3 局变差、24 局相同，26 次出售均合法且
+Policy failure 为 0。两边仍是 0 次通关，因此 H1 只应视为保留的小幅改进。
+
+### H2–H7 实现状态
+
+- H2 在保留利息储备的前提下购买高价值 Voucher 和 Celestial pack，只使用免费
+  reroll。32 局平均从 6.656 提升到 7.406，仍未通关。
+- H4 用公开 `last_hand` 回放校准统一计分器。620 次可比较出牌上，预测 MAPE
+  从 0.890 降到 0.156，±25% 命中率从 33.5% 提升到 79.5%。它覆盖牌型条件、
+  逐牌和持牌效果、edition、动态参数、retrigger，并避免把 face-down 牌虚构成
+  Flush。
+- H4c 把弃牌从固定阈值改为随剩余弃牌数变化的安全边际，并落实 The Psychic
+  的“每手正好五张”约束。32 局平均清除 8.719 个 Blind。
+- H5–H7 修正周期 XMult 的长期估值，识别公开 copy 规则，购买 Blueprint，并
+  在每次出牌前比较可见手牌下的复制目标。补齐 `x3 if ...` 解析后，Blueprint
+  会在 Blackboard 激活时移动到它左侧，最终将原本停在 Ante 7 的同一局转化为
+  Ante 8 通关。
+- H8 将 Boss 规则约束抽到 `boss.py`，覆盖 The Psychic、The Eye、The Mouth、
+  首手 face-down 等公开文本，并加入零目标 Planet 的安全使用入口。H8 在相同
+  32 局上保持 1/32 通关、8.875 平均 Blind 和 0 Policy failure，说明它是低风险
+  结构增强；当前排程没有出现可用的 Planet consumable，因此尚未测出增益。

--- a/human-in-loop/balatro/analysis/evaluate_pair.py
+++ b/human-in-loop/balatro/analysis/evaluate_pair.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Evaluate two Balatro Programs on the same public Benchmark schedule."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from balatro import BalatroBenchmark  # type: ignore[import-not-found]
+
+from evopolicygym import EvaluationConfig, Program, evaluate
+from evopolicygym.execution import ProcessExecution
+from evopolicygym.results import EvaluationResult
+
+
+def _arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    repository = Path(__file__).resolve().parents[3]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline-program",
+        type=Path,
+        default=repository
+        / (
+            "runs/balatro-skill-ab-gpt-5.6-sol-retry-20260725-164423/"
+            "workspace/program"
+        ),
+    )
+    parser.add_argument(
+        "--candidate-program",
+        type=Path,
+        default=repository / "human-in-loop/balatro/program",
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--split",
+        choices=("train", "validation", "test"),
+        default="validation",
+    )
+    parser.add_argument("--episodes", type=int, default=16)
+    parser.add_argument("--seed", type=int, default=20_260_726)
+    parser.add_argument("--episode-timeout-seconds", type=float, default=60)
+    parser.add_argument(
+        "--allow-unsafe-process",
+        action="store_true",
+        help="acknowledge that local Policy subprocesses are not isolated",
+    )
+    arguments = parser.parse_args(argv)
+    if not arguments.allow_unsafe_process:
+        parser.error(
+            "ProcessExecution is not a sandbox; pass --allow-unsafe-process"
+        )
+    if arguments.output.exists() or arguments.output.is_symlink():
+        parser.error("--output must not already exist")
+    if not arguments.output.parent.is_dir():
+        parser.error("--output parent must exist")
+    return arguments
+
+
+def _json_value(result: EvaluationResult) -> dict[str, Any]:
+    return {
+        "benchmark_id": result.benchmark_id,
+        "environment_digest": result.environment_digest,
+        "program_digest": result.program_digest,
+        "feedback": {
+            "score": result.feedback.score,
+            "content": result.feedback.content,
+        },
+        "episodes": [asdict(episode) for episode in result.episodes],
+    }
+
+
+def _write_result(directory: Path, result: EvaluationResult) -> None:
+    directory.mkdir()
+    (directory / "feedback.json").write_text(
+        json.dumps(
+            _json_value(result),
+            allow_nan=False,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    for artifact in result.feedback.artifacts:
+        (directory / artifact.name).write_bytes(artifact.read_bytes())
+
+
+def _reward(summary: object) -> float:
+    reward = getattr(summary, "reward", None)
+    return float(reward) if isinstance(reward, (int, float)) else 0.0
+
+
+def _comparison(
+    *,
+    baseline: EvaluationResult,
+    candidate: EvaluationResult,
+    split: str,
+    episodes: int,
+    seed: int,
+) -> dict[str, Any]:
+    baseline_rewards = [_reward(item) for item in baseline.episodes]
+    candidate_rewards = [_reward(item) for item in candidate.episodes]
+    return {
+        "schema": "evopolicygym-balatro/human-paired-evaluation-v1",
+        "split": split,
+        "episodes": episodes,
+        "seed": seed,
+        "baseline": _json_value(baseline),
+        "candidate": _json_value(candidate),
+        "paired_reward_delta": [
+            candidate_reward - baseline_reward
+            for baseline_reward, candidate_reward in zip(
+                baseline_rewards,
+                candidate_rewards,
+                strict=True,
+            )
+        ],
+        "mean_score_delta": (
+            candidate.feedback.score - baseline.feedback.score
+        ),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _arguments(argv)
+    config = EvaluationConfig(
+        split=arguments.split,
+        episodes=arguments.episodes,
+        seed=arguments.seed,
+        episode_timeout_seconds=arguments.episode_timeout_seconds,
+    )
+    execution = ProcessExecution.unsafe()
+
+    print(
+        f"evaluating baseline: {arguments.episodes} "
+        f"{arguments.split} Episodes",
+        flush=True,
+    )
+    baseline = evaluate(
+        Program.from_directory(arguments.baseline_program),
+        BalatroBenchmark(),
+        execution=execution,
+        config=config,
+    )
+    print(
+        f"baseline score={baseline.feedback.score:.3f}",
+        flush=True,
+    )
+
+    print(
+        f"evaluating candidate: {arguments.episodes} "
+        f"{arguments.split} Episodes",
+        flush=True,
+    )
+    candidate = evaluate(
+        Program.from_directory(arguments.candidate_program),
+        BalatroBenchmark(),
+        execution=execution,
+        config=config,
+    )
+    print(
+        f"candidate score={candidate.feedback.score:.3f}",
+        flush=True,
+    )
+
+    arguments.output.mkdir()
+    _write_result(arguments.output / "baseline", baseline)
+    _write_result(arguments.output / "candidate", candidate)
+    comparison = _comparison(
+        baseline=baseline,
+        candidate=candidate,
+        split=arguments.split,
+        episodes=arguments.episodes,
+        seed=arguments.seed,
+    )
+    (arguments.output / "comparison.json").write_text(
+        json.dumps(
+            comparison,
+            allow_nan=False,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(
+        f"mean delta={comparison['mean_score_delta']:+.3f}; "
+        f"results={arguments.output}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/human-in-loop/balatro/analysis/evidence.md
+++ b/human-in-loop/balatro/analysis/evidence.md
@@ -1,0 +1,622 @@
+# Evidence ledger
+
+| Candidate | Public Episodes | Wins | Mean Blinds | Validation | Notes |
+|---|---:|---:|---:|---:|---|
+| `sha256:60862b...` | 20 | 0 | 8.55 | 6.75 (8 eps) | Best public mean among historical digests |
+| `sha256:8deda60...` | 80 | 0 | 6.23 | 6.75 (8 eps) | Validation-selected submission 10 |
+| `sha256:8ac1c1b...` | 68 | 0 | 7.37 | 6.00 (8 eps) | Current copied baseline; voucher purchase removed |
+| `sha256:c37a548...` | 32 paired | 0 | 6.84 | validation seeds 20260726–27 | H1 replacement candidate; paired baseline 6.66, delta +0.19 |
+| `sha256:ceaeed...` | 32 paired | 0 | 7.41 | validation seeds 20260726–27 | H2 economy candidate; paired baseline 6.66, delta +0.75 |
+| `sha256:d4e559...` | 32 paired | 1 | 8.88 | validation seeds 20260726–27 | Final candidate; 3.125% wins, no Policy failures |
+| `sha256:598424...` | 32 paired | 1 | 8.88 | validation seeds 20260726–27 | H8 Boss constraints + safe Planet use; unchanged score, no Policy failures |
+| `sha256:69b42d...` | 16 smoke | 1 | 9.75 | validation seeds 20260726–27 | H12 visible scoring calibration; retained win, no Policy failures |
+| `sha256:93e2e3...` | 16 smoke | 1 | 9.81 | validation seeds 20260726–27 | H13 round-history scoring; retained win, one Episode +1 Blind |
+| `sha256:9c8aca...` | 16 smoke | 1 | 9.81 | validation seeds 20260726–27 | H14 sell-value scoring calibration; behavior-neutral |
+| `sha256:f0191b...` | 32 paired | 1 | 9.72 | validation seeds 20260726–27 | H16 consecutive-discard stop; +0.84 mean Blinds over H8 |
+| `sha256:5095ed...` | 32 paired | 1 | 9.72 | validation seeds 20260726–27 | H17 mature direct-Planet purchase; behavior-neutral |
+| `sha256:5095ed...` | 64 unseen validation | 1 | 9.34 | validation seeds 20260802–05 | frozen confirmation; median 10, early rate 26.6% |
+| `sha256:5095ed...` | 64 final test | 1 | 10.84 | test seed 20260901 | frozen final result; median 11, early rate 12.5% |
+| `sha256:981dd7...` | 64 unseen validation | 0 | 9.84 | validation seeds 20261101–04 | H19 gate; median 11, early rate 20.3%; final test not reused |
+| `sha256:1f9468...` | 64 unseen validation | 1 | 10.33 | validation seeds 20261401–04 | H21 gate; ≥18 in 6 Episodes, final test not reused |
+| `sha256:da7898...` | 64 unseen validation | 1 | 9.81 | validation seeds 20261601–04 | H22 Needle gate; ≥18 in 6 Episodes, final test not reused |
+| `sha256:8d2526...` | 64 paired unseen validation | 2 | 10.70 | validation seeds 20261801–04 | H24 hidden-card discard gate; paired H22 mean 10.63, no seed regressed |
+| `sha256:afe6da...` | 64 paired unseen validation | 0 | 10.45 | validation seeds 20262001–04 | H25 continuation gate; paired H24 mean 10.23, early deaths 15→14 |
+| `sha256:c61ac8...` | 64 paired unseen validation | 2 | 9.89 | validation seeds 20262201–04 | H26 Joker order gate; paired H25 mean 9.78, ≥18 improved 3→5 |
+
+Public means pool identical Program digests across submissions. Validation values
+come from `validation/report.json`; Validation does not publish replay evidence.
+
+## Experiment queue
+
+| ID | Capability | Hypothesis | Status |
+|---|---|---|---|
+| H0 | Replay diagnosis | High-cash shop exits and weak full slots explain a material share of Ante 3–4 deaths | confirmed: 22/38 exits at $15+ with affordable inventory |
+| H1 | Effect roles + replacement | Replacing low marginal-value Jokers restores mid-game growth | measured: +0.19 mean Blind over 32 paired Episodes; 5 better / 3 worse / 24 equal; 0 wins |
+| H2 | Booster/voucher/reroll budget | Spending above the interest reserve raises Ante reach without destabilizing early survival | confirmed: +0.75 mean Blind over 32 paired Episodes |
+| H3 | Consumable targeting | Legal targeted Tarot/Planet use improves build consistency | pending |
+| H4 | Unified hand scoring | Conditional Joker activation prevents late weak High Card plays | confirmed: replay MAPE 0.890 → 0.156; 33.5% → 79.5% within ±25% |
+| H5 | Draw safety margin | Accurate scores need an explicit reason to spend early discards before hands | confirmed: H4c reaches 8.72 mean Blinds |
+| H6 | Copy build and ordering | Buying and dynamically positioning a visible copy Joker raises the late-game ceiling | confirmed: converted an Ante 7 loss into an Ante 8 win |
+| H8 | Boss constraints + Planet | Public Boss rules prevent legal-but-zero plays; zero-target Planet use adds safe growth | measured: unchanged 1/32 wins and 8.875 mean Blinds; no Planet consumable appeared in this schedule |
+| H9 | Skip Tags | Free Pack/edition/hand-size Tags should repay one skipped Blind | rejected: 3-episode smoke regressed seed26 12.00→7.67 and seed27 5.00→2.67; reverted |
+| H10 | Joker role completion | Narrow XMult/retrigger/copy bonuses improve builds without disrupting stable purchase paths | rejected: retained win but pooled mean Blinds regressed 8.94→8.38; reverted |
+| H11 | Straight-draw discard | Preserving four-card straight draws improves early hand conversion | rejected: seed26 8-Episode score fell to 7.125 and known win disappeared; reverted |
+| H12 | Visible scoring calibration | Modeling public Stuntman, Bootstraps, and Raised Fist effects improves hand selection | smoke accepted: mean Blinds 8.94→9.75 over the same 16 Episodes; retained known win |
+| H13 | Round-history scoring | Supernova and Card Sharp can be scored from public run/round history | smoke accepted: mean Blinds 9.75→9.81; retained win; Seltzer sub-experiment was behavior-neutral and reverted after MAPE worsened |
+| H14 | Sell-value scoring | Swashbuckler can use other Jokers' public sell values instead of its placeholder mult | calibration accepted: removed its systematic underprediction; fixed-seed behavior unchanged |
+| H15 | Early survival threshold | Empty Ante 1–2 builds should play near-sufficient hands instead of spending all discards | rejected: 0.90 moved one Episode 0→13 but another 8→0; 0.95 kept the regression and lost the gain; reverted |
+| H16 | Consecutive-discard stop | Apply the early survival threshold only after a failed discard | confirmed: retained every seed26 smoke result, moved one seed27 Episode 0→13; 32-Episode mean Blinds 8.88→9.72 |
+| H17 | Direct Planet purchase | Buy shop Planets for an established hand without disrupting economy | conservative variant accepted: 32-Episode behavior unchanged; broad variant caused two -1 Blind regressions |
+| H18 | Generalization audit | Improvements should survive schedules never used for tuning | confirmed: +2.89 mean Blinds over 64 unseen validation Episodes and +4.20 over 64 final test Episodes |
+| H19 | Moderate Joker replacement | Lowering the modeled upgrade threshold unlocks full-slot mid-game growth | accepted: same-seed train A/B 11.05→11.64 mean Blinds; all four train seeds improved; unseen validation gate mean 9.84 |
+| H20 | Recent-hand replacement simulation | Use the last public scoring hand to choose which Joker to replace | rejected: train A/B 10.94→11.19 but only 2/4 seeds improved, one regressed; complexity not justified |
+| H21 | Surplus paid reroll | Full-slot high-cash shops should search once more when no purchase qualifies | accepted: train A/B 3/4 seeds improved and one unchanged; wins 1→2; unseen validation mean 10.33 with 1 win |
+| H22 | The Needle discard planning | A one-hand Boss should spend discards before committing its only hand | accepted: train A/B 3/4 seeds improved, one unchanged; mean 9.78→10.00 and early deaths 17→15 |
+| H23 | The Flint score calibration | Halving only base Chips/Mult should improve Flint hand selection | rejected: exact model changed a myopic selector adversely; train mean 10.34→10.28, two seeds regressed; reverted |
+| H24 | Hidden-card discard grouping | Face-down cards must not look like a same-rank or same-suit draw | accepted: train mean 10.34→10.63 with two targeted gains; paired unseen validation 10.63→10.70, no regressions |
+| H25 | Safe play-throughput | Nonlethal hands should cycle safe kickers when future hands can use the extra draws | accepted narrow variant: Ante 2+, no discards; train 10.84→11.36, paired unseen validation 10.23→10.45 |
+| H26 | Main Joker scoring order | Main-stage additive Mult should resolve before main-stage XMult | accepted: train wins 1→2; paired unseen validation mean 9.78→9.89 and ≥18 improved 3→5 |
+| H27 | Brainstorm target arrangement | A single Brainstorm should copy the best visible-hand target at the left edge | rejected: train 10.48→10.52, but paired unseen validation regressed 10.64→10.61 and ≥12 fell 24→23 |
+
+## H1 paired evaluation
+
+Both candidates ran on identical public Benchmark schedules with
+`split=validation`, no Policy failures, and no wins.
+
+| Seed | Episodes | Baseline | H1 | Delta | H1 sell actions |
+|---:|---:|---:|---:|---:|---:|
+| 20260726 | 16 | 6.4375 | 6.6250 | +0.1875 | 12 |
+| 20260727 | 16 | 6.8750 | 7.0625 | +0.1875 | 14 |
+| pooled | 32 | 6.6563 | 6.8438 | +0.1875 | 26 |
+
+Across the pooled paired Episodes, H1 improved 5, worsened 3, and left 24
+unchanged. The effect is directionally reproducible but small, and the absence
+of wins means it is not yet evidence of improved Ante 8 completion.
+
+Artifacts:
+
+- `runs/balatro-human-loop-p1-paired16-seed20260726/`
+- `runs/balatro-human-loop-p1-paired16-seed20260727/`
+
+## H2 paired evaluation
+
+H2 kept baseline open-slot acquisition, added conservative high-value Vouchers,
+one Celestial pack per shop, and free rerolls only.
+
+| Seed | Episodes | Baseline | H2 | Delta |
+|---:|---:|---:|---:|---:|
+| 20260726 | 16 | 6.4375 | 7.4375 | +1.0000 |
+| 20260727 | 16 | 6.8750 | 7.3750 | +0.5000 |
+| pooled | 32 | 6.6563 | 7.4063 | +0.7500 |
+
+Artifacts:
+
+- `runs/balatro-human-loop-h2b-paired16-seed20260726/`
+- `runs/balatro-human-loop-h2b-paired16-seed20260727/`
+
+## Final paired evaluation
+
+Both Programs used the same public deterministic schedules. The final candidate
+had no Policy failures. Mean Blinds is reported separately because a win has
+Run score 1024.
+
+| Seed | Episodes | Baseline Run score | Final Run score | Final mean Blinds | Wins |
+|---:|---:|---:|---:|---:|---:|
+| 20260726 | 16 | 6.4375 | 72.3750 | 9.8750 | 1 |
+| 20260727 | 16 | 6.8750 | 7.8750 | 7.8750 | 0 |
+| pooled | 32 | 6.6563 | 40.1250 | 8.8750 | 1 |
+
+The winning Episode cleared all 24 required Blinds, ended with
+`progress.won=True` at Ante 9, and scored 139,104 against the Ante 8 Boss target
+of 100,000. The last hand scored 50,400. Its final build was Half Joker,
+Loyalty Card, Hack, Blueprint, and Blackboard; visible-hand simulation moved
+Blueprint immediately left of Blackboard whenever the all-black held-card
+condition made copying X3 stronger than copying Half Joker.
+
+Artifacts:
+
+- `runs/balatro-human-loop-final-paired16-seed20260726/`
+- `runs/balatro-human-loop-final-paired16-seed20260727/`
+
+## H8 paired evaluation
+
+H8 added public-text Boss constraints for The Psychic, The Eye, The Mouth, and
+face-down first hands. It also uses a Planet consumable only when the current
+`use_consumable` descriptor explicitly admits a zero-target action matching the
+Episode-local primary hand. Targeted consumables remain untouched.
+
+| Seed | Episodes | Baseline | H8 | Delta | H8 wins |
+|---:|---:|---:|---:|---:|---:|
+| 20260726 | 16 | 6.4375 | 72.3750 | +65.9375 | 1 |
+| 20260727 | 16 | 6.8750 | 7.8750 | +1.0000 | 0 |
+| pooled | 32 | 6.6563 | 40.1250 | +33.4688 | 1 |
+
+The large pooled Run score is caused by the 1024-point complete-run bonus. Mean
+Blinds remains 8.875, and the change introduced no Policy failure.
+
+Artifacts:
+
+- `runs/balatro-human-loop-boss2-paired16-seed20260726/`
+- `runs/balatro-human-loop-boss2-paired16-seed20260727/`
+
+## H10 rejected smoke evaluation
+
+Replacing open-slot acquisition entirely with modeled Joker value removed the
+known seed26 win, so that broad change was rejected. The retained variant keeps
+the prior acquisition ordering and adds narrow bonuses only for a missing
+XMult, retrigger, or copy role. It retained the known win but still reduced
+pooled mean Blinds from about 8.94 to 8.38, so it was reverted. The speculative
+mandatory Joker/Boss cash reserve was also reverted after it removed the known
+win.
+
+| Seed | Episodes | Candidate Run score | Mean Blinds | Wins |
+|---:|---:|---:|---:|---:|
+| 20260726 | 8 | 134.750 | 9.750 | 1 |
+| 20260727 | 8 | 7.000 | 7.000 | 0 |
+| pooled | 16 | 70.875 | 8.375 | 1 |
+
+Artifacts:
+
+- `runs/balatro-human-loop-joker-blend-norestrict-smoke8-seed20260726/`
+- `runs/balatro-human-loop-joker-blend-norestrict-smoke8-seed20260727/`
+
+## H12 smoke evaluation
+
+H12 uses only current public fields: Stuntman's nested `chip_mod`, Bootstraps'
+visible money buckets, and Raised Fist's lowest visible held rank. On the
+existing 32-Episode replay corpus, High Card MAPE fell from 20.2% to 12.2% and
+Two Pair MAPE fell from 19.0% to 13.9%.
+
+| Seed | Episodes | Candidate Run score | Candidate mean Blinds | Wins |
+|---:|---:|---:|---:|---:|
+| 20260726 | 8 | 137.750 | 12.750 | 1 |
+| 20260727 | 8 | 6.750 | 6.750 | 0 |
+| pooled | 16 | 72.250 | 9.750 | 1 |
+
+Artifacts:
+
+- `runs/balatro-human-loop-score-calibration-smoke8-seed20260726/`
+- `runs/balatro-human-loop-score-calibration-smoke8-seed20260727/`
+
+## H13 smoke evaluation
+
+Supernova now uses the public per-hand `played` count including the pending
+play. Card Sharp uses Episode-local same-round hand-type counts, reset at each
+Blind. A separate Seltzer retrigger model changed no action and worsened its
+replay MAPE, so that part was reverted.
+
+| Seed | Episodes | Candidate Run score | Candidate mean Blinds | Wins |
+|---:|---:|---:|---:|---:|
+| 20260726 | 8 | 137.750 | 12.750 | 1 |
+| 20260727 | 8 | 6.875 | 6.875 | 0 |
+| pooled | 16 | 72.3125 | 9.8125 | 1 |
+
+Artifacts:
+
+- `runs/balatro-human-loop-card-sharp-smoke8-seed20260726/`
+- `runs/balatro-human-loop-card-sharp-smoke8-seed20260727/`
+
+## H14 smoke evaluation
+
+Swashbuckler now sums the visible `sell_value` of every other Joker. Its old
+placeholder `mult=1` is no longer double-counted. Replay calibration improved,
+while both fixed-seed schedules remained identical to H13.
+
+Artifacts:
+
+- `runs/balatro-human-loop-swashbuckler-smoke8-seed20260726/`
+- `runs/balatro-human-loop-swashbuckler-smoke8-seed20260727/`
+
+## H16 paired evaluation
+
+H16 tracks consecutive discards within the current Blind. Only after one
+discard, at Ante 1–2 with no Joker, does it play a hand whose projected
+remaining-hand total covers at least 90% of the target gap. Playing a hand or
+starting a new Blind resets the streak.
+
+| Seed | Episodes | Candidate Run score | Candidate mean Blinds | Wins |
+|---:|---:|---:|---:|---:|
+| 20260726 | 16 | 73.1875 | 10.6875 | 1 |
+| 20260727 | 16 | 8.7500 | 8.7500 | 0 |
+| pooled | 32 | 40.9688 | 9.7188 | 1 |
+
+Compared with H8 on the same schedules, mean Blinds rose from 8.8750 to
+9.7188. The count of Episodes ending at five or fewer Blinds fell from eight
+to six. No Policy failure occurred.
+
+Artifacts:
+
+- `runs/balatro-human-loop-discard-stop-paired16-seed20260726/`
+- `runs/balatro-human-loop-discard-stop-paired16-seed20260727/`
+
+## H17 paired evaluation
+
+The broad direct-Planet experiment caused two one-Blind regressions. The
+retained variant buys at most one matching Planet per shop only at Ante 3+,
+with a free consumable slot, five dollars above the normal reserve, and a
+target hand played at least five times or already at Level 2. It produced the
+same 32-Episode results as H16 and introduced no Policy failure.
+
+Artifacts:
+
+- `runs/balatro-human-loop-direct-planet-mature-paired16-seed20260726/`
+- `runs/balatro-human-loop-direct-planet-mature-paired16-seed20260727/`
+
+## H18 frozen generalization audit
+
+Seeds 20260726–27 are development schedules and are no longer treated as
+independent evidence. The Program was frozen at
+`sha256:5095edea0571433beebe58a8bd3f3f24238fdf6e2a73754e99a3cf6e8abd74a8`
+before the following evaluations. No unseen replay trajectory was used to tune
+the Policy.
+
+| Dataset | Episodes | Baseline mean Blind | Candidate mean Blind | Baseline / candidate median | Baseline / candidate early ≤5 | Candidate wins |
+|---|---:|---:|---:|---:|---:|---:|
+| unseen validation, seeds 20260802–05 | 64 | 6.4531 | 9.3438 | 7 / 10 | 45.3% / 26.6% | 1 |
+| final test, seed 20260901 | 64 | 6.6406 | 10.8438 | 7 / 11 | 40.6% / 12.5% | 1 |
+
+The test Run score is 26.4688 because one completed run contributes the
+Benchmark's 1024 reward. Mean Blind replaces that reward with 24 cleared
+Blinds, preventing the win bonus from distorting the main progress metric.
+
+Artifacts:
+
+- `runs/balatro-human-loop-unseen-validation16-seed20260802/`
+- `runs/balatro-human-loop-unseen-validation16-seed20260803/`
+- `runs/balatro-human-loop-unseen-validation16-seed20260804/`
+- `runs/balatro-human-loop-unseen-validation16-seed20260805/`
+- `runs/balatro-human-loop-final-test64-seed20260901/`
+
+## H19 isolated development and gate
+
+The final test above remains sealed and was not reused. Train seeds
+20261001–04 diagnosed the problem: 53 of 57 observed mid-game terminal builds
+had full Joker slots and median cash of 33. H19 changes only the modeled
+replacement threshold from `max(6, 30%)` to `max(4, 20%)`.
+
+On fresh train seeds 20261011–14, H19 and H17 were run on the same 64
+Episodes:
+
+| Candidate | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 |
+|---|---:|---:|---:|---:|---:|
+| H17 control | 11.0469 | 11 | 7 | 29 | 2 |
+| H19 | 11.6406 | 11 | 7 | 31 | 4 |
+
+Every train seed improved. H19 then passed a one-way gate on unseen validation
+seeds 20261101–04:
+
+| Episodes | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Policy failures |
+|---:|---:|---:|---:|---:|---:|---:|
+| 64 | 9.8438 | 11 | 13 (20.3%) | 20 | 3 | 0 |
+
+Artifacts:
+
+- `runs/balatro-human-loop-h19-train16-seed20261011/`
+- `runs/balatro-human-loop-h19-train16-seed20261012/`
+- `runs/balatro-human-loop-h19-train16-seed20261013/`
+- `runs/balatro-human-loop-h19-train16-seed20261014/`
+- `runs/balatro-human-loop-h17-control-train16-seed20261011/`
+- `runs/balatro-human-loop-h17-control-train16-seed20261012/`
+- `runs/balatro-human-loop-h17-control-train16-seed20261013/`
+- `runs/balatro-human-loop-h17-control-train16-seed20261014/`
+- `runs/balatro-human-loop-h19-gate16-seed20261101/`
+- `runs/balatro-human-loop-h19-gate16-seed20261102/`
+- `runs/balatro-human-loop-h19-gate16-seed20261103/`
+- `runs/balatro-human-loop-h19-gate16-seed20261104/`
+
+## H21 isolated development and gate
+
+H21 permits one paid reroll per shop only at Ante 3+, with full Joker slots,
+after all normal purchases fail, and only when paying the reroll still leaves
+the normal reserve plus ten dollars.
+
+On fresh train seeds 20261301–04, H21 and H19 were evaluated on identical
+64-Episode schedules:
+
+| Candidate | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins |
+|---|---:|---:|---:|---:|---:|---:|
+| H19 control | 10.4531 | 11 | 11 | 26 | 2 | 1 |
+| H21 | 10.5938 | 11 | 11 | 25 | 3 | 2 |
+
+Three train seeds improved and one was unchanged. On unseen validation seeds
+20261401–04, H21 achieved:
+
+| Episodes | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins | Policy failures |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 64 | 10.3281 | 10 | 14 (21.9%) | 24 | 6 | 1 | 0 |
+
+The previously sealed final test was not rerun or inspected.
+
+Artifacts:
+
+- `runs/balatro-human-loop-h21-train16-seed20261301/`
+- `runs/balatro-human-loop-h21-train16-seed20261302/`
+- `runs/balatro-human-loop-h21-train16-seed20261303/`
+- `runs/balatro-human-loop-h21-train16-seed20261304/`
+- `runs/balatro-human-loop-h19-control3-train16-seed20261301/`
+- `runs/balatro-human-loop-h19-control3-train16-seed20261302/`
+- `runs/balatro-human-loop-h19-control3-train16-seed20261303/`
+- `runs/balatro-human-loop-h19-control3-train16-seed20261304/`
+- `runs/balatro-human-loop-h21-gate16-seed20261401/`
+- `runs/balatro-human-loop-h21-gate16-seed20261402/`
+- `runs/balatro-human-loop-h21-gate16-seed20261403/`
+- `runs/balatro-human-loop-h21-gate16-seed20261404/`
+
+## H22 isolated development and gate
+
+Train-only Boss diagnosis found The Needle as the most frequent terminal Boss:
+six observed failures averaged only 43.9% of its target. The cause was exact:
+the generic discard guard required more than one remaining hand, while The
+Needle exposes only one. H22 lets that visible rule spend discards before its
+single hand; lethal predicted hands are still played immediately.
+
+On fresh train seeds 20261501–04:
+
+| Candidate | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins |
+|---|---:|---:|---:|---:|---:|---:|
+| H21 control | 9.7812 | 10 | 17 | 21 | 4 | 2 |
+| H22 | 10.0000 | 10 | 15 | 22 | 4 | 2 |
+
+Three seeds improved and one was unchanged. On unseen validation seeds
+20261601–04, H22 achieved:
+
+| Episodes | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins | Policy failures |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 64 | 9.8125 | 10 | 18 (28.1%) | 17 | 6 | 1 | 0 |
+
+The sealed final test remained untouched.
+
+Artifacts:
+
+- `runs/balatro-human-loop-h22-train16-seed20261501/`
+- `runs/balatro-human-loop-h22-train16-seed20261502/`
+- `runs/balatro-human-loop-h22-train16-seed20261503/`
+- `runs/balatro-human-loop-h22-train16-seed20261504/`
+- `runs/balatro-human-loop-h21-control4-train16-seed20261501/`
+- `runs/balatro-human-loop-h21-control4-train16-seed20261502/`
+- `runs/balatro-human-loop-h21-control4-train16-seed20261503/`
+- `runs/balatro-human-loop-h21-control4-train16-seed20261504/`
+- `runs/balatro-human-loop-h22-gate16-seed20261601/`
+- `runs/balatro-human-loop-h22-gate16-seed20261602/`
+- `runs/balatro-human-loop-h22-gate16-seed20261603/`
+- `runs/balatro-human-loop-h22-gate16-seed20261604/`
+
+## H23 rejected Flint calibration
+
+H23 reproduced The Flint's public scoring order: halve and round only the
+poker-hand base Chips and Mult before playing-card and Joker effects. Although
+the formula matched the public breakdown, the current selector optimizes one
+hand at a time. On train seeds 20261701–04, the exact estimate sometimes chose
+a slightly stronger immediate High Card or spent more discards while reducing
+future draw throughput.
+
+| Candidate | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins |
+|---|---:|---:|---:|---:|---:|---:|
+| H22 control | 10.3438 | 11 | 6 | 18 | 3 | 0 |
+| H23 | 10.2812 | 11 | 6 | 18 | 3 | 0 |
+
+Two seeds were unchanged and two regressed. H23 was reverted without entering
+validation. The result supports multi-hand continuation modeling before
+reintroducing exact Flint calibration.
+
+Artifacts:
+
+- `runs/balatro-human-loop-h23-train16-seed20261701/`
+- `runs/balatro-human-loop-h23-train16-seed20261702/`
+- `runs/balatro-human-loop-h23-train16-seed20261703/`
+- `runs/balatro-human-loop-h23-train16-seed20261704/`
+
+## H24 hidden-card discard repair and paired gate
+
+After The Fish plays a hand, newly drawn cards expose `rank=None` and
+`suit=None`. The old discard grouping converted both values to the same string,
+so multiple face-down cards were incorrectly preserved as both a pair and a
+flush draw. H24 excludes unknown rank and suit values from grouping; they
+remain eligible for discard unless selected for the current best hand.
+
+On the same development schedules used to diagnose the bug:
+
+| Candidate | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins |
+|---|---:|---:|---:|---:|---:|---:|
+| H22 control | 10.3438 | 11 | 6 | 18 | 3 | 0 |
+| H24 | 10.6250 | 11 | 6 | 19 | 4 | 0 |
+
+Two seeds improved and two were unchanged. Only two Episode outcomes changed,
+both at The Fish: one moved from 6 to 23 cleared Blinds and one from 8 to 9.
+
+H24 was frozen before a paired gate on unseen validation seeds 20261801–04.
+Only aggregate outcomes were inspected:
+
+| Candidate | Episodes | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins | Policy failures |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| H22 control | 64 | 10.6250 | 11 | 17 | 25 | 10 | 2 | 0 |
+| H24 | 64 | 10.7031 | 11 | 17 | 25 | 10 | 2 | 0 |
+
+Three validation seeds were unchanged and one improved; none regressed. The
+sealed final test remained untouched.
+
+Artifacts:
+
+- `runs/balatro-human-loop-h24-train16-seed20261701/`
+- `runs/balatro-human-loop-h24-train16-seed20261702/`
+- `runs/balatro-human-loop-h24-train16-seed20261703/`
+- `runs/balatro-human-loop-h24-train16-seed20261704/`
+- `runs/balatro-human-loop-h24-gate-paired16-seed20261801/`
+- `runs/balatro-human-loop-h24-gate-paired16-seed20261802/`
+- `runs/balatro-human-loop-h24-gate-paired16-seed20261803/`
+- `runs/balatro-human-loop-h24-gate-paired16-seed20261804/`
+
+## H25 bounded multi-hand continuation
+
+H23 showed that a more accurate immediate-hand score can still lose when the
+selector ignores what the play draws for the next hand. H25 adds a bounded
+continuation proxy after the discard decision has already been made. For a
+nonlethal play with future hands remaining, it may add low, unmodified cards
+that are not part of the selected hand, a visible pair, or a four-card flush
+draw. The augmented play must retain the same poker-hand type and estimated
+score apart from the existing `0.05` non-scoring-card tie-break.
+
+The broad development variant altered 32/64 outcomes. Although mean Blind rose
+from 10.84 to 11.45 and wins from two to three, it caused several large early
+regressions. Every inspected early regression first diverged while discards
+were still available. Requiring zero discards reduced changed outcomes to 16,
+but one Ante 1 Episode still moved from five Blinds to one. The retained H25
+therefore activates only at Ante 2+ with zero discards.
+
+On train seeds 20261901–04:
+
+| Candidate | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins |
+|---|---:|---:|---:|---:|---:|---:|
+| H24 control | 10.8438 | 11 | 11 | 23 | 4 | 2 |
+| H25 retained | 11.3594 | 11 | 9 | 26 | 5 | 2 |
+
+Three train seeds improved and one was unchanged; only 12/64 Episode outcomes
+changed. One H24 win stopped at 23 Blinds while a separate 20-Blind Episode
+became a win.
+
+H25 was frozen before the paired validation gate on seeds 20262001–04. The
+acceptance criteria were fixed in advance: no Policy failures, no reduction in
+wins or mean Blind, and no increase in early deaths. Only aggregate outcomes
+were inspected:
+
+| Candidate | Episodes | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins | Policy failures |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| H24 control | 64 | 10.2344 | 11 | 15 | 27 | 5 | 0 | 0 |
+| H25 | 64 | 10.4531 | 11 | 14 | 28 | 4 | 0 | 0 |
+
+Two validation seeds had equal aggregate means, one improved by 1.0 Blind, and
+one regressed by 0.125. H25 passed the predefined gate, but the `≥18` count
+fell from five to four and neither side won. The evidence therefore supports
+average survival and draw efficiency, not a demonstrated validation win-rate
+increase. The sealed final test remained untouched.
+
+Artifacts:
+
+- `runs/balatro-human-loop-h25c-train16-seed20261901/`
+- `runs/balatro-human-loop-h25c-train16-seed20261902/`
+- `runs/balatro-human-loop-h25c-train16-seed20261903/`
+- `runs/balatro-human-loop-h25c-train16-seed20261904/`
+- `runs/balatro-human-loop-h25-gate-paired16-seed20262001/`
+- `runs/balatro-human-loop-h25-gate-paired16-seed20262002/`
+- `runs/balatro-human-loop-h25-gate-paired16-seed20262003/`
+- `runs/balatro-human-loop-h25-gate-paired16-seed20262004/`
+
+## H26 main-stage Joker ordering
+
+H25 only rearranged Blueprint. A train-only counterfactual found 312 plays
+where a main-stage XMult Joker appeared before a later additive-Mult Joker.
+Moving only main-stage XMult to the right improved the visible estimate on 110
+plays across 12 Episodes, with a median estimated ratio of 1.58. This was a
+model-based diagnostic rather than environment evidence.
+
+H26 resolves one visible inversion per observation. It excludes face-card,
+scored-card, held-card, and per-card effects because those trigger in a
+different scoring phase. It also declines generic ordering whenever a copy
+Joker is present, leaving Blueprint behavior unchanged and avoiding unmodeled
+Brainstorm chains.
+
+On fresh train seeds 20262101–04:
+
+| Candidate | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins |
+|---|---:|---:|---:|---:|---:|---:|
+| H25 control | 10.6094 | 11 | 12 | 28 | 5 | 1 |
+| H26 | 10.7813 | 11 | 12 | 28 | 5 | 2 |
+
+Three train seeds improved and one was unchanged. Only five Episode outcomes
+changed: four improved and one regressed. H26 was then frozen before a paired
+validation gate on seeds 20262201–04. Only aggregate outcomes were inspected:
+
+| Candidate | Episodes | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins | Policy failures |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| H25 control | 64 | 9.7813 | 11 | 14 | 23 | 3 | 2 | 0 |
+| H26 | 64 | 9.8906 | 11 | 14 | 23 | 5 | 2 | 0 |
+
+Two validation seeds improved and two were unchanged; none regressed. Only
+three of 64 Episode outcomes changed. H26 passed the predefined gate: wins,
+early deaths, and Policy failures did not worsen, while mean Blind and the
+`≥18` tail improved. The sealed final test remained untouched.
+
+Artifacts:
+
+- `runs/balatro-human-loop-h26-train16-seed20262101/`
+- `runs/balatro-human-loop-h26-train16-seed20262102/`
+- `runs/balatro-human-loop-h26-train16-seed20262103/`
+- `runs/balatro-human-loop-h26-train16-seed20262104/`
+- `runs/balatro-human-loop-h26-gate-paired16-seed20262201/`
+- `runs/balatro-human-loop-h26-gate-paired16-seed20262202/`
+- `runs/balatro-human-loop-h26-gate-paired16-seed20262203/`
+- `runs/balatro-human-loop-h26-gate-paired16-seed20262204/`
+
+## H27 rejected Brainstorm arrangement
+
+H27 modeled the public single-Brainstorm rule only when no other copy Joker was
+present. Brainstorm copied the leftmost non-self Joker, including the engine's
+special case where a leftmost Brainstorm skips itself. Before each hand, the
+candidate compared visible-hand estimates and moved the selected target one
+step toward the left edge. Blueprint–Brainstorm chains and multiple copy
+Jokers were deliberately excluded.
+
+On fresh train seeds 20262301–04:
+
+| Candidate | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins |
+|---|---:|---:|---:|---:|---:|---:|
+| H26 control | 10.4844 | 11 | 11 | 24 | 2 | 0 |
+| H27 | 10.5156 | 11 | 11 | 24 | 2 | 0 |
+
+Only one of 64 train outcomes changed, improving from 14 to 16 Blinds. H27 was
+frozen at `sha256:d095312...` before the paired validation gate on seeds
+20262401–04. Only aggregate outcomes were inspected:
+
+| Candidate | Episodes | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins | Policy failures |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| H26 control | 64 | 10.6406 | 11 | 12 | 24 | 5 | 1 | 0 |
+| H27 | 64 | 10.6094 | 11 | 12 | 23 | 5 | 1 | 0 |
+
+Three validation seeds were unchanged and one regressed by 0.125 mean reward.
+Because both mean Blind and the `≥12` count declined, H27 failed the gate and
+was fully reverted. No validation trajectory was inspected to construct a
+follow-up patch. H26 remains selected, and the sealed final test remains
+untouched.
+
+Artifacts:
+
+- `runs/balatro-human-loop-h27-train16-seed20262301/`
+- `runs/balatro-human-loop-h27-train16-seed20262302/`
+- `runs/balatro-human-loop-h27-train16-seed20262303/`
+- `runs/balatro-human-loop-h27-train16-seed20262304/`
+- `runs/balatro-human-loop-h27-gate-paired16-seed20262401/`
+- `runs/balatro-human-loop-h27-gate-paired16-seed20262402/`
+- `runs/balatro-human-loop-h27-gate-paired16-seed20262403/`
+- `runs/balatro-human-loop-h27-gate-paired16-seed20262404/`
+
+## H26 random validation audit
+
+After H27 was rejected, four random evaluation-level master seeds were drawn
+before evaluation: 36079239, 67411017, 43177812, and 61585883. None matched an
+existing run directory. For each master seed, the Benchmark derived 16 distinct
+environment seeds from the split, master seed, and Episode index using its
+SHA-256 domain-separated schedule. All 64 environment seeds were distinct. The
+selected H26 digest remained
+`sha256:c61ac881f7e642f639335c6391698975fdaf8102c68b97dc6495878aee3febe6`.
+Each seed evaluated 16 validation Episodes against the original Agent policy
+on the identical schedule. The sealed test split was not reused, and no replay
+trajectory was inspected.
+
+| Candidate | Episodes | Mean Blind | Median | Early ≤5 | ≥12 | ≥18 | Wins | Policy failures |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Original Agent | 64 | 5.7188 | 5 | 34 | 5 | 0 | 0 | 0 |
+| H26 | 64 | 10.4219 | 11 | 12 | 27 | 2 | 0 | 0 |
+
+H26 improved 45 paired Episode outcomes, left 16 unchanged, and regressed
+three. Its mean paired gain was 4.7031 Blinds. The best run cleared 23 Blinds,
+one short of completing Ante 8. Although this batch produced no win, its mean,
+median, and early-death rate are consistent with the preceding unseen H26
+validation batches. It supports a stable mid-game improvement over the
+original Agent but does not establish a stable completion rate.
+
+Artifacts:
+
+- `runs/balatro-human-loop-h26-random-test-paired16-seed36079239/`
+- `runs/balatro-human-loop-h26-random-test-paired16-seed67411017/`
+- `runs/balatro-human-loop-h26-random-test-paired16-seed43177812/`
+- `runs/balatro-human-loop-h26-random-test-paired16-seed61585883/`

--- a/human-in-loop/balatro/analysis/replay_report.py
+++ b/human-in-loop/balatro/analysis/replay_report.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Summarize public Balatro replays without reading private Host state."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import statistics
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class Decision:
+    before: JsonObject
+    action: JsonObject
+    after: JsonObject
+    reward: float
+    terminated: bool
+
+
+@dataclass
+class Episode:
+    source: Path
+    index: int
+    score: float
+    status: str
+    failure: JsonObject | None
+    initial_state: JsonObject
+    decisions: list[Decision] = field(default_factory=list)
+
+    @property
+    def terminal_state(self) -> JsonObject:
+        if self.decisions:
+            return self.decisions[-1].after
+        return self.initial_state
+
+
+@dataclass(frozen=True)
+class ShopExit:
+    source: Path
+    episode: int
+    ante: int
+    money: int
+    joker_count: int
+    joker_slots: int
+    affordable: tuple[str, ...]
+
+
+def _object(value: object) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: object) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _integer(value: object) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _number(value: object) -> float:
+    return float(value) if isinstance(value, (int, float)) else 0.0
+
+
+def discover_paths(arguments: Sequence[str]) -> list[Path]:
+    if arguments:
+        discovered: list[Path] = []
+        for argument in arguments:
+            path = Path(argument).expanduser()
+            if path.is_dir():
+                discovered.extend(sorted(path.glob("**/replay.jsonl")))
+            elif path.is_file():
+                discovered.append(path)
+            else:
+                raise FileNotFoundError(path)
+        return list(dict.fromkeys(item.resolve() for item in discovered))
+
+    repository = Path(__file__).resolve().parents[3]
+    run = repository / (
+        "runs/balatro-skill-ab-gpt-5.6-sol-retry-20260725-164423/"
+        "submissions/submission-000019/artifacts/replay.jsonl"
+    )
+    return [run]
+
+
+def load_replays(paths: Iterable[Path]) -> list[Episode]:
+    episodes: list[Episode] = []
+    for path in paths:
+        by_index: dict[int, Episode] = {}
+        current_states: dict[int, JsonObject] = {}
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, start=1):
+                try:
+                    item = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ValueError(f"{path}:{line_number}: {error}") from error
+                if not isinstance(item, dict):
+                    raise ValueError(f"{path}:{line_number}: expected JSON object")
+                if item.get("type") in {
+                    "episodes_omitted",
+                    "transitions_omitted",
+                }:
+                    continue
+                episode_index = _integer(item.get("episode_index"))
+                item_type = item.get("type")
+                if item_type == "episode":
+                    initial = _object(item.get("initial_state"))
+                    episode = Episode(
+                        source=path,
+                        index=episode_index,
+                        score=_number(item.get("score")),
+                        status=str(item.get("status", "")),
+                        failure=(
+                            _object(item.get("failure"))
+                            if item.get("failure") is not None
+                            else None
+                        ),
+                        initial_state=initial,
+                    )
+                    by_index[episode_index] = episode
+                    current_states[episode_index] = initial
+                    episodes.append(episode)
+                    continue
+                if item_type != "transition":
+                    raise ValueError(
+                        f"{path}:{line_number}: unknown replay item {item_type!r}"
+                    )
+                current_episode = by_index.get(episode_index)
+                before = current_states.get(episode_index)
+                if current_episode is None or before is None:
+                    raise ValueError(
+                        f"{path}:{line_number}: transition before episode header"
+                    )
+                after = _object(item.get("state"))
+                current_episode.decisions.append(
+                    Decision(
+                        before=before,
+                        action=_object(item.get("action")),
+                        after=after,
+                        reward=_number(item.get("reward")),
+                        terminated=bool(item.get("terminated", False)),
+                    )
+                )
+                current_states[episode_index] = after
+    return episodes
+
+
+def _progress(state: JsonObject) -> JsonObject:
+    return _object(state.get("progress"))
+
+
+def _resources(state: JsonObject) -> JsonObject:
+    return _object(state.get("resources"))
+
+
+def _blind(state: JsonObject) -> JsonObject:
+    return _object(state.get("blind"))
+
+
+def _card_label(card: object) -> str:
+    item = _object(card)
+    name = str(item.get("name") or item.get("key") or "?")
+    cost = _integer(item.get("cost"))
+    return f"{name} (${cost})"
+
+
+def _markdown_cell(value: object) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _affordable_shop_items(state: JsonObject) -> tuple[str, ...]:
+    money = _integer(_resources(state).get("money"))
+    shop = _object(state.get("shop"))
+    choices: list[str] = []
+    for area in ("cards", "vouchers", "boosters"):
+        for card in _list(shop.get(area)):
+            if _integer(_object(card).get("cost")) <= money:
+                choices.append(f"{area}:{_card_label(card)}")
+    return tuple(choices)
+
+
+def shop_exits(episodes: Iterable[Episode]) -> list[ShopExit]:
+    exits: list[ShopExit] = []
+    for episode in episodes:
+        for decision in episode.decisions:
+            if (
+                decision.action.get("kind") != "next_round"
+                or decision.before.get("phase") != "shop"
+            ):
+                continue
+            resources = _resources(decision.before)
+            progress = _progress(decision.before)
+            exits.append(
+                ShopExit(
+                    source=episode.source,
+                    episode=episode.index,
+                    ante=_integer(progress.get("ante")),
+                    money=_integer(resources.get("money")),
+                    joker_count=len(_list(decision.before.get("jokers"))),
+                    joker_slots=_integer(resources.get("joker_slots")),
+                    affordable=_affordable_shop_items(decision.before),
+                )
+            )
+    return exits
+
+
+def joker_roles(card: object) -> tuple[str, ...]:
+    joker = _object(card)
+    ability = _object(joker.get("ability"))
+    summary = str(_object(joker.get("rule")).get("summary", "")).lower()
+    roles: set[str] = set()
+    if _number(ability.get("t_chips")) or "chips" in summary:
+        roles.add("chips")
+    if (
+        _number(ability.get("t_mult"))
+        or _number(ability.get("mult"))
+        or "+mult" in summary
+    ):
+        roles.add("+mult")
+    if _number(ability.get("x_mult")) > 1 or "x mult" in summary:
+        roles.add("xmult")
+    if "retrigger" in summary:
+        roles.add("retrigger")
+    if any(word in summary for word in ("scales", "increases", "gains")):
+        roles.add("scaling")
+    if any(
+        word in summary
+        for word in ("earn $", "dollars", "money", "sell value", "reroll")
+    ):
+        roles.add("economy")
+    return tuple(sorted(roles)) or ("unknown",)
+
+
+def _last_scoring_actions(episode: Episode, count: int = 3) -> str:
+    plays = [
+        decision
+        for decision in episode.decisions
+        if decision.action.get("kind") == "play_hand"
+    ][-count:]
+    labels = []
+    for decision in plays:
+        last_hand = _object(decision.after.get("last_hand"))
+        labels.append(
+            f"{last_hand.get('hand_type') or '?'}"
+            f":{_integer(last_hand.get('total'))}"
+        )
+    return ", ".join(labels) or "-"
+
+
+def _terminal_jokers(episode: Episode) -> str:
+    labels = []
+    for card in _list(episode.terminal_state.get("jokers")):
+        joker = _object(card)
+        roles = "/".join(joker_roles(joker))
+        labels.append(f"{joker.get('name', '?')}[{roles}]")
+    return ", ".join(labels) or "-"
+
+
+def _action_counts(episodes: Iterable[Episode]) -> collections.Counter[str]:
+    return collections.Counter(
+        str(decision.action.get("kind", "?"))
+        for episode in episodes
+        for decision in episode.decisions
+    )
+
+
+def render_markdown(episodes: Sequence[Episode]) -> str:
+    if not episodes:
+        return "# Balatro replay report\n\nNo episodes found.\n"
+
+    wins = sum(bool(_progress(item.terminal_state).get("won")) for item in episodes)
+    rounds = [
+        _integer(_progress(item.terminal_state).get("rounds_cleared"))
+        for item in episodes
+    ]
+    antes = [
+        _integer(_progress(item.terminal_state).get("ante")) for item in episodes
+    ]
+    failures = sum(item.failure is not None for item in episodes)
+    counts = _action_counts(episodes)
+    exits = shop_exits(episodes)
+    risky_exits = [
+        item
+        for item in exits
+        if item.money >= 15 and item.affordable
+    ]
+
+    lines = [
+        "# Balatro replay report",
+        "",
+        f"- Episodes: {len(episodes)}",
+        f"- Wins: {wins} ({wins / len(episodes):.1%})",
+        f"- Mean Blinds cleared: {statistics.fmean(rounds):.2f}",
+        f"- Mean / max Ante reached: {statistics.fmean(antes):.2f} / {max(antes)}",
+        f"- Policy failures: {failures}",
+        f"- Shop exits with $15+ and affordable inventory: "
+        f"{len(risky_exits)} / {len(exits)}",
+        "",
+        "## Action mix",
+        "",
+        "| Action | Count |",
+        "|---|---:|",
+    ]
+    lines.extend(
+        f"| {kind} | {count} |" for kind, count in counts.most_common()
+    )
+    lines.extend(
+        [
+            "",
+            "## Episode terminals",
+            "",
+            "| Source | Ep | Score | Ante | Blinds | Money | "
+            "Blind chips | Last scoring actions |",
+            "|---|---:|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for episode in episodes:
+        terminal = episode.terminal_state
+        progress = _progress(terminal)
+        resources = _resources(terminal)
+        blind = _blind(terminal)
+        lines.append(
+            f"| {episode.source.parents[1].name} | {episode.index} | "
+            f"{episode.score:g} | {_integer(progress.get('ante'))} | "
+            f"{_integer(progress.get('rounds_cleared'))} | "
+            f"${_integer(resources.get('money'))} | "
+            f"{_integer(resources.get('chips'))}/"
+            f"{_integer(blind.get('target_chips'))} | "
+            f"{_last_scoring_actions(episode)} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## High-cash shop exits",
+            "",
+            "These are diagnosis candidates, not automatic proof that every "
+            "available item should have been bought.",
+            "",
+            "| Source | Ep | Ante | Money | Jokers | Affordable inventory |",
+            "|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    for item in sorted(
+        risky_exits,
+        key=lambda exit_: (exit_.money, exit_.ante),
+        reverse=True,
+    )[:30]:
+        inventory = _markdown_cell(", ".join(item.affordable))
+        lines.append(
+            f"| {item.source.parents[1].name} | {item.episode} | "
+            f"{item.ante} | ${item.money} | "
+            f"{item.joker_count}/{item.joker_slots} | {inventory} |"
+        )
+    if not risky_exits:
+        lines.append("| - | - | - | - | - | - |")
+
+    lines.extend(
+        [
+            "",
+            "## Terminal builds",
+            "",
+            "| Source | Ep | Jokers and heuristic roles |",
+            "|---|---:|---|",
+        ]
+    )
+    for episode in episodes:
+        lines.append(
+            f"| {episode.source.parents[1].name} | {episode.index} | "
+            f"{_markdown_cell(_terminal_jokers(episode))} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Replay files or directories containing replay.jsonl files",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write Markdown to this path instead of stdout",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = parse_args(argv)
+    report = render_markdown(load_replays(discover_paths(arguments.paths)))
+    if arguments.output is None:
+        print(report, end="")
+    else:
+        arguments.output.write_text(report, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/human-in-loop/balatro/analysis/score_calibration.py
+++ b/human-in-loop/balatro/analysis/score_calibration.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Compare visible score estimates with public replay outcomes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from policy_system.hands import classify
+from policy_system.scoring import ScoringContext, estimate_score
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("replays", nargs="+", type=Path)
+    return parser.parse_args()
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _ratio(predicted: float, actual: float) -> float:
+    return predicted / actual if actual else 0.0
+
+
+def main() -> int:
+    groups: dict[str, list[tuple[float, float]]] = defaultdict(list)
+    joker_groups: dict[str, list[tuple[float, float]]] = defaultdict(list)
+    for path in _arguments().replays:
+        states: dict[int, dict[str, Any]] = {}
+        for line in path.read_text(encoding="utf-8").splitlines():
+            item = json.loads(line)
+            if item.get("type") in {
+                "episodes_omitted",
+                "transitions_omitted",
+            }:
+                continue
+            episode = int(item["episode_index"])
+            if item["type"] == "episode":
+                states[episode] = _mapping(item.get("initial_state"))
+                continue
+            before = states[episode]
+            after = _mapping(item.get("state"))
+            action = _mapping(item.get("action"))
+            states[episode] = after
+            if action.get("kind") != "play_hand":
+                continue
+            hand = list(before.get("hand") or [])
+            selected_indices = [int(x) for x in action.get("card_indices", [])]
+            selected = [hand[index] for index in selected_indices]
+            hand_name, scoring_local = classify(selected)
+            poker = {
+                str(value.get("name")): value
+                for value in before.get("poker_hands") or []
+            }
+            resources = _mapping(before.get("resources"))
+            deck = _mapping(before.get("deck"))
+            predicted = estimate_score(
+                hand=hand,
+                selected_indices=selected_indices,
+                scoring_local=scoring_local,
+                hand_name=hand_name,
+                poker_hand=poker.get(hand_name, {}),
+                jokers=list(before.get("jokers") or []),
+                context=ScoringContext(
+                    money=int(resources.get("money", 0)),
+                    deck_remaining=int(deck.get("draw_pile", 0)),
+                    discards_left=int(resources.get("discards_left", 0)),
+                    hands_left=int(resources.get("hands_left", 0)),
+                ),
+            )
+            actual = float(_mapping(after.get("last_hand")).get("total", 0))
+            groups[hand_name].append((predicted, actual))
+            for joker in before.get("jokers") or []:
+                joker_groups[str(joker.get("name", "?"))].append(
+                    (predicted, actual)
+                )
+
+    def rows(source: dict[str, list[tuple[float, float]]]) -> list[str]:
+        result = []
+        for name, values in source.items():
+            if len(values) < 3:
+                continue
+            ratios = [_ratio(predicted, actual) for predicted, actual in values]
+            errors = [
+                abs(predicted - actual) / actual
+                for predicted, actual in values
+                if actual
+            ]
+            result.append(
+                f"{name}\t{len(values)}\t"
+                f"{statistics.median(ratios):.3f}\t"
+                f"{statistics.mean(errors):.3f}"
+            )
+        return sorted(result, key=lambda row: float(row.rsplit("\t", 1)[1]), reverse=True)
+
+    print("group\tn\tmedian_predicted/actual\tMAPE")
+    print("\n".join(rows(groups)))
+    print("\nJokers")
+    print("group\tn\tmedian_predicted/actual\tMAPE")
+    print("\n".join(rows(joker_groups)[:30]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/human-in-loop/balatro/program/policy.py
+++ b/human-in-loop/balatro/program/policy.py
@@ -1,0 +1,10 @@
+"""EvoPolicyGym Policy ABI entrypoint."""
+
+from policy_system.strategy import BalatroPolicy
+
+from evopolicygym.policy import PolicyContext
+
+
+def make_policy(context: PolicyContext) -> BalatroPolicy:
+    del context
+    return BalatroPolicy()

--- a/human-in-loop/balatro/program/policy_system/__init__.py
+++ b/human-in-loop/balatro/program/policy_system/__init__.py
@@ -1,0 +1,1 @@
+"""Decision system for the Balatro policy."""

--- a/human-in-loop/balatro/program/policy_system/actions.py
+++ b/human-in-loop/balatro/program/policy_system/actions.py
@@ -1,0 +1,92 @@
+"""Strict construction and admission of legal Actions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_SIMPLE = {
+    "select_blind",
+    "skip_blind",
+    "cash_out",
+    "reroll_shop",
+    "next_round",
+    "skip_pack",
+    "sort_hand_by_rank",
+    "sort_hand_by_suit",
+}
+_ENTITY = {
+    "buy_card",
+    "sell_joker",
+    "sell_consumable",
+    "redeem_voucher",
+    "open_booster",
+    "swap_joker_left",
+    "swap_joker_right",
+    "swap_hand_left",
+    "swap_hand_right",
+}
+
+
+class ActionGateway:
+    def __init__(self, legal: dict[str, dict[str, Any]]) -> None:
+        self.legal = legal
+
+    def simple(self, kind: str) -> dict[str, Any] | None:
+        if kind in _SIMPLE and kind in self.legal:
+            return {"kind": kind}
+        return None
+
+    def entity(self, kind: str, target: int) -> dict[str, Any] | None:
+        desc = self.legal.get(kind)
+        if kind not in _ENTITY or not desc:
+            return None
+        if target not in [int(x) for x in desc.get("target_indices", [])]:
+            return None
+        return {"kind": kind, "target_index": target}
+
+    def cards(self, kind: str, indices: list[int]) -> dict[str, Any] | None:
+        desc = self.legal.get(kind)
+        if kind not in {"play_hand", "discard"} or not desc:
+            return None
+        allowed = {int(x) for x in desc.get("card_indices", [])}
+        if len(indices) != len(set(indices)) or not set(indices) <= allowed:
+            return None
+        if not int(desc.get("min_cards", 1)) <= len(indices) <= int(
+            desc.get("max_cards", 5)
+        ):
+            return None
+        return {"kind": kind, "card_indices": indices}
+
+    def target_cards(
+        self,
+        kind: str,
+        target: int,
+        indices: list[int],
+    ) -> dict[str, Any] | None:
+        desc = self.legal.get(kind)
+        if kind not in {"use_consumable", "pick_pack_card"} or not desc:
+            return None
+        targets = desc.get("targets") or []
+        spec = next(
+            (x for x in targets if int(x.get("target_index", -1)) == target),
+            None,
+        )
+        if spec is None:
+            if (
+                target not in [int(x) for x in desc.get("target_indices", [])]
+                or indices
+            ):
+                return None
+        else:
+            allowed = {int(x) for x in spec.get("card_indices", [])}
+            if len(indices) != len(set(indices)) or not set(indices) <= allowed:
+                return None
+            if not int(spec.get("min_cards", 0)) <= len(indices) <= int(
+                spec.get("max_cards", 0)
+            ):
+                return None
+        return {
+            "kind": kind,
+            "target_index": target,
+            "card_indices": indices,
+        }

--- a/human-in-loop/balatro/program/policy_system/boss.py
+++ b/human-in-loop/balatro/program/policy_system/boss.py
@@ -1,0 +1,79 @@
+"""Pure constraints derived from the visible Boss Blind rule text."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _rule(blind: dict[str, Any]) -> str:
+    return str(blind.get("rule", "")).lower()
+
+
+def requires_five_cards(blind: dict[str, Any]) -> bool:
+    rule = _rule(blind)
+    return "must play 5 cards" in rule or (
+        "five cards" in rule and "must be played" in rule
+    )
+
+
+def only_one_hand(blind: dict[str, Any]) -> bool:
+    rule = _rule(blind)
+    return (
+        "only one hand is available" in rule
+        or "only 1 hand" in rule
+    )
+
+
+def restricts_hand_type(blind: dict[str, Any]) -> str:
+    """Return ``unique`` or ``single`` for visible hand-type Boss rules."""
+
+    rule = _rule(blind)
+    if (
+        "no repeat hand types" in rule
+        or "no poker hand type may be played more than once" in rule
+    ):
+        return "unique"
+    if (
+        "only one hand type" in rule
+        or "after the first hand, only that poker hand type" in rule
+    ):
+        return "single"
+    return ""
+
+
+def first_hand_hidden(blind: dict[str, Any], hand: list[dict[str, Any]]) -> bool:
+    rule = _rule(blind)
+    return (
+        "first hand" in rule
+        and "face-down" in rule
+        and any(card.get("rank") is None for card in hand)
+    )
+
+
+def filter_candidates(
+    ranked: list[tuple[float, str, list[int]]],
+    *,
+    blind: dict[str, Any],
+    played_hand_types: set[str],
+) -> list[tuple[float, str, list[int]]]:
+    result = ranked
+    if requires_five_cards(blind):
+        result = [candidate for candidate in result if len(candidate[2]) == 5]
+
+    restriction = restricts_hand_type(blind)
+    if played_hand_types and restriction in {"unique", "single"}:
+        if restriction == "unique":
+            result = [
+                candidate
+                for candidate in result
+                if candidate[1] not in played_hand_types
+            ]
+        else:
+            result = [
+                candidate
+                for candidate in result
+                if candidate[1] in played_hand_types
+            ]
+
+    # A public rule must not make the policy emit an empty/illegal intent.
+    return result or ranked

--- a/human-in-loop/balatro/program/policy_system/build.py
+++ b/human-in-loop/balatro/program/policy_system/build.py
@@ -1,0 +1,193 @@
+"""Build-aware Joker valuation and shop upgrade selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .effects import EffectContext, EffectProfile, profile_joker
+
+
+@dataclass(frozen=True)
+class JokerValue:
+    card: dict[str, Any]
+    profile: EffectProfile
+    value: float
+
+
+@dataclass(frozen=True)
+class ShopUpgrade:
+    candidate: JokerValue
+    replaced: JokerValue | None
+    gain: float
+
+
+def acquisition_score(card: dict[str, Any]) -> float:
+    """Preserve the baseline's open-slot acquisition behavior."""
+
+    ability = card.get("ability") or {}
+    summary = str((card.get("rule") or {}).get("summary", "")).lower()
+    score = float(ability.get("t_chips") or ability.get("bonus") or 0) / 12
+    score += float(ability.get("t_mult") or ability.get("mult") or 0)
+    score += max(0.0, float(ability.get("x_mult") or 1) - 1) * 20
+    for word, value in (
+        ("chips", 3),
+        ("mult", 4),
+        ("retrigger", 5),
+        ("copy", 9),
+        ("scales", 5),
+        ("each played", 3),
+        ("contains", 2),
+    ):
+        if word in summary:
+            score += value
+    if any(
+        phrase in summary for phrase in ("earn $", "sell value", "reroll")
+    ):
+        score -= 3
+    if card.get("edition") in ("foil", "holo", "polychrome", "negative"):
+        score += 8
+    return score
+
+
+def effect_context(
+    *,
+    primary_hand: str,
+    money: int,
+    jokers: list[dict[str, Any]],
+    deck_remaining: int,
+    ante: int,
+) -> EffectContext:
+    return EffectContext(
+        primary_hand=primary_hand,
+        money=money,
+        joker_count=len(jokers),
+        deck_remaining=deck_remaining,
+        ante=ante,
+    )
+
+
+def _profile_value(profile: EffectProfile, *, owned: bool) -> float:
+    value = (
+        profile.chips / 10
+        + profile.add_mult * 1.8
+        + (profile.x_mult - 1) * 28
+        + profile.retriggers * 12
+        + profile.economy
+        + profile.utility
+    )
+    value *= 0.55 + 0.45 * profile.confidence
+    if owned and "unknown" in profile.roles:
+        value += 6
+    return value
+
+
+def value_joker(
+    card: dict[str, Any],
+    context: EffectContext,
+    *,
+    owned: bool,
+) -> JokerValue:
+    profile = profile_joker(card, context)
+    return JokerValue(
+        card=card,
+        profile=profile,
+        value=_profile_value(profile, owned=owned),
+    )
+
+
+def _role_multiplier(
+    candidate: JokerValue,
+    owned: list[JokerValue],
+) -> float:
+    covered = {
+        role
+        for joker in owned
+        for role in joker.profile.roles
+        if role != "unknown"
+    }
+    missing = candidate.profile.roles - covered - {"unknown"}
+    multiplier = 1.0 + min(0.3, len(missing) * 0.12)
+    if "xmult" in missing and {"+mult", "chips"} <= covered:
+        multiplier += 0.12
+    return multiplier
+
+
+def choose_joker_upgrade(
+    *,
+    shop_cards: list[dict[str, Any]],
+    owned_cards: list[dict[str, Any]],
+    sellable_indices: set[int],
+    slots: int,
+    money: int,
+    context: EffectContext,
+    reserve: int = 0,
+) -> ShopUpgrade | None:
+    """Return a worthwhile affordable addition or replacement."""
+
+    owned = [
+        value_joker(card, context, owned=True) for card in owned_cards
+    ]
+    candidates = []
+    for card in shop_cards:
+        if card.get("set") != "Joker":
+            continue
+        candidate = value_joker(card, context, owned=False)
+        candidate = JokerValue(
+            card=candidate.card,
+            profile=candidate.profile,
+            value=candidate.value * _role_multiplier(candidate, owned),
+        )
+        candidates.append(candidate)
+    candidates.sort(
+        key=lambda item: (item.value, -int(item.card.get("cost", 99))),
+        reverse=True,
+    )
+
+    has_slot = len(owned_cards) < slots
+    if has_slot:
+        affordable = [
+            item
+            for item in candidates
+            if int(item.card.get("cost", 99)) <= money
+            and money - int(item.card.get("cost", 99)) >= reserve
+        ]
+        if not affordable:
+            return None
+        affordable.sort(
+            key=lambda item: (
+                acquisition_score(item.card),
+                -int(item.card.get("cost", 0)),
+            ),
+            reverse=True,
+        )
+        best = affordable[0]
+        if acquisition_score(best.card) <= 1 and owned_cards:
+            return None
+        return ShopUpgrade(candidate=best, replaced=None, gain=best.value)
+
+    sellable = [
+        item
+        for item in owned
+        if int(item.card.get("index", -1)) in sellable_indices
+        and not item.card.get("eternal")
+    ]
+    if not sellable:
+        return None
+    weakest = min(sellable, key=lambda item: item.value)
+    affordable_after_sale = [
+        item
+        for item in candidates
+        if int(item.card.get("cost", 99))
+        <= money + int(weakest.card.get("sell_value", 0))
+        and money + int(weakest.card.get("sell_value", 0))
+        - int(item.card.get("cost", 99)) >= reserve
+    ]
+    if not affordable_after_sale:
+        return None
+    best = affordable_after_sale[0]
+    gain = best.value - weakest.value
+    required_gain = max(4.0, weakest.value * 0.2)
+    if gain < required_gain:
+        return None
+    return ShopUpgrade(candidate=best, replaced=weakest, gain=gain)

--- a/human-in-loop/balatro/program/policy_system/consumables.py
+++ b/human-in-loop/balatro/program/policy_system/consumables.py
@@ -1,0 +1,50 @@
+"""Conservative selection of visible, explicitly-targeted consumables."""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Any
+
+
+def targeted_consumable(
+    consumables: list[dict[str, Any]],
+    descriptor: dict[str, Any],
+    hand: list[dict[str, Any]],
+    primary_hand: str,
+) -> tuple[int, list[int]] | None:
+    """Return a safe target only when the public rule describes its intent.
+
+    This deliberately avoids guessing Tarot/Spectral effects: a card must say
+    ``selected``/``enhance`` (or be a matching Planet) and the legal descriptor
+    must provide the complete target bounds.
+    """
+    by_index = {int(card.get("index", -1)): card for card in consumables}
+    hand_indices = [int(card.get("index", -1)) for card in hand]
+    for raw in descriptor.get("targets") or []:
+        if not isinstance(raw, dict):
+            continue
+        target = int(raw.get("target_index", -1))
+        card = by_index.get(target)
+        if card is None:
+            continue
+        summary = str((card.get("rule") or {}).get("summary", "")).lower()
+        card_set = str(card.get("set", "")).lower()
+        planet = "planet" in card_set and primary_hand.lower() in summary
+        targeted = any(word in summary for word in ("selected", "enhance"))
+        if not (planet or targeted):
+            continue
+        minimum = int(raw.get("min_cards", 0))
+        maximum = int(raw.get("max_cards", 0))
+        allowed = sorted({int(x) for x in raw.get("card_indices", [])})
+        allowed = [index for index in allowed if index in hand_indices]
+        if minimum == maximum == 0:
+            return target, []
+        if minimum < 1 or maximum < minimum or len(allowed) < minimum:
+            continue
+        # Prefer the largest legal target set; the ordering is deterministic
+        # and does not depend on hidden card state.
+        count = min(maximum, len(allowed))
+        if count < minimum:
+            continue
+        return target, list(next(combinations(allowed, count)))
+    return None

--- a/human-in-loop/balatro/program/policy_system/economy.py
+++ b/human-in-loop/balatro/program/policy_system/economy.py
@@ -1,0 +1,232 @@
+"""Budgeted Voucher, Celestial pack, and reroll decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class EconomyContext:
+    money: int
+    ante: int
+    reroll_cost: int
+    free_rerolls: int
+    rerolls_this_shop: int
+    celestials_this_shop: int
+    joker_count: int
+    joker_slots: int
+
+    @property
+    def reserve(self) -> int:
+        return min(25, max(5, self.ante * 5))
+
+
+@dataclass(frozen=True)
+class EconomyIntent:
+    kind: str
+    target_index: int | None = None
+
+
+def _parameters(card: dict[str, Any]) -> dict[str, Any]:
+    rule = card.get("rule")
+    if not isinstance(rule, dict):
+        return {}
+    parameters = rule.get("parameters")
+    return parameters if isinstance(parameters, dict) else {}
+
+
+def voucher_value(card: dict[str, Any], context: EconomyContext) -> float:
+    """Value visible permanent effects without using Voucher identity."""
+
+    summary = str((card.get("rule") or {}).get("summary", "")).lower()
+    value = 0.0
+    if "add 1 hand" in summary:
+        value += 18
+    if "hand size" in summary:
+        value += 14
+    if "cheaper" in summary or "% cheaper" in summary:
+        value += 12
+    if "card slot" in summary and "shop" in summary:
+        value += 10
+    if "interest cap" in summary and context.money >= 25:
+        value += 8
+    if "planet cards appear" in summary:
+        value += 8
+    if "consumable slot" in summary:
+        value += 7
+    if "edition" in summary:
+        value += 6
+    if "add 1 discard" in summary:
+        value += 5
+    if "prerequisite" in summary or "no immediate gameplay effect" in summary:
+        value = 0
+    if "lose 1 hand" in summary:
+        value -= 18
+    return value
+
+
+def _affordable(
+    card: dict[str, Any],
+    context: EconomyContext,
+) -> bool:
+    cost = int(card.get("cost", 99))
+    return cost <= context.money and context.money - cost >= context.reserve
+
+
+def choose_voucher(
+    vouchers: list[dict[str, Any]],
+    *,
+    legal_indices: set[int],
+    context: EconomyContext,
+) -> EconomyIntent | None:
+    candidates = [
+        card
+        for card in vouchers
+        if int(card.get("index", -1)) in legal_indices
+        and _affordable(card, context)
+    ]
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda card: (
+            voucher_value(card, context),
+            -int(card.get("cost", 99)),
+        ),
+        reverse=True,
+    )
+    best = candidates[0]
+    if voucher_value(best, context) < 9:
+        return None
+    return EconomyIntent(
+        kind="redeem_voucher",
+        target_index=int(best["index"]),
+    )
+
+
+def _celestial_value(card: dict[str, Any]) -> float:
+    name = str(card.get("name", "")).lower()
+    parameters = _parameters(card)
+    choices = int(parameters.get("choose", 1))
+    revealed = int(parameters.get("extra", 3))
+    size_bonus = 0.0
+    if "mega" in name:
+        size_bonus = 5
+    elif "jumbo" in name:
+        size_bonus = 2
+    return 8 + size_bonus + max(0, choices - 1) * 3 + max(0, revealed - 3)
+
+
+def choose_celestial(
+    boosters: list[dict[str, Any]],
+    *,
+    legal_indices: set[int],
+    context: EconomyContext,
+) -> EconomyIntent | None:
+    if context.celestials_this_shop >= 1:
+        return None
+    candidates = [
+        card
+        for card in boosters
+        if int(card.get("index", -1)) in legal_indices
+        and "celestial" in str(card.get("name", "")).lower()
+        and _affordable(card, context)
+    ]
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda card: (
+            _celestial_value(card),
+            -int(card.get("cost", 99)),
+        ),
+        reverse=True,
+    )
+    return EconomyIntent(
+        kind="open_booster",
+        target_index=int(candidates[0]["index"]),
+    )
+
+
+def choose_planet_purchase(
+    cards: list[dict[str, Any]],
+    *,
+    legal_indices: set[int],
+    context: EconomyContext,
+    primary_hand: str,
+    poker_hands: dict[str, dict[str, Any]],
+    consumable_count: int,
+    consumable_slots: int,
+    planets_this_shop: int,
+) -> EconomyIntent | None:
+    if (
+        planets_this_shop >= 1
+        or consumable_count >= consumable_slots
+        or context.ante < 3
+    ):
+        return None
+    ranked: list[tuple[int, int, dict[str, Any]]] = []
+    for card in cards:
+        index = int(card.get("index", -1))
+        summary = str((card.get("rule") or {}).get("summary", "")).lower()
+        if (
+            index not in legal_indices
+            or not _affordable(card, context)
+            or context.money - int(card.get("cost", 99))
+            < context.reserve + 5
+            or (
+                str(card.get("set", "")).lower() != "planet"
+                and "level up" not in summary
+            )
+        ):
+            continue
+        hand = next(
+            (
+                name
+                for name in sorted(poker_hands, key=len, reverse=True)
+                if f"level up {name.lower()}" in summary
+            ),
+            "",
+        )
+        if not hand:
+            continue
+        history = poker_hands[hand]
+        played = int(history.get("played", 0))
+        level = int(history.get("level", 1))
+        if played < 5 and level < 2:
+            continue
+        alignment = (
+            played * 2
+            + max(0, level - 1) * 4
+            + (4 if hand == primary_hand else 0)
+        )
+        ranked.append((alignment, -int(card.get("cost", 99)), card))
+    if not ranked:
+        return None
+    _, _, best = max(ranked, key=lambda item: (item[0], item[1]))
+    return EconomyIntent(
+        kind="buy_card",
+        target_index=int(best["index"]),
+    )
+
+
+def choose_reroll(
+    *,
+    reroll_legal: bool,
+    context: EconomyContext,
+) -> EconomyIntent | None:
+    if not reroll_legal or context.rerolls_this_shop >= 1:
+        return None
+    if context.free_rerolls > 0:
+        if context.money < context.reserve:
+            return None
+        if context.joker_count < context.joker_slots and context.ante < 3:
+            return None
+        return EconomyIntent(kind="reroll_shop")
+    if (
+        context.ante >= 3
+        and context.joker_count >= context.joker_slots
+        and context.money - context.reroll_cost
+        >= context.reserve + 10
+    ):
+        return EconomyIntent(kind="reroll_shop")
+    return None

--- a/human-in-loop/balatro/program/policy_system/effects.py
+++ b/human-in-loop/balatro/program/policy_system/effects.py
@@ -1,0 +1,349 @@
+"""Turn visible Joker rules into generic effect profiles."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+_NUMBER = re.compile(r"(x|\+)\s*(\d+(?:\.\d+)?)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class EffectContext:
+    primary_hand: str
+    money: int
+    joker_count: int
+    deck_remaining: int
+    ante: int
+
+
+@dataclass(frozen=True)
+class EffectProfile:
+    chips: float
+    add_mult: float
+    x_mult: float
+    retriggers: float
+    economy: float
+    utility: float
+    roles: frozenset[str]
+    confidence: float
+
+
+def _number(value: object, default: float = 0.0) -> float:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return default
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _summary(card: dict[str, Any]) -> str:
+    return str(_mapping(card.get("rule")).get("summary", "")).lower()
+
+
+def _parameters(card: dict[str, Any]) -> dict[str, Any]:
+    ability = _mapping(card.get("ability"))
+    return _mapping(_mapping(card.get("rule")).get("parameters")) or ability
+
+
+def _copy_joker(card: dict[str, Any]) -> bool:
+    summary = _summary(card)
+    return "copy" in summary and "joker" in summary
+
+
+def _card_phase_effect(card: dict[str, Any]) -> bool:
+    summary = _summary(card)
+    return any(
+        token in summary
+        for token in (
+            "scored card",
+            "when scored",
+            "held card",
+            " held in hand",
+            "face card",
+            "per card",
+        )
+    )
+
+
+def _main_xmult(card: dict[str, Any]) -> bool:
+    if card.get("debuffed") or _copy_joker(card) or _card_phase_effect(card):
+        return False
+    parameters = _parameters(card)
+    nested = _mapping(parameters.get("extra"))
+    return (
+        _number(parameters.get("x_mult"), 1.0) > 1
+        or _number(nested.get("Xmult", nested.get("x_mult")), 1.0) > 1
+        or "x mult" in _summary(card)
+        or "xmult" in _summary(card)
+    )
+
+
+def _main_add_mult(card: dict[str, Any]) -> bool:
+    if card.get("debuffed") or _copy_joker(card) or _card_phase_effect(card):
+        return False
+    parameters = _parameters(card)
+    nested = _mapping(parameters.get("extra"))
+    return any(
+        _number(value) != 0
+        for value in (
+            parameters.get("t_mult"),
+            parameters.get("mult"),
+            nested.get("mult"),
+            nested.get("s_mult"),
+        )
+    ) or "+mult" in _summary(card)
+
+
+def next_main_xmult_swap(jokers: list[dict[str, Any]]) -> int | None:
+    """Return a position whose main XMult Joker should move one step right."""
+
+    if any(_copy_joker(joker) for joker in jokers):
+        return None
+    additive_positions = [
+        position
+        for position, joker in enumerate(jokers)
+        if _main_add_mult(joker)
+    ]
+    for position in range(len(jokers) - 1, -1, -1):
+        if (
+            _main_xmult(jokers[position])
+            and any(other > position for other in additive_positions)
+        ):
+            return position
+    return None
+
+
+def _hand_activation(required: str, primary: str) -> float:
+    if not required:
+        return 1.0
+    if required == primary:
+        return 1.0
+    contained_by = {
+        "Pair": {
+            "Two Pair",
+            "Three of a Kind",
+            "Full House",
+            "Four of a Kind",
+            "Five of a Kind",
+            "Flush House",
+            "Flush Five",
+        },
+        "Two Pair": {"Full House", "Flush House"},
+        "Three of a Kind": {
+            "Full House",
+            "Four of a Kind",
+            "Five of a Kind",
+            "Flush House",
+            "Flush Five",
+        },
+        "Flush": {"Straight Flush", "Flush House", "Flush Five"},
+        "Straight": {"Straight Flush"},
+    }
+    if primary in contained_by.get(required, set()):
+        return 0.9
+    # A shop purchase can justify pivoting toward a visible hand-specific
+    # effect, so a mismatch is discounted without being treated as impossible.
+    return 0.4
+
+
+def _nested_extra(
+    extra: dict[str, Any],
+) -> tuple[float, float, float, float]:
+    chips = 0.0
+    mult = 0.0
+    x_mult = 1.0
+    economy = 0.0
+    for key, value in extra.items():
+        normalized = key.lower().replace("_", "")
+        amount = _number(value)
+        if "chip" in normalized:
+            chips += amount
+        elif normalized in {"mult", "smult", "hmult"}:
+            mult += amount
+        elif "xmult" in normalized and amount > 1:
+            x_mult = max(x_mult, amount)
+        elif any(word in normalized for word in ("dollar", "money", "payout")):
+            economy += amount
+    odds = _number(extra.get("odds"), 1.0)
+    if odds > 1:
+        probability = 1.0 / odds
+        chips *= probability
+        mult *= probability
+        x_mult = 1.0 + (x_mult - 1.0) * probability
+        economy *= probability
+    return chips, mult, x_mult, economy
+
+
+def profile_joker(
+    card: dict[str, Any],
+    context: EffectContext,
+) -> EffectProfile:
+    """Approximate one visible Joker without relying on its identity."""
+
+    ability = _mapping(card.get("ability"))
+    rule = _mapping(card.get("rule"))
+    parameters = _mapping(rule.get("parameters")) or ability
+    summary = str(rule.get("summary", "")).lower()
+    effect = str(parameters.get("effect", "")).lower()
+    required_hand = str(parameters.get("type") or "")
+    activation = _hand_activation(required_hand, context.primary_hand)
+
+    chips = (
+        _number(parameters.get("t_chips"))
+        + _number(parameters.get("bonus"))
+        + _number(parameters.get("perma_bonus"))
+    ) * activation
+    add_mult = (
+        _number(parameters.get("t_mult"))
+        + _number(parameters.get("mult"))
+        + _number(parameters.get("h_mult"))
+    ) * activation
+    x_mult = max(
+        1.0,
+        _number(parameters.get("x_mult"), 1.0),
+        _number(parameters.get("h_x_mult"), 1.0),
+    )
+    retriggers = 0.0
+    economy = (
+        _number(parameters.get("h_dollars"))
+        + _number(parameters.get("p_dollars"))
+    )
+    utility = (
+        _number(parameters.get("d_size")) * 5
+        + _number(parameters.get("h_size")) * 7
+    )
+    roles: set[str] = set()
+    confidence = 0.8
+
+    raw_extra = parameters.get("extra")
+    extra = _number(raw_extra)
+    if isinstance(raw_extra, dict):
+        nested_chips, nested_mult, nested_x_mult, nested_economy = (
+            _nested_extra(raw_extra)
+        )
+        every = _number(raw_extra.get("every"))
+        if every > 0 and nested_x_mult > 1:
+            nested_x_mult = (
+                1.0 + (nested_x_mult - 1.0) / (every + 1.0)
+            )
+        elif (
+            nested_x_mult > 1
+            and any(token in summary for token in (" if ", " when "))
+        ):
+            nested_x_mult = 1.0 + (nested_x_mult - 1.0) * 0.4
+        chips += nested_chips
+        add_mult += nested_mult
+        x_mult = max(x_mult, nested_x_mult)
+        economy += nested_economy
+
+    if required_hand and x_mult > 1:
+        x_mult = 1.0 + (x_mult - 1.0) * activation
+
+    if extra:
+        if "per joker owned" in summary:
+            add_mult += extra * max(1, context.joker_count)
+        elif "per $1 held" in summary and "chip" in summary:
+            chips += extra * context.money
+        elif "per card remaining in deck" in summary and "chip" in summary:
+            chips += extra * context.deck_remaining
+        elif "total tarot uses" in summary and "mult" in summary:
+            add_mult += extra
+        elif "x mult" in summary or "xmult" in summary:
+            x_activation = 1.0
+            if any(token in summary for token in (" if ", " first ", " when ")):
+                x_activation = 0.5
+            if any(token in summary for token in ("≥", "at least")):
+                x_activation = 0.2
+            x_mult = max(x_mult, 1.0 + (extra - 1.0) * x_activation)
+        elif "face card" in summary and "mult" in summary:
+            add_mult += extra * 1.4
+        elif "face card" in summary and "chip" in summary:
+            chips += extra * 1.4
+        elif "even" in summary and "mult" in summary:
+            add_mult += extra * 1.5
+        elif "odd" in summary and "chip" in summary:
+            chips += extra * 1.5
+        elif chips == 0 and "chip" in summary:
+            chips += extra * activation
+        elif add_mult == 0 and "mult" in summary:
+            add_mult += extra * activation
+
+    if "retrigger" in summary:
+        retriggers = 1.0
+    if "level up" in summary:
+        utility += 9
+        roles.add("scaling")
+    if any(word in summary for word in ("scales", "increases", "gains")):
+        utility += 5
+        roles.add("scaling")
+    if "free reroll" in summary or "bonus reroll" in effect:
+        utility += 5
+        roles.add("economy")
+    if any(word in summary for word in ("create tarot", "create planet")):
+        utility += 5
+        roles.add("generation")
+    if "all played cards score" in summary:
+        utility += 8
+        roles.add("enabler")
+    if "copy" in summary and "joker" in summary:
+        utility += 38
+        roles.add("copy")
+    if any(
+        word in summary
+        for word in ("earn $", "dollars", "money", "sell value")
+    ):
+        economy += max(1.0, extra)
+
+    match = _NUMBER.search(summary)
+    if x_mult == 1.0 and match and match.group(1).lower() == "x":
+        x_mult = float(match.group(2))
+        if " if " in summary:
+            x_mult = 1.0 + (x_mult - 1.0) * 0.4
+            confidence = min(confidence, 0.6)
+
+    edition = str(card.get("edition") or "").lower()
+    if edition == "foil":
+        chips += 50
+    elif edition in {"holo", "holographic"}:
+        add_mult += 10
+    elif edition == "polychrome":
+        x_mult *= 1.5
+    elif edition == "negative":
+        utility += 8
+        roles.add("slot")
+
+    if card.get("debuffed"):
+        chips = add_mult = retriggers = economy = utility = 0.0
+        x_mult = 1.0
+        confidence = 1.0
+
+    if chips:
+        roles.add("chips")
+    if add_mult:
+        roles.add("+mult")
+    if x_mult > 1:
+        roles.add("xmult")
+    if retriggers:
+        roles.add("retrigger")
+    if economy:
+        roles.add("economy")
+    if utility and not roles:
+        roles.add("utility")
+    if not roles:
+        roles.add("unknown")
+        confidence = min(confidence, 0.35)
+
+    return EffectProfile(
+        chips=chips,
+        add_mult=add_mult,
+        x_mult=x_mult,
+        retriggers=retriggers,
+        economy=economy,
+        utility=utility,
+        roles=frozenset(roles),
+        confidence=confidence,
+    )

--- a/human-in-loop/balatro/program/policy_system/hands.py
+++ b/human-in-loop/balatro/program/policy_system/hands.py
@@ -1,0 +1,191 @@
+"""Pure poker hand classification, enumeration, and visible score estimates."""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+from .scoring import ScoringContext, estimate_score
+
+RANK = {
+    "2": 2,
+    "3": 3,
+    "4": 4,
+    "5": 5,
+    "6": 6,
+    "7": 7,
+    "8": 8,
+    "9": 9,
+    "10": 10,
+    "Jack": 11,
+    "Queen": 12,
+    "King": 13,
+    "Ace": 14,
+}
+
+
+def _draw_keep_indices(
+    hand: list[dict[str, Any]],
+    best_indices: list[int],
+) -> set[int]:
+    keep = set(best_indices)
+    suits: dict[str, list[int]] = {}
+    ranks: dict[str, list[int]] = {}
+    for index, card in enumerate(hand):
+        suit = card.get("suit")
+        rank = card.get("rank")
+        if suit:
+            suits.setdefault(str(suit), []).append(index)
+        if rank:
+            ranks.setdefault(str(rank), []).append(index)
+    for group in suits.values():
+        if len(group) >= 4:
+            keep.update(group)
+    for group in ranks.values():
+        if len(group) >= 2:
+            keep.update(group)
+    return keep
+
+
+def classify(cards: list[dict[str, Any]]) -> tuple[str, list[int]]:
+    ranks = [RANK.get(str(c.get("rank")), 0) for c in cards]
+    by_rank = {
+        rank: [index for index, value in enumerate(ranks) if value == rank]
+        for rank in set(ranks)
+        if rank
+    }
+    groups = sorted(
+        by_rank.values(),
+        key=lambda indices: (len(indices), ranks[indices[0]]),
+        reverse=True,
+    )
+    suits = [str(card.get("suit") or "") for card in cards]
+    flush = (
+        len(cards) == 5
+        and all(suits)
+        and len(set(suits)) == 1
+    )
+    unique = sorted(set(ranks))
+    straight = len(cards) == 5 and len(unique) == 5 and (
+        unique[-1] - unique[0] == 4 or unique == [2, 3, 4, 5, 14]
+    )
+    counts = sorted((len(indices) for indices in groups), reverse=True)
+    if straight and flush:
+        return "Straight Flush", list(range(5))
+    if counts == [4, 1]:
+        return "Four of a Kind", groups[0]
+    if counts == [3, 2]:
+        return "Full House", groups[0] + groups[1]
+    if flush:
+        return "Flush", list(range(5))
+    if straight:
+        return "Straight", list(range(5))
+    if counts and counts[0] == 3:
+        return "Three of a Kind", groups[0]
+    if counts[:2] == [2, 2]:
+        return "Two Pair", groups[0] + groups[1]
+    if counts and counts[0] == 2:
+        return "Pair", groups[0]
+    high = max(range(len(cards)), key=lambda index: ranks[index])
+    return "High Card", [high]
+
+
+def candidates(
+    hand: list[dict[str, Any]],
+    poker: dict[str, dict[str, Any]],
+    jokers: list[dict[str, Any]],
+    *,
+    money: int = 0,
+    deck_remaining: int = 0,
+    discards_left: int = 0,
+    hands_left: int = 0,
+    round_hand_counts: dict[str, int] | None = None,
+) -> list[tuple[float, str, list[int]]]:
+    result = []
+    context = ScoringContext(
+        money=money,
+        deck_remaining=deck_remaining,
+        discards_left=discards_left,
+        hands_left=hands_left,
+        round_hand_counts=round_hand_counts,
+    )
+    for size in range(1, min(5, len(hand)) + 1):
+        for combo in itertools.combinations(range(len(hand)), size):
+            cards = [hand[index] for index in combo]
+            name, scoring_local = classify(cards)
+            score = estimate_score(
+                hand=hand,
+                selected_indices=list(combo),
+                scoring_local=scoring_local,
+                hand_name=name,
+                poker_hand=poker.get(name, {}),
+                jokers=jokers,
+                context=context,
+            )
+            result.append(
+                (
+                    score - 0.05 * (size - len(scoring_local)),
+                    name,
+                    list(combo),
+                )
+            )
+    return sorted(result, reverse=True)
+
+
+def discard_choice(
+    hand: list[dict[str, Any]],
+    best_indices: list[int],
+) -> list[int]:
+    keep = _draw_keep_indices(hand, best_indices)
+    junk = [index for index in range(len(hand)) if index not in keep]
+    if not junk:
+        junk = sorted(
+            range(len(hand)),
+            key=lambda index: RANK.get(str(hand[index].get("rank")), 0),
+        )[:3]
+    return junk[:5]
+
+
+def cycle_play_choice(
+    hand: list[dict[str, Any]],
+    ranked: list[tuple[float, str, list[int]]],
+    *,
+    score: float,
+    hand_name: str,
+    selected_indices: list[int],
+) -> list[int]:
+    """Add safe non-scoring cards to improve next-hand draw throughput."""
+
+    capacity = 5 - len(selected_indices)
+    if capacity <= 0:
+        return selected_indices
+
+    keep = _draw_keep_indices(hand, selected_indices)
+    unmodified = {"", "base", "c_base", "default base"}
+    extras = [
+        index
+        for index, card in enumerate(hand)
+        if index not in keep
+        and not card.get("edition")
+        and not card.get("seal")
+        and str(card.get("enhancement") or "").lower() in unmodified
+    ]
+    extras.sort(
+        key=lambda index: (
+            RANK.get(str(hand[index].get("rank")), 0),
+            index,
+        )
+    )
+
+    for count in range(min(capacity, len(extras)), 0, -1):
+        desired = set(selected_indices)
+        desired.update(extras[:count])
+        minimum_score = score - 0.05 * count - 1e-9
+        for candidate_score, candidate_name, candidate_indices in ranked:
+            if (
+                candidate_name == hand_name
+                and candidate_score >= minimum_score
+                and set(candidate_indices) == desired
+            ):
+                return candidate_indices
+    return selected_indices

--- a/human-in-loop/balatro/program/policy_system/scoring.py
+++ b/human-in-loop/balatro/program/policy_system/scoring.py
@@ -1,0 +1,546 @@
+"""Visible, order-aware hand score approximation."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+_FACE_RANKS = {"Jack", "Queen", "King"}
+_ODD_RANKS = {"Ace", "3", "5", "7", "9"}
+_EVEN_RANKS = {"2", "4", "6", "8", "10"}
+RANK_VALUE = {
+    **{str(value): value for value in range(2, 11)},
+    "Jack": 11,
+    "Queen": 12,
+    "King": 13,
+    "Ace": 14,
+}
+_X_MULT_TEXT = re.compile(r"\bx\s*\d+(?:\.\d+)?")
+_LOWEST_HELD_MULT = re.compile(
+    r"\+(\d+(?:\.\d+)?)× lowest held card"
+)
+
+
+@dataclass(frozen=True)
+class ScoringContext:
+    money: int = 0
+    deck_remaining: int = 0
+    discards_left: int = 0
+    hands_left: int = 0
+    round_hand_counts: dict[str, int] | None = None
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _number(value: object, default: float = 0.0) -> float:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return default
+
+
+def _rank(card: dict[str, Any]) -> str:
+    return str(card.get("rank") or "")
+
+
+def _suit(card: dict[str, Any]) -> str:
+    return str(card.get("suit") or "")
+
+
+def _mentions_x_mult(summary: str) -> bool:
+    return (
+        "x mult" in summary
+        or "xmult" in summary
+        or _X_MULT_TEXT.search(summary) is not None
+    )
+
+
+def hand_contains(actual: str, required: str) -> bool:
+    if not required or actual == required:
+        return True
+    contained_by = {
+        "Pair": {
+            "Two Pair",
+            "Three of a Kind",
+            "Full House",
+            "Four of a Kind",
+            "Five of a Kind",
+            "Flush House",
+            "Flush Five",
+        },
+        "Two Pair": {"Full House", "Flush House"},
+        "Three of a Kind": {
+            "Full House",
+            "Four of a Kind",
+            "Five of a Kind",
+            "Flush House",
+            "Flush Five",
+        },
+        "Straight": {"Straight Flush"},
+        "Flush": {"Straight Flush", "Flush House", "Flush Five"},
+    }
+    return actual in contained_by.get(required, set())
+
+
+def _card_values(card: dict[str, Any]) -> tuple[float, float, float]:
+    if card.get("debuffed"):
+        return 0.0, 0.0, 1.0
+    ability = _mapping(card.get("ability"))
+    chips = (
+        _number(card.get("chips"))
+        + _number(ability.get("bonus"))
+        + _number(ability.get("perma_bonus"))
+    )
+    mult = _number(ability.get("mult"))
+    x_mult = 1.0
+    edition = str(card.get("edition") or "").lower()
+    if edition == "foil":
+        chips += 50
+    elif edition in {"holo", "holographic"}:
+        mult += 10
+    elif edition == "polychrome":
+        x_mult *= 1.5
+    enhancement = str(card.get("enhancement") or "").lower()
+    if enhancement in {"m_glass", "glass card"}:
+        x_mult *= 2
+    return chips, mult, x_mult
+
+
+def _retriggered_scoring(
+    scoring: list[dict[str, Any]],
+    jokers: list[dict[str, Any]],
+    context: ScoringContext,
+) -> list[dict[str, Any]]:
+    repetitions = [1] * len(scoring)
+    for joker in jokers:
+        if joker.get("debuffed"):
+            continue
+        parameters = _mapping(_mapping(joker.get("rule")).get("parameters"))
+        if not parameters:
+            parameters = _mapping(joker.get("ability"))
+        summary = str(
+            _mapping(joker.get("rule")).get("summary", "")
+        ).lower()
+        if "retrigger" not in summary:
+            continue
+        extra = max(1, int(_number(parameters.get("extra"), 1.0)))
+        if "first scored card" in summary and repetitions:
+            repetitions[0] += extra
+        elif "2/3/4/5" in summary:
+            for index, card in enumerate(scoring):
+                if _rank(card) in {"2", "3", "4", "5"}:
+                    repetitions[index] += extra
+        elif "face card" in summary:
+            for index, card in enumerate(scoring):
+                if _rank(card) in _FACE_RANKS:
+                    repetitions[index] += extra
+        elif "final hand" in summary and context.hands_left == 1:
+            repetitions = [count + extra for count in repetitions]
+
+    expanded: list[dict[str, Any]] = []
+    for card, count in zip(scoring, repetitions, strict=True):
+        expanded.extend([card] * count)
+    return expanded
+
+
+def _effective_jokers(
+    jokers: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    effective: list[dict[str, Any]] = []
+    for position, joker in enumerate(jokers):
+        summary = str(
+            _mapping(joker.get("rule")).get("summary", "")
+        ).lower()
+        if (
+            not joker.get("debuffed")
+            and "copy the joker to the right" in summary
+            and position + 1 < len(jokers)
+        ):
+            copied = dict(jokers[position + 1])
+            copied["edition"] = joker.get("edition")
+            effective.append(copied)
+        else:
+            effective.append(joker)
+    return effective
+
+
+def _condition_applies(
+    summary: str,
+    *,
+    hand_name: str,
+    selected: list[dict[str, Any]],
+    scoring: list[dict[str, Any]],
+    held: list[dict[str, Any]],
+    context: ScoringContext,
+) -> bool:
+    if "same hand type played twice this round" in summary:
+        counts = context.round_hand_counts or {}
+        return counts.get(hand_name, 0) >= 1
+    if "3 or fewer" in summary:
+        return len(selected) <= 3
+    if "≤3" in summary:
+        return len(selected) <= 3
+    if "0 discard" in summary:
+        return context.discards_left == 0
+    if "final hand" in summary or "last hand" in summary:
+        return context.hands_left == 1
+    if "face card" in summary:
+        return any(_rank(card) in _FACE_RANKS for card in scoring)
+    if "all 4 suits" in summary:
+        return len({_suit(card) for card in scoring}) == 4
+    if "all held cards are spades or clubs" in summary:
+        return bool(held) and all(
+            _suit(card) in {"Spades", "Clubs"} for card in held
+        )
+    if "club + card of another suit" in summary:
+        suits = {_suit(card) for card in scoring}
+        return "Clubs" in suits and len(suits) >= 2
+    if any(
+        token in summary
+        for token in (" if ", " when ", " only")
+    ):
+        return False
+    return True
+
+
+def _per_card_effect(
+    *,
+    parameters: dict[str, Any],
+    summary: str,
+    scoring: list[dict[str, Any]],
+    held: list[dict[str, Any]],
+) -> tuple[float, float, float]:
+    raw_extra = parameters.get("extra")
+    extra = _number(raw_extra)
+    nested = _mapping(raw_extra)
+    chips = 0.0
+    mult = 0.0
+    x_mult = 1.0
+
+    suit = str(nested.get("suit") or "")
+    if not suit and "scored" in summary:
+        for plural, singular in (
+            ("Hearts", "heart"),
+            ("Diamonds", "diamond"),
+            ("Spades", "spade"),
+            ("Clubs", "club"),
+        ):
+            if singular in summary:
+                suit = plural
+                break
+    suit_cards = [card for card in scoring if _suit(card) == suit]
+    if suit and suit_cards:
+        suit_mult = _number(nested.get("s_mult"), extra)
+        suit_chips = _number(nested.get("s_chips"), extra)
+        if "mult" in summary:
+            mult += suit_mult * len(suit_cards)
+        if "chip" in summary:
+            chips += suit_chips * len(suit_cards)
+
+    raw_ranks = nested.get("ranks")
+    allowed_ranks: set[str] = set()
+    if isinstance(raw_ranks, list):
+        allowed_ranks = {str(rank) for rank in raw_ranks}
+    elif "for ace" in summary:
+        allowed_ranks = {"Ace"}
+    elif "for 10 or 4" in summary:
+        allowed_ranks = {"10", "4"}
+    if allowed_ranks:
+        count = sum(_rank(card) in allowed_ranks for card in scoring)
+        chips += _number(nested.get("chips")) * count
+        mult += _number(nested.get("mult")) * count
+
+    face_count = sum(_rank(card) in _FACE_RANKS for card in scoring)
+    if face_count:
+        if "face card" in summary and "chip" in summary:
+            chips += extra * face_count
+        if (
+            "face card" in summary
+            and "mult" in summary
+            and not _mentions_x_mult(summary)
+        ):
+            mult += extra * face_count
+        if _mentions_x_mult(summary) and "first" in summary:
+            first_face = next(
+                card for card in scoring if _rank(card) in _FACE_RANKS
+            )
+            triggers = sum(card is first_face for card in scoring)
+            x_mult *= max(1.0, extra) ** triggers
+
+    if "even" in summary and "mult" in summary:
+        mult += extra * sum(_rank(card) in _EVEN_RANKS for card in scoring)
+    if "odd" in summary and "chip" in summary:
+        chips += extra * sum(_rank(card) in _ODD_RANKS for card in scoring)
+    lowest_held = _LOWEST_HELD_MULT.search(summary)
+    if lowest_held and held:
+        held_values = [
+            value
+            for card in held
+            if (value := RANK_VALUE.get(_rank(card), 0)) > 0
+            and not card.get("debuffed")
+        ]
+        if held_values:
+            mult += float(lowest_held.group(1)) * min(held_values)
+
+    for rank in ("Ace", "King", "Queen", "Jack"):
+        if f"per {rank.lower()} held" not in summary:
+            continue
+        count = sum(
+            _rank(card) == rank and not card.get("debuffed")
+            for card in held
+        )
+        if "x mult" in summary:
+            x_mult *= max(1.0, extra) ** count
+        elif "mult" in summary:
+            mult += extra * count
+    return chips, mult, x_mult
+
+
+def _dynamic_effect(
+    *,
+    parameters: dict[str, Any],
+    summary: str,
+    joker_count: int,
+    context: ScoringContext,
+    condition_active: bool,
+    per_card_handled: bool,
+) -> tuple[float, float, float]:
+    raw_extra = parameters.get("extra")
+    extra = _number(raw_extra)
+    nested = _mapping(raw_extra)
+    chips = 0.0
+    mult = 0.0
+    x_mult = 1.0
+
+    if "per joker owned" in summary and "mult" in summary:
+        mult += extra * joker_count
+    elif (
+        "per $" in summary
+        and "mult" in summary
+        and _number(nested.get("dollars")) > 0
+    ):
+        mult += (
+            context.money // int(_number(nested.get("dollars")))
+        ) * _number(nested.get("mult"))
+    elif "per $1 held" in summary and "chip" in summary:
+        chips += extra * context.money
+    elif "per card remaining in deck" in summary and "chip" in summary:
+        chips += extra * context.deck_remaining
+    elif "per discard remaining" in summary and "chip" in summary:
+        chips += extra * context.discards_left
+    elif "total tarot uses" in summary and "mult" in summary:
+        mult += extra
+    elif "random mult between" in summary:
+        mult += (
+            _number(nested.get("min")) + _number(nested.get("max"))
+        ) / 2
+    elif (
+        condition_active
+        and not per_card_handled
+        and ("chips" in nested or "chip_mod" in nested)
+        and "ranks" not in nested
+        and "suit" not in nested
+    ):
+        chips += _number(nested.get("chips"), _number(nested.get("chip_mod")))
+    elif (
+        condition_active
+        and not per_card_handled
+        and "mult" in nested
+        and "ranks" not in nested
+        and "suit" not in nested
+    ):
+        mult += _number(nested.get("mult"))
+
+    nested_x = _number(
+        nested.get("Xmult", nested.get("x_mult")),
+        1.0,
+    )
+    recurring = _number(nested.get("every")) > 0
+    remaining_value = nested.get("remaining")
+    if isinstance(remaining_value, str):
+        remaining_text = remaining_value.strip().split(maxsplit=1)[0]
+        remaining = (
+            float(remaining_text)
+            if remaining_text.lstrip("-").isdigit()
+            else None
+        )
+    elif isinstance(remaining_value, (int, float)) and not isinstance(
+        remaining_value,
+        bool,
+    ):
+        remaining = float(remaining_value)
+    else:
+        remaining = None
+    recurring_ready = not recurring or remaining == 0
+    if nested_x > 1 and recurring_ready and condition_active:
+        odds = max(1.0, _number(nested.get("odds"), 1.0))
+        x_mult *= 1.0 + (nested_x - 1.0) / odds
+    return chips, mult, x_mult
+
+
+def estimate_score(
+    *,
+    hand: list[dict[str, Any]],
+    selected_indices: list[int],
+    scoring_local: list[int],
+    hand_name: str,
+    poker_hand: dict[str, Any],
+    jokers: list[dict[str, Any]],
+    context: ScoringContext,
+) -> float:
+    jokers = _effective_jokers(jokers)
+    selected = [hand[index] for index in selected_indices]
+    if any(
+        "all played cards score"
+        in str((_mapping(joker.get("rule"))).get("summary", "")).lower()
+        for joker in jokers
+        if not joker.get("debuffed")
+    ):
+        scoring_local = list(range(len(selected)))
+    scoring = [selected[index] for index in scoring_local]
+    scoring = _retriggered_scoring(scoring, jokers, context)
+    selected_set = set(selected_indices)
+    held = [
+        card for index, card in enumerate(hand) if index not in selected_set
+    ]
+
+    chips = _number(poker_hand.get("chips"), 5.0)
+    mult = _number(poker_hand.get("mult"), 1.0)
+    for card in scoring:
+        card_chips, card_mult, card_x_mult = _card_values(card)
+        chips += card_chips
+        mult += card_mult
+        mult *= card_x_mult
+
+    for joker_position, joker in enumerate(jokers):
+        if joker.get("debuffed"):
+            continue
+        parameters = _mapping(_mapping(joker.get("rule")).get("parameters"))
+        if not parameters:
+            parameters = _mapping(joker.get("ability"))
+        summary = str(
+            _mapping(joker.get("rule")).get("summary", "")
+        ).lower()
+        required = str(parameters.get("type") or "")
+        active = hand_contains(hand_name, required)
+        sell_value_mult = (
+            "sum of all other jokers' sell values" in summary
+        )
+        condition_active = _condition_applies(
+            summary,
+            hand_name=hand_name,
+            selected=selected,
+            scoring=scoring,
+            held=held,
+            context=context,
+        )
+
+        edition = str(joker.get("edition") or "").lower()
+        if edition == "foil":
+            chips += 50
+        elif edition in {"holo", "holographic"}:
+            mult += 10
+        elif edition == "polychrome":
+            mult *= 1.5
+
+        if active:
+            chips += (
+                _number(parameters.get("t_chips"))
+                + _number(parameters.get("bonus"))
+                + _number(parameters.get("perma_bonus"))
+            )
+            mult += (
+                _number(parameters.get("t_mult"))
+                + (
+                    0.0
+                    if sell_value_mult
+                    else _number(parameters.get("mult"))
+                )
+                + _number(parameters.get("h_mult"))
+            )
+            if sell_value_mult:
+                mult += sum(
+                    _number(other.get("sell_value"))
+                    for position, other in enumerate(jokers)
+                    if position != joker_position
+                )
+
+        per_chips, per_mult, per_x = _per_card_effect(
+            parameters=parameters,
+            summary=summary,
+            scoring=scoring,
+            held=held,
+        )
+        chips += per_chips
+        mult += per_mult
+        mult *= per_x
+
+        dynamic_chips, dynamic_mult, dynamic_x = _dynamic_effect(
+            parameters=parameters,
+            summary=summary,
+            joker_count=len(jokers),
+            context=context,
+            condition_active=condition_active,
+            per_card_handled=bool(
+                per_chips or per_mult or per_x > 1
+            ),
+        )
+        chips += dynamic_chips
+        mult += dynamic_mult
+        mult *= dynamic_x
+
+        raw_extra = parameters.get("extra")
+        extra = _number(raw_extra)
+        history_handled = (
+            "times this hand type played" in summary
+            and isinstance(poker_hand.get("played"), int)
+        )
+        if history_handled:
+            mult += max(1.0, extra) * (
+                int(poker_hand.get("played", 0)) + 1
+            )
+        structurally_per_card = any(
+            token in summary
+            for token in (
+                " per ",
+                "face card",
+                "even",
+                "odd",
+                " scored",
+            )
+        )
+        if (
+            extra
+            and condition_active
+            and not structurally_per_card
+            and not history_handled
+        ):
+            if (
+                "mult" in summary
+                and not _mentions_x_mult(summary)
+                and not per_mult
+                and not dynamic_mult
+                and not _number(parameters.get("t_mult"))
+            ):
+                mult += extra
+            elif (
+                "chip" in summary
+                and not per_chips
+                and not dynamic_chips
+                and not _number(parameters.get("t_chips"))
+            ):
+                chips += extra
+            elif _mentions_x_mult(summary) and not per_x > 1:
+                mult *= max(1.0, extra)
+
+        if active:
+            x_mult = max(
+                1.0,
+                _number(parameters.get("x_mult"), 1.0),
+                _number(parameters.get("h_x_mult"), 1.0),
+            )
+            mult *= x_mult
+
+    return chips * mult

--- a/human-in-loop/balatro/program/policy_system/state.py
+++ b/human-in-loop/balatro/program/policy_system/state.py
@@ -1,0 +1,61 @@
+"""Normalized observation access and episode-local planning state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class EpisodePlan:
+    primary_hand: str = "Pair"
+    secondary_hand: str = "High Card"
+    confidence: float = 0.5
+    used_discard_this_round: bool = False
+    pending_purchase_key: str | None = None
+    shop_round: int = -1
+    rerolls_this_shop: int = 0
+    celestials_this_shop: int = 0
+    planets_this_shop: int = 0
+    hand_round_id: int = -1
+    played_hand_types: set[str] | None = None
+    played_hand_counts: dict[str, int] | None = None
+    consecutive_discards: int = 0
+
+    def prepare_round(self, round_id: int) -> None:
+        if self.hand_round_id != round_id:
+            self.hand_round_id = round_id
+            self.played_hand_types = set()
+            self.played_hand_counts = {}
+            self.consecutive_discards = 0
+
+
+class StateView:
+    def __init__(self, raw: dict[str, Any]) -> None:
+        self.raw = raw
+        self.phase = str(raw.get("phase", ""))
+        self.hand = list(raw.get("hand") or [])
+        self.jokers = list(raw.get("jokers") or [])
+        self.consumables = list(raw.get("consumables") or [])
+        self.resources = dict(raw.get("resources") or {})
+        self.progress = dict(raw.get("progress") or {})
+        self.blind = dict(raw.get("blind") or {})
+        self.shop = dict(raw.get("shop") or {})
+        self.pack = dict(raw.get("pack") or {})
+        self.deck = dict(raw.get("deck") or {})
+        self.poker_hands = {
+            str(item.get("name")): item for item in (raw.get("poker_hands") or [])
+        }
+        self.legal = {
+            str(item.get("kind")): item for item in (raw.get("legal_actions") or [])
+        }
+
+    def money(self) -> int:
+        return int(self.resources.get("money", 0))
+
+    def remaining(self) -> int:
+        return max(
+            0,
+            int(self.blind.get("target_chips", 0))
+            - int(self.resources.get("chips", 0)),
+        )

--- a/human-in-loop/balatro/program/policy_system/strategy.py
+++ b/human-in-loop/balatro/program/policy_system/strategy.py
@@ -1,0 +1,453 @@
+"""Phase planning and shared action selection."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from .actions import ActionGateway
+from .boss import filter_candidates, first_hand_hidden, only_one_hand
+from .build import (
+    acquisition_score,
+    choose_joker_upgrade,
+    effect_context,
+    value_joker,
+)
+from .consumables import targeted_consumable
+from .economy import (
+    EconomyContext,
+    choose_celestial,
+    choose_planet_purchase,
+    choose_reroll,
+    choose_voucher,
+)
+from .effects import next_main_xmult_swap
+from .hands import candidates, cycle_play_choice, discard_choice
+from .state import EpisodePlan, StateView
+
+
+class BalatroPolicy:
+    def __init__(self) -> None:
+        self.plan = EpisodePlan()
+
+    def act(self, observation: Any) -> Any:
+        if type(observation) is not dict:
+            raise ValueError("observation must be an object")
+        state = StateView(cast(dict[str, Any], observation))
+        gate = ActionGateway(state.legal)
+        if state.phase == "blind_select":
+            self.plan.used_discard_this_round = False
+            self.plan.prepare_round(int(state.progress.get("rounds_cleared", 0)))
+            return gate.simple("select_blind")
+        if state.phase == "round_eval":
+            return gate.simple("cash_out")
+        if state.phase == "selecting_hand":
+            return self._hand(state, gate)
+        if state.phase == "shop":
+            return self._shop(state, gate)
+        if state.phase == "pack_opening":
+            return self._pack(state, gate)
+        raise RuntimeError(f"unexpected phase {state.phase!r}")
+
+    def _hand(
+        self,
+        state: StateView,
+        gate: ActionGateway,
+    ) -> dict[str, Any]:
+        self.plan.prepare_round(int(state.progress.get("rounds_cleared", 0)))
+        consumable = targeted_consumable(
+            state.consumables,
+            state.legal.get("use_consumable", {}),
+            state.hand,
+            self.plan.primary_hand,
+        )
+        if consumable is not None:
+            target, indices = consumable
+            action = gate.target_cards("use_consumable", target, indices)
+            if action is not None:
+                return action
+        arrangement = self._arrange_copy_joker(state, gate)
+        if arrangement is not None:
+            return arrangement
+        arrangement = self._arrange_main_xmult(state, gate)
+        if arrangement is not None:
+            return arrangement
+        ranked = candidates(
+            state.hand,
+            state.poker_hands,
+            state.jokers,
+            money=state.money(),
+            deck_remaining=int(state.deck.get("draw_pile", 0)),
+            discards_left=int(state.resources.get("discards_left", 0)),
+            hands_left=int(state.resources.get("hands_left", 0)),
+            round_hand_counts=self.plan.played_hand_counts,
+        )
+        ranked = filter_candidates(
+            ranked,
+            blind=state.blind,
+            played_hand_types=self.plan.played_hand_types or set(),
+        )
+        score, name, indices = ranked[0]
+        self.plan.primary_hand = name
+        hands = int(state.resources.get("hands_left", 1))
+        discards = int(state.resources.get("discards_left", 0))
+        draw_threshold = 0.82 + 0.10 * min(discards, 4)
+        if (
+            int(state.progress.get("ante", 1)) <= 2
+            and not state.jokers
+            and self.plan.consecutive_discards >= 1
+        ):
+            draw_threshold = min(draw_threshold, 0.90)
+        if (
+            discards
+            and (hands > 1 or only_one_hand(state.blind))
+            and not first_hand_hidden(state.blind, state.hand)
+            and score < state.remaining()
+            and (
+                name == "High Card"
+                or score
+                < state.remaining() / hands * draw_threshold
+            )
+        ):
+            choice = discard_choice(state.hand, indices)
+            action = gate.cards("discard", choice)
+            if action:
+                self.plan.used_discard_this_round = True
+                self.plan.consecutive_discards += 1
+                return action
+        play_indices = indices
+        if (
+            hands > 1
+            and discards == 0
+            and int(state.progress.get("ante", 1)) >= 2
+            and score < state.remaining()
+        ):
+            play_indices = cycle_play_choice(
+                state.hand,
+                ranked,
+                score=score,
+                hand_name=name,
+                selected_indices=indices,
+            )
+        action = gate.cards("play_hand", play_indices)
+        if action:
+            self.plan.consecutive_discards = 0
+            if self.plan.played_hand_types is None:
+                self.plan.played_hand_types = set()
+            self.plan.played_hand_types.add(name)
+            if self.plan.played_hand_counts is None:
+                self.plan.played_hand_counts = {}
+            self.plan.played_hand_counts[name] = (
+                self.plan.played_hand_counts.get(name, 0) + 1
+            )
+            return action
+        raise RuntimeError("no admitted hand action")
+
+    def _arrange_copy_joker(
+        self,
+        state: StateView,
+        gate: ActionGateway,
+    ) -> dict[str, Any] | None:
+        copy_positions = [
+            position
+            for position, joker in enumerate(state.jokers)
+            if "copy the joker to the right"
+            in str(
+                (joker.get("rule") or {}).get("summary", "")
+            ).lower()
+        ]
+        if not copy_positions:
+            return None
+
+        copy_position = copy_positions[0]
+        context = effect_context(
+            primary_hand=self.plan.primary_hand,
+            money=state.money(),
+            jokers=state.jokers,
+            deck_remaining=int(state.deck.get("draw_pile", 0)),
+            ante=int(state.progress.get("ante", 1)),
+        )
+        targets = [
+            (
+                value_joker(joker, context, owned=True).value,
+                position,
+                joker,
+            )
+            for position, joker in enumerate(state.jokers)
+            if position not in copy_positions
+        ]
+        if not targets:
+            return None
+        if state.hand:
+            copy_joker = state.jokers[copy_position]
+            non_copy = [
+                joker
+                for position, joker in enumerate(state.jokers)
+                if position != copy_position
+            ]
+            scoring_context: dict[str, Any] = {
+                "money": state.money(),
+                "deck_remaining": int(
+                    state.deck.get("draw_pile", 0)
+                ),
+                "discards_left": int(
+                    state.resources.get("discards_left", 0)
+                ),
+                "hands_left": int(
+                    state.resources.get("hands_left", 0)
+                ),
+                "round_hand_counts": self.plan.played_hand_counts,
+            }
+
+            def copied_score(target: dict[str, Any]) -> float:
+                position = next(
+                    index
+                    for index, joker in enumerate(non_copy)
+                    if joker is target
+                )
+                arranged = list(non_copy)
+                arranged.insert(position, copy_joker)
+                ranked = candidates(
+                    state.hand,
+                    state.poker_hands,
+                    arranged,
+                    **scoring_context,
+                )
+                return ranked[0][0]
+
+            _, target_position, _ = max(
+                targets,
+                key=lambda item: copied_score(item[2]),
+            )
+        else:
+            _, target_position, _ = max(targets)
+        if copy_position + 1 == target_position:
+            return None
+
+        copy_index = int(
+            state.jokers[copy_position].get("index", copy_position)
+        )
+        kind = (
+            "swap_joker_left"
+            if copy_position > target_position
+            else "swap_joker_right"
+        )
+        return gate.entity(kind, copy_index)
+
+    def _arrange_main_xmult(
+        self,
+        state: StateView,
+        gate: ActionGateway,
+    ) -> dict[str, Any] | None:
+        position = next_main_xmult_swap(state.jokers)
+        if position is None:
+            return None
+        index = int(state.jokers[position].get("index", position))
+        return gate.entity("swap_joker_right", index)
+
+    def _shop(
+        self,
+        state: StateView,
+        gate: ActionGateway,
+    ) -> dict[str, Any]:
+        money = state.money()
+        slots = int(state.resources.get("joker_slots", 5))
+        shop_cards = list(state.shop.get("cards", []))
+        round_id = int(state.progress.get("rounds_cleared", 0))
+        if self.plan.shop_round != round_id:
+            self.plan.shop_round = round_id
+            self.plan.rerolls_this_shop = 0
+            self.plan.celestials_this_shop = 0
+            self.plan.planets_this_shop = 0
+
+        if self.plan.pending_purchase_key:
+            pending = next(
+                (
+                    card
+                    for card in shop_cards
+                    if card.get("key") == self.plan.pending_purchase_key
+                ),
+                None,
+            )
+            if pending is not None:
+                action = gate.entity("buy_card", int(pending.get("index", -1)))
+                if action:
+                    self.plan.pending_purchase_key = None
+                    return action
+            self.plan.pending_purchase_key = None
+
+        sell_descriptor = state.legal.get("sell_joker", {})
+        sellable = {
+            int(index) for index in sell_descriptor.get("target_indices", [])
+        }
+        context = effect_context(
+            primary_hand=self.plan.primary_hand,
+            money=money,
+            jokers=state.jokers,
+            deck_remaining=int(state.deck.get("draw_pile", 0)),
+            ante=int(state.progress.get("ante", 1)),
+        )
+        upgrade = choose_joker_upgrade(
+            shop_cards=shop_cards,
+            owned_cards=state.jokers,
+            sellable_indices=sellable,
+            slots=slots,
+            money=money,
+            context=context,
+        )
+        if upgrade is not None and upgrade.replaced is not None:
+            replacement_index = int(upgrade.replaced.card.get("index", -1))
+            action = gate.entity("sell_joker", replacement_index)
+            if action:
+                self.plan.pending_purchase_key = str(
+                    upgrade.candidate.card.get("key", "")
+                )
+                return action
+        if upgrade is not None:
+            candidate_index = int(upgrade.candidate.card.get("index", -1))
+            action = gate.entity("buy_card", candidate_index)
+            if action:
+                return action
+        for booster in state.shop.get("boosters", []):
+            name = str(booster.get("name", "")).lower()
+            if (
+                int(booster.get("cost", 99)) <= money
+                and "buffoon" in name
+            ):
+                action = gate.entity(
+                    "open_booster",
+                    int(booster["index"]),
+                )
+                if action:
+                    return action
+
+        economy = EconomyContext(
+            money=money,
+            ante=int(state.progress.get("ante", 1)),
+            reroll_cost=int(state.resources.get("reroll_cost", 5)),
+            free_rerolls=int(state.resources.get("free_rerolls", 0)),
+            rerolls_this_shop=self.plan.rerolls_this_shop,
+            celestials_this_shop=self.plan.celestials_this_shop,
+            joker_count=len(state.jokers),
+            joker_slots=slots,
+        )
+        buy_descriptor = state.legal.get("buy_card", {})
+        planet = choose_planet_purchase(
+            shop_cards,
+            legal_indices={
+                int(index)
+                for index in buy_descriptor.get("target_indices", [])
+            },
+            context=economy,
+            primary_hand=self.plan.primary_hand,
+            poker_hands=state.poker_hands,
+            consumable_count=len(state.consumables),
+            consumable_slots=int(
+                state.resources.get("consumable_slots", 0)
+            ),
+            planets_this_shop=self.plan.planets_this_shop,
+        )
+        if planet is not None and planet.target_index is not None:
+            action = gate.entity(planet.kind, planet.target_index)
+            if action:
+                self.plan.planets_this_shop += 1
+                return action
+
+        voucher_descriptor = state.legal.get("redeem_voucher", {})
+        voucher = choose_voucher(
+            list(state.shop.get("vouchers", [])),
+            legal_indices={
+                int(index)
+                for index in voucher_descriptor.get("target_indices", [])
+            },
+            context=economy,
+        )
+        if voucher is not None and voucher.target_index is not None:
+            action = gate.entity(voucher.kind, voucher.target_index)
+            if action:
+                return action
+
+        booster_descriptor = state.legal.get("open_booster", {})
+        celestial = choose_celestial(
+            list(state.shop.get("boosters", [])),
+            legal_indices={
+                int(index)
+                for index in booster_descriptor.get("target_indices", [])
+            },
+            context=economy,
+        )
+        if celestial is not None and celestial.target_index is not None:
+            action = gate.entity(celestial.kind, celestial.target_index)
+            if action:
+                self.plan.celestials_this_shop += 1
+                return action
+
+        reroll = choose_reroll(
+            reroll_legal="reroll_shop" in state.legal,
+            context=economy,
+        )
+        if reroll is not None:
+            action = gate.simple(reroll.kind)
+            if action:
+                self.plan.rerolls_this_shop += 1
+                return action
+        result = gate.simple("next_round")
+        if result:
+            return result
+        raise RuntimeError("no admitted shop action")
+
+    def _pack(
+        self,
+        state: StateView,
+        gate: ActionGateway,
+    ) -> dict[str, Any]:
+        cards = list(state.pack.get("cards", []))
+        hand_priorities = {
+            str(hand.get("name", "")): (
+                int(hand.get("played", 0)) * 2
+                + max(0, int(hand.get("level", 1)) - 1) * 4
+            )
+            for hand in state.poker_hands.values()
+        }
+
+        def hand_alignment(card: dict[str, Any]) -> int:
+            summary = str((card.get("rule") or {}).get("summary", "")).lower()
+            return max(
+                (
+                    priority
+                    for hand, priority in hand_priorities.items()
+                    if hand.lower() in summary
+                ),
+                default=0,
+            )
+
+        cards.sort(
+            key=lambda card: (
+                hand_alignment(card),
+                self.plan.primary_hand.lower()
+                in str(
+                    (card.get("rule") or {}).get("summary", "")
+                ).lower(),
+                acquisition_score(card),
+                card.get("set") == "Joker",
+            ),
+            reverse=True,
+        )
+        desc = state.legal.get("pick_pack_card", {})
+        advertised = {
+            int(target) for target in desc.get("target_indices", [])
+        }
+        for card in cards:
+            target = int(card.get("index", -1))
+            if advertised and target not in advertised:
+                continue
+            action = gate.target_cards(
+                "pick_pack_card",
+                target,
+                [],
+            )
+            if action:
+                return action
+        result = gate.simple("skip_pack")
+        if result:
+            return result
+        raise RuntimeError("no admitted pack action")

--- a/human-in-loop/balatro/program/tests/test_actions.py
+++ b/human-in-loop/balatro/program/tests/test_actions.py
@@ -1,0 +1,63 @@
+"""Unit tests for exact Action admission."""
+
+from __future__ import annotations
+
+import unittest
+
+from policy_system.actions import ActionGateway
+
+
+class ActionGatewayTest(unittest.TestCase):
+    def test_card_action_requires_current_membership_and_cardinality(self) -> None:
+        gate = ActionGateway(
+            {
+                "play_hand": {
+                    "kind": "play_hand",
+                    "card_indices": [0, 1, 2],
+                    "min_cards": 1,
+                    "max_cards": 2,
+                }
+            }
+        )
+
+        self.assertEqual(
+            gate.cards("play_hand", [2, 0]),
+            {"kind": "play_hand", "card_indices": [2, 0]},
+        )
+        self.assertIsNone(gate.cards("play_hand", []))
+        self.assertIsNone(gate.cards("play_hand", [0, 0]))
+        self.assertIsNone(gate.cards("play_hand", [3]))
+        self.assertIsNone(gate.cards("play_hand", [0, 1, 2]))
+
+    def test_nested_target_card_constraints_are_exact(self) -> None:
+        gate = ActionGateway(
+            {
+                "use_consumable": {
+                    "kind": "use_consumable",
+                    "targets": [
+                        {
+                            "target_index": 1,
+                            "card_indices": [0, 2, 4],
+                            "min_cards": 2,
+                            "max_cards": 2,
+                        }
+                    ],
+                }
+            }
+        )
+
+        self.assertEqual(
+            gate.target_cards("use_consumable", 1, [4, 0]),
+            {
+                "kind": "use_consumable",
+                "target_index": 1,
+                "card_indices": [4, 0],
+            },
+        )
+        self.assertIsNone(gate.target_cards("use_consumable", 1, [0]))
+        self.assertIsNone(gate.target_cards("use_consumable", 1, [0, 3]))
+        self.assertIsNone(gate.target_cards("use_consumable", 2, [0, 2]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/human-in-loop/balatro/program/tests/test_boss.py
+++ b/human-in-loop/balatro/program/tests/test_boss.py
@@ -1,0 +1,68 @@
+"""Tests for visible Boss Blind constraints."""
+
+from __future__ import annotations
+
+import unittest
+
+from policy_system.boss import (
+    filter_candidates,
+    only_one_hand,
+    restricts_hand_type,
+)
+from policy_system.state import EpisodePlan
+
+
+class BossConstraintTest(unittest.TestCase):
+    def test_needle_allows_discard_planning_for_its_only_hand(self) -> None:
+        self.assertTrue(
+            only_one_hand({"rule": "Only one hand is available."})
+        )
+
+    def test_round_history_resets_together(self) -> None:
+        plan = EpisodePlan()
+        plan.prepare_round(3)
+        assert plan.played_hand_types is not None
+        assert plan.played_hand_counts is not None
+        plan.played_hand_types.add("Pair")
+        plan.played_hand_counts["Pair"] = 1
+
+        plan.prepare_round(4)
+
+        self.assertEqual(plan.played_hand_types, set())
+        self.assertEqual(plan.played_hand_counts, {})
+
+    def test_eye_rule_forbids_repeating_a_hand_type(self) -> None:
+        blind = {
+            "rule": "No poker hand type may be played more than once this round."
+        }
+        ranked = [(20.0, "Pair", [0, 1]), (15.0, "Flush", [0, 1, 2, 3, 4])]
+
+        self.assertEqual(restricts_hand_type(blind), "unique")
+        self.assertEqual(
+            filter_candidates(
+                ranked,
+                blind=blind,
+                played_hand_types={"Pair"},
+            ),
+            [ranked[1]],
+        )
+
+    def test_mouth_rule_reuses_the_first_hand_type(self) -> None:
+        blind = {
+            "rule": "After the first hand, only that poker hand type may be played this round."
+        }
+        ranked = [(20.0, "Flush", [0, 1, 2, 3, 4]), (15.0, "Pair", [0, 1])]
+
+        self.assertEqual(restricts_hand_type(blind), "single")
+        self.assertEqual(
+            filter_candidates(
+                ranked,
+                blind=blind,
+                played_hand_types={"Pair"},
+            ),
+            [ranked[1]],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/human-in-loop/balatro/program/tests/test_build.py
+++ b/human-in-loop/balatro/program/tests/test_build.py
@@ -1,0 +1,515 @@
+"""Tests for visible effect parsing and build-aware replacement."""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from policy_system.build import choose_joker_upgrade, effect_context
+from policy_system.effects import (
+    EffectContext,
+    next_main_xmult_swap,
+    profile_joker,
+)
+from policy_system.strategy import BalatroPolicy
+
+
+def _joker(
+    *,
+    index: int,
+    key: str,
+    summary: str,
+    cost: int = 5,
+    sell_value: int = 2,
+    **parameters: Any,
+) -> dict[str, Any]:
+    return {
+        "index": index,
+        "key": key,
+        "name": key,
+        "set": "Joker",
+        "cost": cost,
+        "sell_value": sell_value,
+        "edition": None,
+        "debuffed": False,
+        "eternal": False,
+        "ability": parameters,
+        "rule": {
+            "summary": summary,
+            "parameters": parameters,
+            "rarity": {"level": 1, "name": "Common"},
+        },
+    }
+
+
+class EffectProfileTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.context = EffectContext(
+            primary_hand="Pair",
+            money=20,
+            joker_count=5,
+            deck_remaining=30,
+            ante=3,
+        )
+
+    def test_dynamic_visible_parameters_use_current_context(self) -> None:
+        abstract = _joker(
+            index=0,
+            key="abstract",
+            summary="+3 mult per joker owned.",
+            extra=3,
+        )
+        bull = _joker(
+            index=1,
+            key="bull",
+            summary="+2 chips per $1 held.",
+            extra=2,
+        )
+
+        self.assertEqual(profile_joker(abstract, self.context).add_mult, 15)
+        self.assertEqual(profile_joker(bull, self.context).chips, 40)
+
+    def test_hand_specific_effect_is_discounted_when_build_mismatches(self) -> None:
+        droll = _joker(
+            index=0,
+            key="droll",
+            summary="+conditional Mult if hand contains Flush.",
+            t_mult=10,
+            type="Flush",
+        )
+        flush_context = EffectContext(
+            primary_hand="Flush",
+            money=20,
+            joker_count=3,
+            deck_remaining=30,
+            ante=3,
+        )
+
+        self.assertEqual(profile_joker(droll, flush_context).add_mult, 10)
+        self.assertEqual(profile_joker(droll, self.context).add_mult, 4)
+
+    def test_conditional_xmult_is_not_misclassified_as_additive_mult(self) -> None:
+        photograph = _joker(
+            index=0,
+            key="photograph",
+            summary="X Mult on FIRST face card in scoring hand only.",
+            extra=2,
+        )
+
+        profile = profile_joker(photograph, self.context)
+
+        self.assertEqual(profile.add_mult, 0)
+        self.assertEqual(profile.x_mult, 1.5)
+        self.assertIn("xmult", profile.roles)
+
+    def test_recurring_xmult_is_valued_by_visible_trigger_frequency(
+        self,
+    ) -> None:
+        loyalty = _joker(
+            index=0,
+            key="loyalty",
+            summary="X Mult every N+1 hands.",
+            extra={"Xmult": 4, "every": 5},
+        )
+
+        profile = profile_joker(loyalty, self.context)
+
+        self.assertEqual(profile.x_mult, 1.5)
+
+    def test_copy_rule_receives_build_utility(self) -> None:
+        blueprint = _joker(
+            index=0,
+            key="blueprint",
+            summary="Copy the Joker to the right.",
+        )
+
+        profile = profile_joker(blueprint, self.context)
+
+        self.assertGreaterEqual(profile.utility, 38)
+        self.assertIn("copy", profile.roles)
+
+
+class BuildUpgradeTest(unittest.TestCase):
+    def test_empty_build_accepts_affordable_unmodeled_first_joker(self) -> None:
+        first = _joker(
+            index=0,
+            key="first",
+            summary="Visible but not yet modeled scaling effect.",
+        )
+        context = effect_context(
+            primary_hand="Pair",
+            money=5,
+            jokers=[],
+            deck_remaining=30,
+            ante=1,
+        )
+
+        upgrade = choose_joker_upgrade(
+            shop_cards=[first],
+            owned_cards=[],
+            sellable_indices=set(),
+            slots=5,
+            money=5,
+            context=context,
+        )
+
+        self.assertIsNotNone(upgrade)
+        assert upgrade is not None
+        self.assertEqual(upgrade.candidate.card["key"], "first")
+        self.assertIsNone(upgrade.replaced)
+
+    def test_open_build_preserves_baseline_non_scoring_rejection(self) -> None:
+        owned = _joker(
+            index=0,
+            key="owned",
+            summary="+10 Mult.",
+            t_mult=10,
+        )
+        economy = _joker(
+            index=0,
+            key="economy",
+            summary="Earn $4 at end of round.",
+            extra=4,
+        )
+        context = effect_context(
+            primary_hand="Pair",
+            money=10,
+            jokers=[owned],
+            deck_remaining=30,
+            ante=2,
+        )
+
+        upgrade = choose_joker_upgrade(
+            shop_cards=[economy],
+            owned_cards=[owned],
+            sellable_indices={0},
+            slots=5,
+            money=10,
+            context=context,
+        )
+
+        self.assertIsNone(upgrade)
+
+    def test_full_build_replaces_weak_sellable_joker(self) -> None:
+        weak = _joker(
+            index=0,
+            key="weak",
+            summary="No modeled scoring effect.",
+        )
+        strong = _joker(
+            index=0,
+            key="strong",
+            summary="+20 Mult.",
+            t_mult=20,
+        )
+        context = effect_context(
+            primary_hand="Pair",
+            money=20,
+            jokers=[weak],
+            deck_remaining=30,
+            ante=3,
+        )
+
+        upgrade = choose_joker_upgrade(
+            shop_cards=[strong],
+            owned_cards=[weak],
+            sellable_indices={0},
+            slots=1,
+            money=20,
+            context=context,
+        )
+
+        self.assertIsNotNone(upgrade)
+        assert upgrade is not None
+        assert upgrade.replaced is not None
+        self.assertEqual(upgrade.replaced.card["key"], "weak")
+        self.assertEqual(upgrade.candidate.card["key"], "strong")
+
+    def test_full_build_accepts_moderate_positive_upgrade(self) -> None:
+        weak = _joker(
+            index=0,
+            key="weak",
+            summary="+10 Mult.",
+            t_mult=10,
+        )
+        better = _joker(
+            index=1,
+            key="better",
+            summary="+13 Mult.",
+            t_mult=13,
+        )
+        context = effect_context(
+            primary_hand="Pair",
+            money=20,
+            jokers=[weak],
+            deck_remaining=30,
+            ante=3,
+        )
+
+        upgrade = choose_joker_upgrade(
+            shop_cards=[better],
+            owned_cards=[weak],
+            sellable_indices={0},
+            slots=1,
+            money=20,
+            context=context,
+        )
+
+        self.assertIsNotNone(upgrade)
+        assert upgrade is not None
+        self.assertEqual(upgrade.candidate.card["key"], "better")
+
+    def test_policy_sells_then_buys_same_visible_upgrade(self) -> None:
+        weak = _joker(
+            index=0,
+            key="weak",
+            summary="No modeled scoring effect.",
+        )
+        strong = _joker(
+            index=0,
+            key="strong",
+            summary="+20 Mult.",
+            t_mult=20,
+        )
+        policy = BalatroPolicy()
+        full_shop = _shop_state(
+            jokers=[weak],
+            shop_cards=[strong],
+            slots=1,
+            legal=[
+                {
+                    "kind": "sell_joker",
+                    "target_indices": [0],
+                },
+                {"kind": "next_round"},
+            ],
+        )
+
+        self.assertEqual(
+            policy.act(full_shop),
+            {"kind": "sell_joker", "target_index": 0},
+        )
+
+        open_shop = _shop_state(
+            jokers=[],
+            shop_cards=[strong],
+            slots=1,
+            legal=[
+                {
+                    "kind": "buy_card",
+                    "target_indices": [0],
+                },
+                {"kind": "next_round"},
+            ],
+        )
+        self.assertEqual(
+            policy.act(open_shop),
+            {"kind": "buy_card", "target_index": 0},
+        )
+
+    def test_policy_places_right_copy_before_strongest_joker(self) -> None:
+        strong = _joker(
+            index=0,
+            key="strong",
+            summary="+20 Mult.",
+            t_mult=20,
+        )
+        weak = _joker(
+            index=1,
+            key="weak",
+            summary="+10 Chips.",
+            t_chips=10,
+        )
+        blueprint = _joker(
+            index=2,
+            key="blueprint",
+            summary="Copy the Joker to the right.",
+        )
+        state = {
+            "phase": "selecting_hand",
+            "jokers": [strong, weak, blueprint],
+            "resources": {"money": 20},
+            "progress": {"ante": 3},
+            "deck": {"draw_pile": 30},
+            "legal_actions": [
+                {
+                    "kind": "swap_joker_left",
+                    "target_indices": [1, 2],
+                },
+            ],
+        }
+
+        self.assertEqual(
+            BalatroPolicy().act(state),
+            {"kind": "swap_joker_left", "target_index": 2},
+        )
+
+    def test_policy_moves_main_xmult_after_additive_mult(self) -> None:
+        trio = _joker(
+            index=0,
+            key="trio",
+            summary="X3 Mult if hand contains Three of a Kind.",
+            x_mult=3,
+            type="Three of a Kind",
+        )
+        chips = _joker(
+            index=1,
+            key="chips",
+            summary="+50 Chips.",
+            t_chips=50,
+        )
+        zany = _joker(
+            index=2,
+            key="zany",
+            summary="+12 Mult if hand contains Three of a Kind.",
+            t_mult=12,
+            type="Three of a Kind",
+        )
+        state = {
+            "phase": "selecting_hand",
+            "jokers": [trio, chips, zany],
+            "resources": {"money": 20},
+            "progress": {"ante": 3},
+            "deck": {"draw_pile": 30},
+            "legal_actions": [
+                {
+                    "kind": "swap_joker_right",
+                    "target_indices": [0, 1],
+                },
+            ],
+        }
+
+        self.assertEqual(next_main_xmult_swap([trio, chips, zany]), 0)
+        self.assertEqual(
+            BalatroPolicy().act(state),
+            {"kind": "swap_joker_right", "target_index": 0},
+        )
+
+    def test_main_order_leaves_card_phase_and_copy_jokers_alone(
+        self,
+    ) -> None:
+        photograph = _joker(
+            index=0,
+            key="photograph",
+            summary="X2 Mult on FIRST face card when scored.",
+            extra=2,
+        )
+        zany = _joker(
+            index=1,
+            key="zany",
+            summary="+12 Mult if hand contains Three of a Kind.",
+            t_mult=12,
+            type="Three of a Kind",
+        )
+        blueprint = _joker(
+            index=2,
+            key="blueprint",
+            summary="Copy the Joker to the right.",
+        )
+
+        self.assertIsNone(next_main_xmult_swap([photograph, zany]))
+        self.assertIsNone(next_main_xmult_swap([photograph, zany, blueprint]))
+
+    def test_copy_target_uses_current_visible_hand_context(self) -> None:
+        blueprint = _joker(
+            index=0,
+            key="blueprint",
+            summary="Copy the Joker to the right.",
+        )
+        half = _joker(
+            index=1,
+            key="half",
+            summary="+20 Mult if ≤3 cards played.",
+            extra={"mult": 20, "size": 3},
+        )
+        blackboard = _joker(
+            index=2,
+            key="blackboard",
+            summary="X3 if all held cards are Spades or Clubs.",
+            extra=3,
+        )
+        state = {
+            "phase": "selecting_hand",
+            "hand": [
+                {
+                    "rank": "10",
+                    "suit": "Hearts",
+                    "chips": 10,
+                    "debuffed": False,
+                    "ability": {},
+                },
+                {
+                    "rank": "10",
+                    "suit": "Diamonds",
+                    "chips": 10,
+                    "debuffed": False,
+                    "ability": {},
+                },
+                {
+                    "rank": "King",
+                    "suit": "Spades",
+                    "chips": 10,
+                    "debuffed": False,
+                    "ability": {},
+                },
+                {
+                    "rank": "Queen",
+                    "suit": "Clubs",
+                    "chips": 10,
+                    "debuffed": False,
+                    "ability": {},
+                },
+            ],
+            "jokers": [blueprint, half, blackboard],
+            "poker_hands": [
+                {"name": "Pair", "chips": 10, "mult": 2},
+                {"name": "High Card", "chips": 5, "mult": 1},
+            ],
+            "resources": {
+                "money": 20,
+                "discards_left": 0,
+                "hands_left": 4,
+            },
+            "progress": {"ante": 3},
+            "blind": {
+                "rule": "No special rule.",
+                "target_chips": 300,
+            },
+            "deck": {"draw_pile": 30},
+            "legal_actions": [
+                {
+                    "kind": "swap_joker_right",
+                    "target_indices": [0, 1],
+                },
+            ],
+        }
+
+        self.assertEqual(
+            BalatroPolicy().act(state),
+            {"kind": "swap_joker_right", "target_index": 0},
+        )
+
+
+def _shop_state(
+    *,
+    jokers: list[dict[str, Any]],
+    shop_cards: list[dict[str, Any]],
+    slots: int,
+    legal: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "phase": "shop",
+        "jokers": jokers,
+        "shop": {"cards": shop_cards, "boosters": [], "vouchers": []},
+        "resources": {
+            "money": 20,
+            "joker_slots": slots,
+        },
+        "progress": {"ante": 3},
+        "deck": {"draw_pile": 30},
+        "legal_actions": legal,
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/human-in-loop/balatro/program/tests/test_consumables.py
+++ b/human-in-loop/balatro/program/tests/test_consumables.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import unittest
+
+from policy_system.consumables import targeted_consumable
+
+
+class ConsumableTest(unittest.TestCase):
+    def test_targeted_visible_effect_uses_legal_cards(self) -> None:
+        result = targeted_consumable(
+            [{"index": 7, "set": "Tarot", "rule": {"summary": "Enhance 2 selected cards."}}],
+            {"targets": [{"target_index": 7, "card_indices": [1, 2, 9], "min_cards": 2, "max_cards": 2}]},
+            [{"index": 1}, {"index": 2}, {"index": 3}],
+            "Pair",
+        )
+        self.assertEqual(result, (7, [1, 2]))
+
+    def test_unrelated_target_is_ignored(self) -> None:
+        self.assertIsNone(
+            targeted_consumable(
+                [{"index": 7, "set": "Spectral", "rule": {"summary": "Create a random card."}}],
+                {"targets": [{"target_index": 7, "card_indices": [1], "min_cards": 1, "max_cards": 1}]},
+                [{"index": 1}],
+                "Pair",
+            )
+        )

--- a/human-in-loop/balatro/program/tests/test_economy.py
+++ b/human-in-loop/balatro/program/tests/test_economy.py
@@ -1,0 +1,348 @@
+"""Tests for budgeted long-horizon shop spending."""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from policy_system.economy import (
+    EconomyContext,
+    choose_celestial,
+    choose_planet_purchase,
+    choose_reroll,
+    choose_voucher,
+)
+from policy_system.strategy import BalatroPolicy
+
+
+def _context(**overrides: int) -> EconomyContext:
+    values = {
+        "money": 40,
+        "ante": 3,
+        "reroll_cost": 5,
+        "free_rerolls": 0,
+        "rerolls_this_shop": 0,
+        "celestials_this_shop": 0,
+        "joker_count": 5,
+        "joker_slots": 5,
+    }
+    values.update(overrides)
+    return EconomyContext(**values)
+
+
+def _shop_card(
+    *,
+    index: int,
+    name: str,
+    cost: int,
+    card_set: str,
+    summary: str,
+    parameters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "index": index,
+        "key": name.lower().replace(" ", "_"),
+        "name": name,
+        "cost": cost,
+        "set": card_set,
+        "rule": {
+            "summary": summary,
+            "parameters": parameters or {},
+        },
+        "ability": parameters or {},
+    }
+
+
+class EconomyTest(unittest.TestCase):
+    def test_direct_planet_purchase_prefers_established_hand(self) -> None:
+        pair = _shop_card(
+            index=0,
+            name="Pair Planet",
+            cost=3,
+            card_set="Planet",
+            summary="Level up Pair by 1.",
+        )
+        high_card = _shop_card(
+            index=1,
+            name="High Card Planet",
+            cost=3,
+            card_set="Planet",
+            summary="Level up High Card by 1.",
+        )
+
+        intent = choose_planet_purchase(
+            [pair, high_card],
+            legal_indices={0, 1},
+            context=_context(money=25, ante=3),
+            primary_hand="High Card",
+            poker_hands={
+                "Pair": {"played": 2, "level": 1},
+                "High Card": {"played": 8, "level": 2},
+            },
+            consumable_count=0,
+            consumable_slots=2,
+            planets_this_shop=0,
+        )
+
+        self.assertIsNotNone(intent)
+        assert intent is not None
+        self.assertEqual(intent.kind, "buy_card")
+        self.assertEqual(intent.target_index, 1)
+
+    def test_direct_planet_purchase_requires_slot_and_reserve(self) -> None:
+        planet = _shop_card(
+            index=0,
+            name="Pair Planet",
+            cost=3,
+            card_set="Planet",
+            summary="Level up Pair by 1.",
+        )
+        full = choose_planet_purchase(
+            [planet],
+            legal_indices={0},
+            context=_context(),
+            primary_hand="Pair",
+            poker_hands={"Pair": {"played": 3, "level": 1}},
+            consumable_count=2,
+            consumable_slots=2,
+            planets_this_shop=0,
+        )
+        poor = choose_planet_purchase(
+            [planet],
+            legal_indices={0},
+            context=_context(money=17, ante=3),
+            primary_hand="Pair",
+            poker_hands={"Pair": {"played": 3, "level": 1}},
+            consumable_count=0,
+            consumable_slots=2,
+            planets_this_shop=0,
+        )
+
+        self.assertIsNone(full)
+        self.assertIsNone(poor)
+
+    def test_high_value_voucher_beats_no_effect_prerequisite(self) -> None:
+        blank = _shop_card(
+            index=0,
+            name="Blank",
+            cost=10,
+            card_set="Voucher",
+            summary="No immediate gameplay effect; prerequisite.",
+        )
+        hand = _shop_card(
+            index=1,
+            name="More Hands",
+            cost=10,
+            card_set="Voucher",
+            summary="Permanently add 1 hand per round.",
+        )
+
+        intent = choose_voucher(
+            [blank, hand],
+            legal_indices={0, 1},
+            context=_context(),
+        )
+
+        self.assertIsNotNone(intent)
+        assert intent is not None
+        self.assertEqual(intent.kind, "redeem_voucher")
+        self.assertEqual(intent.target_index, 1)
+
+    def test_celestial_pack_preserves_interest_reserve(self) -> None:
+        pack = _shop_card(
+            index=0,
+            name="Celestial Pack",
+            cost=4,
+            card_set="Booster",
+            summary="Reveal 3 Planet cards and choose 1.",
+            parameters={"choose": 1, "extra": 3},
+        )
+
+        affordable = choose_celestial(
+            [pack],
+            legal_indices={0},
+            context=_context(money=20, ante=3),
+        )
+        too_expensive = choose_celestial(
+            [pack],
+            legal_indices={0},
+            context=_context(money=18, ante=3),
+        )
+        already_opened = choose_celestial(
+            [pack],
+            legal_indices={0},
+            context=_context(celestials_this_shop=1),
+        )
+
+        self.assertIsNotNone(affordable)
+        self.assertIsNone(too_expensive)
+        self.assertIsNone(already_opened)
+
+    def test_reroll_is_limited_and_budgeted(self) -> None:
+        self.assertIsNone(
+            choose_reroll(
+                reroll_legal=True,
+                context=_context(money=29),
+            )
+        )
+        self.assertIsNotNone(
+            choose_reroll(
+                reroll_legal=True,
+                context=_context(free_rerolls=1),
+            )
+        )
+        self.assertIsNone(
+            choose_reroll(
+                reroll_legal=True,
+                context=_context(free_rerolls=1, rerolls_this_shop=1),
+            )
+        )
+        self.assertIsNone(
+            choose_reroll(
+                reroll_legal=True,
+                context=_context(money=14, free_rerolls=1),
+            )
+        )
+
+    def test_paid_reroll_requires_full_build_and_large_surplus(self) -> None:
+        paid = choose_reroll(
+            reroll_legal=True,
+            context=_context(money=35, ante=4),
+        )
+        short = choose_reroll(
+            reroll_legal=True,
+            context=_context(money=34, ante=4),
+        )
+        open_slot = choose_reroll(
+            reroll_legal=True,
+            context=_context(
+                money=35,
+                ante=4,
+                joker_count=4,
+                joker_slots=5,
+            ),
+        )
+
+        self.assertIsNotNone(paid)
+        self.assertIsNone(short)
+        self.assertIsNone(open_slot)
+
+    def test_planet_pack_prefers_established_hand_over_last_hand(self) -> None:
+        pair = _shop_card(
+            index=0,
+            name="Pair Planet",
+            cost=3,
+            card_set="Planet",
+            summary="Level up Pair (+15 Chips, +1 Mult).",
+        )
+        flush = _shop_card(
+            index=1,
+            name="Flush Planet",
+            cost=3,
+            card_set="Planet",
+            summary="Level up Flush (+15 Chips, +2 Mult).",
+        )
+        policy = BalatroPolicy()
+        policy.plan.primary_hand = "Flush"
+        state = {
+            "phase": "pack_opening",
+            "pack": {
+                "cards": [pair, flush],
+                "choices_remaining": 1,
+            },
+            "poker_hands": [
+                {
+                    "name": "Pair",
+                    "played": 8,
+                    "level": 1,
+                    "chips": 10,
+                    "mult": 2,
+                },
+                {
+                    "name": "Flush",
+                    "played": 1,
+                    "level": 1,
+                    "chips": 35,
+                    "mult": 4,
+                },
+            ],
+            "legal_actions": [
+                {
+                    "kind": "pick_pack_card",
+                    "targets": [
+                        {
+                            "target_index": 0,
+                            "card_indices": [],
+                            "min_cards": 0,
+                            "max_cards": 0,
+                        },
+                        {
+                            "target_index": 1,
+                            "card_indices": [],
+                            "min_cards": 0,
+                            "max_cards": 0,
+                        },
+                    ],
+                },
+                {"kind": "skip_pack"},
+            ],
+        }
+
+        self.assertEqual(
+            policy.act(state),
+            {
+                "kind": "pick_pack_card",
+                "target_index": 0,
+                "card_indices": [],
+            },
+        )
+
+    def test_policy_uses_zero_target_planet_consumable(self) -> None:
+        policy = BalatroPolicy()
+        state = {
+            "phase": "selecting_hand",
+            "hand": [],
+            "jokers": [],
+            "consumables": [
+                {
+                    "index": 0,
+                    "set": "Planet",
+                    "name": "Pluto",
+                    "rule": {"summary": "Level up High Card."},
+                }
+            ],
+            "poker_hands": [],
+            "resources": {"money": 10, "discards_left": 0, "hands_left": 4},
+            "progress": {"rounds_cleared": 0},
+            "blind": {"rule": "No special rule.", "target_chips": 300},
+            "deck": {"draw_pile": 44},
+            "legal_actions": [
+                {
+                    "kind": "use_consumable",
+                    "targets": [
+                        {
+                            "target_index": 0,
+                            "card_indices": [],
+                            "min_cards": 0,
+                            "max_cards": 0,
+                        }
+                    ],
+                },
+                {"kind": "next_round"},
+            ],
+        }
+
+        policy.plan.primary_hand = "High Card"
+
+        self.assertEqual(
+            policy.act(state),
+            {
+                "kind": "use_consumable",
+                "target_index": 0,
+                "card_indices": [],
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/human-in-loop/balatro/program/tests/test_hands.py
+++ b/human-in-loop/balatro/program/tests/test_hands.py
@@ -1,0 +1,380 @@
+"""Tests for public-information poker hand classification."""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from policy_system.hands import classify, discard_choice
+from policy_system.strategy import BalatroPolicy
+
+
+class HandClassificationTest(unittest.TestCase):
+    def test_face_down_cards_are_not_preserved_as_a_pair_or_flush(
+        self,
+    ) -> None:
+        hand: list[dict[str, Any]] = [
+            {"rank": None, "suit": None} for _ in range(5)
+        ] + [
+            {"rank": "7", "suit": "Hearts"},
+            {"rank": "7", "suit": "Clubs"},
+            {"rank": "Ace", "suit": "Spades"},
+        ]
+
+        self.assertEqual(discard_choice(hand, [5, 6]), [0, 1, 2, 3, 4])
+
+    def test_face_down_cards_do_not_form_an_invented_flush(self) -> None:
+        hidden: list[dict[str, Any]] = [
+            {"rank": None, "suit": None} for _ in range(5)
+        ]
+
+        name, scoring = classify(hidden)
+
+        self.assertEqual(name, "High Card")
+        self.assertEqual(scoring, [0])
+
+    def test_psychic_rule_never_plays_fewer_than_five_cards(self) -> None:
+        ranks = ["Ace", "King", "Queen", "Jack", "10", "9", "8", "7"]
+        hand: list[dict[str, Any]] = [
+            {
+                "rank": rank,
+                "suit": ("Hearts", "Clubs", "Spades", "Diamonds")[index % 4],
+                "chips": 11 if rank == "Ace" else min(10, 14 - index),
+                "debuffed": False,
+                "ability": {},
+            }
+            for index, rank in enumerate(ranks)
+        ]
+        observation: dict[str, Any] = {
+            "phase": "selecting_hand",
+            "hand": hand,
+            "jokers": [],
+            "poker_hands": [],
+            "resources": {
+                "chips": 0,
+                "discards_left": 0,
+                "hands_left": 4,
+                "money": 0,
+            },
+            "progress": {},
+            "blind": {
+                "rule": "Exactly five cards must be played in every hand.",
+                "target_chips": 300,
+            },
+            "deck": {"draw_pile": 44},
+            "legal_actions": [
+                {
+                    "kind": "play_hand",
+                    "card_indices": list(range(8)),
+                    "min_cards": 1,
+                    "max_cards": 5,
+                },
+            ],
+        }
+
+        action = BalatroPolicy().act(observation)
+
+        self.assertEqual(action["kind"], "play_hand")
+        self.assertEqual(len(action["card_indices"]), 5)
+
+    def test_early_discard_seeks_margin_before_spending_a_hand(self) -> None:
+        ranks = ["10", "10", "Ace", "King", "Queen", "9", "7", "3"]
+        hand: list[dict[str, Any]] = [
+            {
+                "rank": rank,
+                "suit": "Clubs" if index < 2 else "Hearts",
+                "chips": 11 if rank == "Ace" else 10,
+                "debuffed": False,
+                "ability": {},
+            }
+            for index, rank in enumerate(ranks)
+        ]
+        onyx_agate = {
+            "name": "Onyx Agate",
+            "debuffed": False,
+            "rule": {
+                "summary": "+7 Mult per Club scored.",
+                "parameters": {"extra": 7},
+            },
+        }
+        observation: dict[str, Any] = {
+            "phase": "selecting_hand",
+            "hand": hand,
+            "jokers": [onyx_agate],
+            "poker_hands": [
+                {"name": "Pair", "chips": 10, "mult": 2},
+                {"name": "High Card", "chips": 5, "mult": 1},
+            ],
+            "resources": {
+                "chips": 0,
+                "discards_left": 4,
+                "hands_left": 4,
+                "money": 0,
+            },
+            "progress": {},
+            "blind": {
+                "rule": "No special rule.",
+                "target_chips": 1600,
+            },
+            "deck": {"draw_pile": 44},
+            "legal_actions": [
+                {
+                    "kind": "play_hand",
+                    "card_indices": list(range(8)),
+                    "min_cards": 1,
+                    "max_cards": 5,
+                },
+                {
+                    "kind": "discard",
+                    "card_indices": list(range(8)),
+                    "min_cards": 1,
+                    "max_cards": 5,
+                },
+            ],
+        }
+
+        action = BalatroPolicy().act(observation)
+
+        self.assertEqual(action["kind"], "discard")
+
+    def test_early_build_stops_chasing_after_one_failed_discard(
+        self,
+    ) -> None:
+        ranks = ["5", "5", "4", "4", "Ace", "7", "9", "3"]
+        hand: list[dict[str, Any]] = [
+            {
+                "rank": rank,
+                "suit": ("Hearts", "Clubs", "Spades", "Diamonds")[index % 4],
+                "chips": (
+                    11
+                    if rank == "Ace"
+                    else min(10, int(rank))
+                ),
+                "debuffed": False,
+                "ability": {},
+            }
+            for index, rank in enumerate(ranks)
+        ]
+        observation: dict[str, Any] = {
+            "phase": "selecting_hand",
+            "hand": hand,
+            "jokers": [],
+            "poker_hands": [
+                {"name": "Two Pair", "chips": 20, "mult": 2},
+                {"name": "Pair", "chips": 10, "mult": 2},
+            ],
+            "resources": {
+                "chips": 0,
+                "discards_left": 3,
+                "hands_left": 4,
+                "money": 0,
+            },
+            "progress": {"ante": 1, "rounds_cleared": 0},
+            "blind": {"rule": "No special rule.", "target_chips": 300},
+            "deck": {"draw_pile": 39},
+            "legal_actions": [
+                {
+                    "kind": "play_hand",
+                    "card_indices": list(range(8)),
+                    "min_cards": 1,
+                    "max_cards": 5,
+                },
+                {
+                    "kind": "discard",
+                    "card_indices": list(range(8)),
+                    "min_cards": 1,
+                    "max_cards": 5,
+                },
+            ],
+        }
+        policy = BalatroPolicy()
+        policy.plan.prepare_round(0)
+        policy.plan.consecutive_discards = 1
+
+        self.assertEqual(policy.act(observation)["kind"], "play_hand")
+
+    def test_nonlethal_play_cycles_safe_low_cards(self) -> None:
+        cards = [
+            ("10", "Hearts"),
+            ("10", "Clubs"),
+            ("Ace", "Diamonds"),
+            ("King", "Spades"),
+            ("Queen", "Diamonds"),
+            ("9", "Spades"),
+            ("7", "Diamonds"),
+            ("3", "Spades"),
+        ]
+        hand: list[dict[str, Any]] = [
+            {
+                "rank": rank,
+                "suit": suit,
+                "chips": (
+                    11
+                    if rank == "Ace"
+                    else 10
+                    if rank in {"10", "Jack", "Queen", "King"}
+                    else int(rank)
+                ),
+                "debuffed": False,
+                "edition": None,
+                "enhancement": "c_base",
+                "seal": None,
+                "ability": {},
+            }
+            for rank, suit in cards
+        ]
+        observation: dict[str, Any] = {
+            "phase": "selecting_hand",
+            "hand": hand,
+            "jokers": [],
+            "poker_hands": [
+                {"name": "Pair", "chips": 10, "mult": 2},
+                {"name": "High Card", "chips": 5, "mult": 1},
+            ],
+            "resources": {
+                "chips": 0,
+                "discards_left": 0,
+                "hands_left": 3,
+                "money": 0,
+            },
+            "progress": {"ante": 2, "rounds_cleared": 3},
+            "blind": {"rule": "No special rule.", "target_chips": 1000},
+            "deck": {"draw_pile": 44},
+            "legal_actions": [
+                {
+                    "kind": "play_hand",
+                    "card_indices": list(range(8)),
+                    "min_cards": 1,
+                    "max_cards": 5,
+                },
+            ],
+        }
+
+        action = BalatroPolicy().act(observation)
+
+        self.assertEqual(action["kind"], "play_hand")
+        self.assertEqual(
+            set(action["card_indices"]),
+            {0, 1, 5, 6, 7},
+        )
+
+        observation["blind"]["target_chips"] = 100
+        observation["resources"]["discards_left"] = 1
+        action_with_discard = BalatroPolicy().act(observation)
+
+        self.assertEqual(action_with_discard["kind"], "play_hand")
+        self.assertEqual(
+            set(action_with_discard["card_indices"]),
+            {0, 1},
+        )
+
+        observation["progress"]["ante"] = 1
+        observation["resources"]["discards_left"] = 0
+        observation["blind"]["target_chips"] = 1000
+        early_action = BalatroPolicy().act(observation)
+
+        self.assertEqual(early_action["kind"], "play_hand")
+        self.assertEqual(
+            set(early_action["card_indices"]),
+            {0, 1},
+        )
+
+    def test_first_hidden_hand_is_played_without_spending_a_discard(self) -> None:
+        observation: dict[str, Any] = {
+            "phase": "selecting_hand",
+            "hand": [
+                {
+                    "rank": None,
+                    "suit": None,
+                    "chips": None,
+                    "debuffed": False,
+                    "ability": {},
+                }
+            ],
+            "jokers": [],
+            "poker_hands": [],
+            "resources": {
+                "chips": 0,
+                "discards_left": 4,
+                "hands_left": 4,
+                "money": 0,
+            },
+            "progress": {"rounds_cleared": 0},
+            "blind": {
+                "rule": "The first hand is drawn face-down.",
+                "target_chips": 300,
+            },
+            "deck": {"draw_pile": 44},
+            "legal_actions": [
+                {
+                    "kind": "play_hand",
+                    "card_indices": [0],
+                    "min_cards": 1,
+                    "max_cards": 1,
+                },
+                {
+                    "kind": "discard",
+                    "card_indices": [0],
+                    "min_cards": 1,
+                    "max_cards": 1,
+                },
+            ],
+        }
+
+        self.assertEqual(
+            BalatroPolicy().act(observation)["kind"],
+            "play_hand",
+        )
+
+    def test_needle_uses_discard_before_its_only_weak_hand(self) -> None:
+        hand: list[dict[str, Any]] = [
+            {
+                "rank": rank,
+                "suit": ("Hearts", "Clubs", "Spades", "Diamonds")[index % 4],
+                "chips": int(rank),
+                "debuffed": False,
+                "ability": {},
+            }
+            for index, rank in enumerate(("2", "2", "3", "5", "7", "8", "9", "10"))
+        ]
+        observation: dict[str, Any] = {
+            "phase": "selecting_hand",
+            "hand": hand,
+            "jokers": [],
+            "poker_hands": [
+                {"name": "Pair", "chips": 10, "mult": 2},
+                {"name": "High Card", "chips": 5, "mult": 1},
+            ],
+            "resources": {
+                "chips": 0,
+                "discards_left": 4,
+                "hands_left": 1,
+                "money": 0,
+            },
+            "progress": {"ante": 2, "rounds_cleared": 5},
+            "blind": {
+                "rule": "Only one hand is available.",
+                "target_chips": 600,
+            },
+            "deck": {"draw_pile": 44},
+            "legal_actions": [
+                {
+                    "kind": "play_hand",
+                    "card_indices": list(range(8)),
+                    "min_cards": 1,
+                    "max_cards": 5,
+                },
+                {
+                    "kind": "discard",
+                    "card_indices": list(range(8)),
+                    "min_cards": 1,
+                    "max_cards": 5,
+                },
+            ],
+        }
+
+        self.assertEqual(BalatroPolicy().act(observation)["kind"], "discard")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/human-in-loop/balatro/program/tests/test_replays.py
+++ b/human-in-loop/balatro/program/tests/test_replays.py
@@ -1,0 +1,114 @@
+"""Replay every public observation through the current Policy and gateway."""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import pathlib
+import unittest
+from typing import Any
+
+from policy import make_policy
+
+_SIMPLE = {
+    "select_blind",
+    "skip_blind",
+    "cash_out",
+    "reroll_shop",
+    "next_round",
+    "skip_pack",
+    "sort_hand_by_rank",
+    "sort_hand_by_suit",
+}
+
+
+def _descriptor(state: dict[str, Any], kind: str) -> dict[str, Any]:
+    return next(
+        item for item in state["legal_actions"] if item.get("kind") == kind
+    )
+
+
+def _validate_action(state: dict[str, Any], action: dict[str, Any]) -> None:
+    kind = action["kind"]
+    descriptor = _descriptor(state, kind)
+    if kind in _SIMPLE:
+        if set(action) != {"kind"}:
+            raise AssertionError(f"unexpected {kind} fields: {action}")
+        return
+    if kind in {"play_hand", "discard"}:
+        if set(action) != {"kind", "card_indices"}:
+            raise AssertionError(f"unexpected {kind} fields: {action}")
+        indices = action["card_indices"]
+        allowed = set(descriptor["card_indices"])
+        if (
+            len(indices) != len(set(indices))
+            or not set(indices) <= allowed
+            or not descriptor["min_cards"]
+            <= len(indices)
+            <= descriptor["max_cards"]
+        ):
+            raise AssertionError(f"invalid {kind} targets: {action}")
+        return
+    if kind in {"use_consumable", "pick_pack_card"}:
+        if set(action) != {"kind", "target_index", "card_indices"}:
+            raise AssertionError(f"unexpected {kind} fields: {action}")
+        target = next(
+            item
+            for item in descriptor.get("targets", [])
+            if item.get("target_index") == action["target_index"]
+        )
+        indices = action["card_indices"]
+        if (
+            len(indices) != len(set(indices))
+            or not set(indices) <= set(target.get("card_indices", []))
+            or not target.get("min_cards", 0)
+            <= len(indices)
+            <= target.get("max_cards", 0)
+        ):
+            raise AssertionError(f"invalid {kind} targets: {action}")
+        return
+    if set(action) != {"kind", "target_index"}:
+        raise AssertionError(f"unexpected {kind} fields: {action}")
+    if action["target_index"] not in descriptor["target_indices"]:
+        raise AssertionError(f"invalid {kind} target: {action}")
+
+
+def _replay_paths() -> list[pathlib.Path]:
+    configured = os.environ.get("BALATRO_REPLAY_GLOB")
+    repository = pathlib.Path(__file__).resolve().parents[4]
+    pattern = configured or str(
+        repository
+        / (
+            "runs/balatro-skill-ab-gpt-5.6-sol-retry-20260725-164423/"
+            "submissions/submission-000019/artifacts/replay.jsonl"
+        )
+    )
+    if configured:
+        return [pathlib.Path(item) for item in sorted(glob.glob(pattern))]
+    return [pathlib.Path(pattern)]
+
+
+class ReplayTest(unittest.TestCase):
+    def test_all_public_observations_produce_exact_legal_actions(self) -> None:
+        checked = 0
+        for path in _replay_paths():
+            policies: dict[int, Any] = {}
+            for line in path.read_text(encoding="utf-8").splitlines():
+                item = json.loads(line)
+                episode_index = item["episode_index"]
+                if item["type"] == "episode":
+                    policies[episode_index] = make_policy(None)  # type: ignore[arg-type]
+                    state = item["initial_state"]
+                else:
+                    state = item["state"]
+                if state["phase"] == "game_over":
+                    continue
+                action = policies[episode_index].act(state)
+                _validate_action(state, action)
+                checked += 1
+        self.assertGreater(checked, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/human-in-loop/balatro/program/tests/test_scoring.py
+++ b/human-in-loop/balatro/program/tests/test_scoring.py
@@ -1,0 +1,467 @@
+"""Tests for visible hand and Joker score modeling."""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from policy_system.scoring import ScoringContext, estimate_score
+
+
+def _card(rank: str, suit: str = "Hearts") -> dict[str, Any]:
+    if rank == "Ace":
+        chips = 11
+    elif rank in {"10", "Jack", "Queen", "King"}:
+        chips = 10
+    else:
+        chips = int(rank)
+    return {
+        "rank": rank,
+        "suit": suit,
+        "chips": chips,
+        "debuffed": False,
+        "edition": None,
+        "enhancement": "c_base",
+        "ability": {},
+    }
+
+
+def _joker(
+    summary: str,
+    **parameters: Any,
+) -> dict[str, Any]:
+    return {
+        "debuffed": False,
+        "edition": None,
+        "ability": parameters,
+        "rule": {
+            "summary": summary,
+            "parameters": parameters,
+        },
+    }
+
+
+def _pair_score(
+    jokers: list[dict[str, Any]],
+    *,
+    context: ScoringContext | None = None,
+) -> float:
+    hand = [_card("10", "Diamonds"), _card("10", "Diamonds")]
+    return estimate_score(
+        hand=hand,
+        selected_indices=[0, 1],
+        scoring_local=[0, 1],
+        hand_name="Pair",
+        poker_hand={"chips": 10, "mult": 2},
+        jokers=jokers,
+        context=context or ScoringContext(),
+    )
+
+
+class ScoringTest(unittest.TestCase):
+    def test_visible_default_chip_mod_is_counted(self) -> None:
+        stuntman = _joker(
+            "+Chips chips (default 250).",
+            extra={"chip_mod": 250, "h_size": 2},
+        )
+
+        self.assertEqual(_pair_score([stuntman]), 560)
+
+    def test_money_bucket_mult_uses_current_visible_money(self) -> None:
+        bootstraps = _joker(
+            "+2 mult per $5 held.",
+            extra={"dollars": 5, "mult": 2},
+        )
+
+        self.assertEqual(
+            _pair_score([bootstraps], context=ScoringContext(money=17)),
+            240,
+        )
+
+    def test_lowest_held_rank_mult_uses_unplayed_card(self) -> None:
+        raised_fist = _joker("+2× lowest held card's rank as mult.")
+        hand = [_card("10"), _card("10"), _card("3")]
+
+        score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1],
+            scoring_local=[0, 1],
+            hand_name="Pair",
+            poker_hand={"chips": 10, "mult": 2},
+            jokers=[raised_fist],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 240)
+
+    def test_hand_specific_bonus_does_not_leak_to_wrong_hand(self) -> None:
+        zany = _joker(
+            "+12 Mult if hand contains Three of a Kind.",
+            t_mult=12,
+            type="Three of a Kind",
+        )
+
+        self.assertEqual(_pair_score([zany]), 60)
+
+    def test_hand_specific_xmult_does_not_leak_to_wrong_hand(self) -> None:
+        tribe = _joker(
+            "X Mult if hand contains Flush.",
+            x_mult=2,
+            type="Flush",
+        )
+
+        self.assertEqual(_pair_score([tribe]), 60)
+
+    def test_recurring_xmult_requires_visible_ready_state(self) -> None:
+        waiting = _joker(
+            "X Mult every N+1 hands.",
+            extra={"Xmult": 4, "every": 5, "remaining": "5 remaining"},
+        )
+        ready = _joker(
+            "X Mult every N+1 hands.",
+            extra={"Xmult": 4, "every": 5, "remaining": "0 remaining"},
+        )
+
+        self.assertEqual(_pair_score([waiting]), 60)
+        self.assertEqual(_pair_score([ready]), 240)
+
+    def test_unobservable_conditional_nested_xmult_stays_inactive(self) -> None:
+        card_sharp = _joker(
+            "X Mult if same hand type played twice this round.",
+            extra={"Xmult": 3},
+        )
+
+        self.assertEqual(_pair_score([card_sharp]), 60)
+
+    def test_final_hand_xmult_uses_visible_hands_left(self) -> None:
+        acrobat = _joker(
+            "X Mult on last hand of round.",
+            extra=3,
+        )
+
+        self.assertEqual(
+            _pair_score(
+                [acrobat],
+                context=ScoringContext(hands_left=3),
+            ),
+            60,
+        )
+        self.assertEqual(
+            _pair_score(
+                [acrobat],
+                context=ScoringContext(hands_left=1),
+            ),
+            180,
+        )
+
+    def test_unmatched_per_card_effect_does_not_become_flat_bonus(self) -> None:
+        even_steven = _joker(
+            "+4 Mult for even cards.",
+            extra=4,
+        )
+        odd_pair = [_card("5"), _card("5")]
+
+        score = estimate_score(
+            hand=odd_pair,
+            selected_indices=[0, 1],
+            scoring_local=[0, 1],
+            hand_name="Pair",
+            poker_hand={"chips": 10, "mult": 2},
+            jokers=[even_steven],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 40)
+
+    def test_nested_mult_respects_visible_hand_size_condition(self) -> None:
+        half_joker = _joker(
+            "+20 Mult if ≤3 cards played.",
+            extra={"mult": 20, "size": 3},
+        )
+        short_score = _pair_score([half_joker])
+        hand = [
+            _card("10", "Hearts"),
+            _card("9", "Hearts"),
+            _card("8", "Hearts"),
+            _card("7", "Hearts"),
+            _card("6", "Hearts"),
+        ]
+        long_score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1, 2, 3, 4],
+            scoring_local=[0, 1, 2, 3, 4],
+            hand_name="Straight Flush",
+            poker_hand={"chips": 100, "mult": 8},
+            jokers=[half_joker],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(short_score, 660)
+        self.assertEqual(long_score, 1120)
+
+    def test_visible_current_chips_are_not_disabled_by_decay_wording(
+        self,
+    ) -> None:
+        ice_cream = _joker(
+            "Starts +100 Chips, -5 per hand.",
+            extra={"chip_mod": 5, "chips": 100},
+        )
+
+        self.assertEqual(_pair_score([ice_cream]), 260)
+
+    def test_visible_rank_filter_applies_nested_values_per_card(self) -> None:
+        scholar = _joker(
+            "+20 Chips and +4 Mult for Ace.",
+            extra={"chips": 20, "mult": 4},
+        )
+        hand = [_card("Ace"), _card("Ace")]
+
+        score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1],
+            scoring_local=[0, 1],
+            hand_name="Pair",
+            poker_hand={"chips": 10, "mult": 2},
+            jokers=[scholar],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 720)
+
+    def test_suit_mult_counts_matching_scoring_cards(self) -> None:
+        greedy = _joker(
+            "+3 Mult per Diamond scored.",
+            effect="Suit Mult",
+            extra={"s_mult": 3, "suit": "Diamonds"},
+        )
+
+        self.assertEqual(_pair_score([greedy]), 240)
+
+    def test_visible_suit_name_can_supply_per_card_mult(self) -> None:
+        onyx = _joker(
+            "+7 Mult per Club scored.",
+            extra=7,
+        )
+        hand = [_card("10", "Clubs"), _card("10", "Clubs")]
+
+        score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1],
+            scoring_local=[0, 1],
+            hand_name="Pair",
+            poker_hand={"chips": 10, "mult": 2},
+            jokers=[onyx],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 480)
+
+    def test_held_rank_mult_counts_only_unplayed_cards(self) -> None:
+        shoot_the_moon = _joker(
+            "+13 Mult per Queen held.",
+            extra=13,
+        )
+        hand = [
+            _card("10", "Diamonds"),
+            _card("10", "Clubs"),
+            _card("Queen"),
+        ]
+
+        score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1],
+            scoring_local=[0, 1],
+            hand_name="Pair",
+            poker_hand={"chips": 10, "mult": 2},
+            jokers=[shoot_the_moon],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 450)
+
+    def test_all_four_suits_condition_uses_scoring_cards(self) -> None:
+        flower_pot = _joker(
+            "X Mult if scoring hand contains all 4 suits.",
+            extra=3,
+        )
+        hand = [
+            _card("10", "Hearts"),
+            _card("10", "Diamonds"),
+            _card("10", "Spades"),
+            _card("10", "Clubs"),
+        ]
+
+        score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1, 2, 3],
+            scoring_local=[0, 1, 2, 3],
+            hand_name="Four of a Kind",
+            poker_hand={"chips": 60, "mult": 7},
+            jokers=[flower_pot],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 2100)
+
+    def test_all_black_held_condition_applies_visible_xmult(self) -> None:
+        blackboard = _joker(
+            "X3 if all held cards are Spades or Clubs.",
+            extra=3,
+        )
+        hand = [
+            _card("10", "Hearts"),
+            _card("10", "Diamonds"),
+            _card("King", "Spades"),
+            _card("Queen", "Clubs"),
+        ]
+
+        score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1],
+            scoring_local=[0, 1],
+            hand_name="Pair",
+            poker_hand={"chips": 10, "mult": 2},
+            jokers=[blackboard],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 180)
+
+    def test_visible_dynamic_mult_uses_current_joker_count(self) -> None:
+        abstract = _joker(
+            "+3 mult per joker owned.",
+            extra=3,
+        )
+        inert = _joker("No scoring effect.")
+
+        self.assertEqual(_pair_score([abstract, inert]), 240)
+
+    def test_hand_history_mult_includes_the_current_play(self) -> None:
+        supernova = _joker(
+            "+mult = times this hand type played in the run.",
+            extra=1,
+        )
+        hand = [_card("10"), _card("10")]
+
+        score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1],
+            scoring_local=[0, 1],
+            hand_name="Pair",
+            poker_hand={"chips": 10, "mult": 2, "played": 4},
+            jokers=[supernova],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 210)
+
+    def test_same_round_repeat_xmult_uses_episode_history(self) -> None:
+        card_sharp = _joker(
+            "X Mult if same hand type played twice this round.",
+            extra={"Xmult": 3},
+        )
+
+        first = _pair_score(
+            [card_sharp],
+            context=ScoringContext(round_hand_counts={}),
+        )
+        repeat = _pair_score(
+            [card_sharp],
+            context=ScoringContext(round_hand_counts={"Pair": 1}),
+        )
+
+        self.assertEqual(first, 60)
+        self.assertEqual(repeat, 180)
+
+    def test_sell_value_mult_uses_other_visible_jokers(self) -> None:
+        swashbuckler = _joker(
+            "+mult = sum of all other jokers' sell values.",
+            mult=1,
+        )
+        swashbuckler["sell_value"] = 3
+        first = _joker("No scoring effect.")
+        first["sell_value"] = 4
+        second = _joker("No scoring effect.")
+        second["sell_value"] = 6
+
+        self.assertEqual(
+            _pair_score([swashbuckler, first, second]),
+            360,
+        )
+
+    def test_face_additive_and_xmult_apply_in_joker_order(self) -> None:
+        face_mult = _joker("+5 Mult for face cards.", extra=5)
+        photograph = _joker(
+            "X Mult on FIRST face card in scoring hand only.",
+            extra=2,
+        )
+        hand = [_card("King"), _card("King")]
+
+        score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1],
+            scoring_local=[0, 1],
+            hand_name="Pair",
+            poker_hand={"chips": 10, "mult": 2},
+            jokers=[face_mult, photograph],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 720)
+
+    def test_visible_retrigger_repeats_card_and_per_card_effects(self) -> None:
+        hack = _joker(
+            "Retrigger 2/3/4/5 cards.",
+            extra=1,
+        )
+        greedy = _joker(
+            "+3 Mult per Heart scored.",
+            effect="Suit Mult",
+            extra={"s_mult": 3, "suit": "Hearts"},
+        )
+        hand = [_card("5"), _card("5")]
+
+        score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1],
+            scoring_local=[0, 1],
+            hand_name="Pair",
+            poker_hand={"chips": 10, "mult": 2},
+            jokers=[hack, greedy],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 420)
+
+    def test_visible_right_copy_repeats_neighbor_scoring_effect(self) -> None:
+        blueprint = _joker("Copy the Joker to the right.")
+        strong = _joker("+20 Mult.", t_mult=20)
+
+        self.assertEqual(_pair_score([blueprint, strong]), 1260)
+
+    def test_first_card_retrigger_repeats_first_face_xmult(self) -> None:
+        hanging_chad = _joker(
+            "+2 retriggers for FIRST scored card.",
+            extra=2,
+        )
+        photograph = _joker(
+            "X Mult on FIRST face card in scoring hand only.",
+            extra=2,
+        )
+        hand = [_card("King"), _card("King")]
+
+        score = estimate_score(
+            hand=hand,
+            selected_indices=[0, 1],
+            scoring_local=[0, 1],
+            hand_name="Pair",
+            poker_hand={"chips": 10, "mult": 2},
+            jokers=[hanging_chad, photograph],
+            context=ScoringContext(),
+        )
+
+        self.assertEqual(score, 800)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/optimize-balatro-policy/SKILL.md
+++ b/skills/optimize-balatro-policy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimize-balatro-policy
-description: Build, improve, test, and select a reward-aligned EvoPolicyGym Bot system for the Jackdaw Balatro Benchmark. Use when architecting files under program/, analyzing Feedback or replay.jsonl, modeling hands, draws, builds, economy, and visible effects, hardening legal Actions, allocating the Episode budget, diagnosing Policy failures, or handing final candidates to the Host.
+description: Build, improve, test, and select a reward-aligned EvoPolicyGym Bot system for the Jackdaw Balatro Benchmark. Use when architecting program/, analyzing indexed train Feedback or replay.jsonl, modeling hands, draws, builds, economy, and visible effects, hardening legal Actions, partitioning a train-only Episode pool and budget, running matched Program comparisons, diagnosing Policy failures, or handing frozen published candidates to Host Validation and Assessment.
 ---
 
 # Optimize Balatro Policy
@@ -10,18 +10,32 @@ strategy, software architecture, replay testing, and noisy evaluation as one
 engineering problem. Prefer a small shared decision model over disconnected
 phase heuristics, tooltip tier lists, and encounter-specific patches.
 
+## Load the reusable resources
+
+- Before planning or interpreting an evaluation, read
+  [references/experiment-protocol.md](references/experiment-protocol.md).
+- Before changing scoring, discard, shop, build, or Joker-order behavior, read
+  the relevant part of
+  [references/strategy-lessons.md](references/strategy-lessons.md).
+- Use `scripts/summarize_evidence.py` to pool public submission Feedback by
+  immutable digest. Do not hand-calculate repeated evidence summaries.
+
 ## Align with the objective
 
 - Distinguish Benchmark reward from in-game Chips and dollars. Optimize
   expected Episode score: Blinds cleared plus the large complete-run win bonus.
+- Keep win reward and ordinary progress separate. A normal win clears 24
+  Blinds and receives the 1000-point win bonus, producing run reward 1024.
 - Treat Ante reach and Blinds cleared as development diagnostics, not
   substitutes for winning. Prefer changes that increase robust Ante 8
   completion probability over changes that only improve early progress.
 - Group evidence by Program digest and pool all Episodes for that digest. A
   single win is high-variance evidence, not proof that one observed build or
   purchase caused it.
-- Record wins, Episodes, Policy failures, score distribution, and Ante reach
-  separately. Never compare only the largest submission mean.
+- Record wins, Episodes, Policy failures, mean/median Blinds, early deaths,
+  mid/late tails, and Ante reach separately. Never compare only the largest
+  submission mean. Results for the same selected Episode indices are matched;
+  results for different index sets remain unmatched noisy evidence.
 
 ## Preserve the boundary
 
@@ -38,18 +52,35 @@ phase heuristics, tooltip tier lists, and encounter-specific patches.
 
 ## Establish evidence first
 
-1. Read this skill, inspect every file under `program/`, and inspect all
-   existing Feedback and advertised Artifacts.
-2. Submit the unchanged Program with the smallest useful batch to establish its
-   correctness, score distribution, failure count, Ante reach, and win rate.
-3. Keep an evidence ledger with submission ID, digest, Episode count, score,
-   failures, wins, Ante reach, hypothesis, and architectural change.
-4. Inspect retained replay trajectories and omission markers, not only
-   terminal states or aggregate scores. Identify the first consequential bad
-   decision in representative weak, strong, and failed Episodes.
+1. Read the Host task's Run-local Episode-index range, Episode budget,
+   submission limits, and candidate limit. Before the first result, partition
+   both train indices and spend into baseline, diagnosis, matched capability
+   development, and frozen confirmation roles.
+2. Inspect every file under `program/` and the permitted public train Feedback
+   and advertised Artifacts. Record the unchanged Program digest and preserve
+   an exact restore method.
+3. Submit the smallest useful baseline batch to establish correctness,
+   distribution, failures, Ante reach, and wins.
+4. Keep an evidence ledger with digest, submission IDs, selected Episode
+   indices, preassigned role, Episode count, mean/median Blinds, `≤5`, `≥12`,
+   `≥18`, failures, wins, hypothesis, and decision. Keep the ledger in working
+   reasoning; do not add non-Policy evidence files to the submitted `program/`.
+5. Inspect replay trajectories and omission markers only for baseline,
+   diagnosis, and capability-development submissions. Identify the first
+   consequential bad decision in representative weak, strong, and failed
+   Episodes.
+6. Enter frozen confirmation only once. Stop editing strategic behavior,
+   evaluate the frozen shortlist on pre-reserved, previously unseen train
+   indices, and inspect aggregate outcomes only.
 
-Treat small-batch score changes as noisy observations. Compare repeated
-identical digests and distributions before attributing a result to an edit.
+All Agent-visible submissions are train evidence from one fixed Host-owned
+Episode pool. The Agent can choose and reuse Run-local Episode indices but
+cannot observe their actual Environment or Policy seeds. Reusing an index
+preserves its hidden Episode specification and Policy seed while creating a
+fresh Environment and Policy runtime and consuming budget again. Use identical
+index selectors for matched online A/B, and treat comparisons over different
+selectors as unmatched. Follow the complete index-partition, budget, and freeze
+procedure in the experiment protocol.
 
 ## Build a Policy system
 
@@ -141,6 +172,11 @@ data cannot express an encountered rule.
   above a highly upgraded core hand merely by poker category.
 - Compare predicted hand score with actual `last_hand` breakdowns and turn
   systematic error into effect-model regressions.
+- Treat two hidden cards with absent rank or suit as two unknowns, never as a
+  known Pair or Flush relation.
+- Test the downstream selector whenever calibration changes. A more accurate
+  immediate score can reduce survival when the play/discard horizon remains
+  myopic.
 
 ### Effects and build
 
@@ -158,6 +194,9 @@ data cannot express an encountered rule.
 - Model temporary, scaling, conditional, consumable, and decaying effects
   differently. Evaluate Joker and played-card ordering when resolution order
   matters.
+- Separate scored-card, held-card, main additive-Mult, main XMult, retrigger,
+  and copy phases. Do not apply a generic Joker sort across unresolved copy
+  dependencies.
 
 ### Economy and horizon
 
@@ -172,6 +211,30 @@ data cannot express an encountered rule.
   handling as a constraint on the plan, not a late special case.
 - Evaluate a purchase or skip by its effect on the current plan and future
   survival, not by a fixed global threshold alone.
+
+## Run controlled capability experiments
+
+Change one capability at a time:
+
+1. State which public states are eligible, which decisions may change, why the
+   change should improve survival or growth, and what would reject it.
+2. Run a development replay or counterfactual opportunity audit before an
+   environment evaluation. Count eligible states and changed actions.
+3. Predeclare a small development index selector. Evaluate the exact control
+   digest and candidate digest on that same selector, then compare public
+   outcomes by `episode_index`. Prefer narrow guards that prevent catastrophic
+   early regressions.
+4. When a candidate looks promising, repeat the matched comparison on a second
+   predeclared selector or evaluate the unchanged digest on reserved train
+   indices. Require evidence beyond one matched batch.
+5. Require zero Policy failures and no safety regression. Restore rejected
+   controls exactly and verify their digest.
+
+Once frozen confirmation begins, do not inspect its replay to learn how to
+patch. Use its aggregate evidence only to reject brittle candidates or order
+the final shortlist. Host Validation and Assessment occur after Agent cleanup,
+publish nothing back to the Agent workspace, and stay outside the iteration
+loop.
 
 ## Add replay regression gates
 
@@ -207,11 +270,13 @@ Use a staged sequence unless evidence points elsewhere:
 2. Eliminate Policy failures and implement exact Action admission.
 3. Complete the required system checkpoint: normalized state, Episode plan,
    module boundaries, and persistent replay tests.
-4. Unify hand enumeration, visible scoring, draw probability, and discard
+4. Audit whether the proposed capability can alter actions often enough to
+   matter.
+5. Unify hand enumeration, visible scoring, draw probability, and discard
    value.
-5. Add structured effect roles and build-aware scoring.
-6. Add economy, slot replacement, pack, consumable, and ordering decisions.
-7. Add Blind scaling, Boss constraints, and long-horizon build control.
+6. Add structured effect roles and build-aware scoring.
+7. Add economy, slot replacement, pack, consumable, and ordering decisions.
+8. Add Blind scaling, Boss constraints, and long-horizon build control.
 
 Change one decision capability per experiment, but implement it through the
 shared system rather than appending a phase-local exception. Avoid named-object
@@ -234,6 +299,12 @@ reconstructing a previous candidate.
   enough.
 - Use small batches for correctness and directional experiments, then larger
   batches or repeated identical digests for candidate confidence.
+- Reserve a meaningful confirmation allocation before development consumes the
+  budget, including train indices that development will not inspect. Do not
+  spend the whole reserve chasing one promising result.
+- Reuse identical selectors deliberately for matched comparisons, remembering
+  that every reuse consumes budget. Never inspect, infer, name, or claim
+  control over the hidden seed identities behind Run-local indices.
 - Enter repeat-only evidence collection only after the required system
   checkpoint is complete, replay tests persist, and no known correctness or
   model-consistency defect remains.
@@ -244,8 +315,9 @@ reconstructing a previous candidate.
   alternatives rather than lucky observations.
 - Follow the Host task's current `finish` syntax and candidate limit. When
   private Validation is configured, hand the Host the strongest ordered
-  candidate set; do not consume Agent search budget pretending to reproduce
-  Host Validation.
+  credible candidate set. The Host evaluates them on identical private
+  Validation Episodes only after Agent exit; do not consume train budget
+  pretending to reproduce that stage.
 - Expect neither Validation nor held-out Assessment evidence in workspace
   Feedback. Never adapt after final handoff.
 - Finish successfully before exiting. Unsubmitted workspace edits are not

--- a/skills/optimize-balatro-policy/agents/openai.yaml
+++ b/skills/optimize-balatro-policy/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Engineer Balatro Policy"
-  short_description: "Build and validate robust Balatro policy systems"
-  default_prompt: "Use $optimize-balatro-policy to engineer, test, and select a robust Balatro Policy system."
+  display_name: "Optimize Balatro Policy"
+  short_description: "Run indexed Balatro policy experiments"
+  default_prompt: "Use $optimize-balatro-policy to partition the train Episode pool and budget, run matched Policy experiments, and hand frozen candidates to Host Validation."

--- a/skills/optimize-balatro-policy/references/experiment-protocol.md
+++ b/skills/optimize-balatro-policy/references/experiment-protocol.md
@@ -1,0 +1,126 @@
+# Train-only experiment protocol
+
+In a formal EvoPolicyGym Run, the Agent receives only train submissions from
+one fixed Host-owned Episode pool. The Host exposes Run-local integer indices,
+not the hidden Environment or Policy seeds behind them. The Agent may select
+and reuse indices across submissions; the same index preserves its hidden
+Episode specification and Policy seed while every use creates fresh runtime
+state and consumes budget again. Host Validation and Assessment start only
+after `finish` closes Agent authority, use independent Host-only Episodes, and
+never return evidence to the workspace.
+
+Create evidence roles by partitioning the train budget, not by pretending to
+have Benchmark validation data.
+
+## Contents
+
+- Partition before the first submission
+- Run development experiments
+- Enter frozen confirmation once
+- Report metrics and hand off to the Host
+- Keep an evidence ledger
+
+## Partition before the first submission
+
+Read the available Run-local index range, total Episode budget,
+per-submission cap, maximum submissions, and candidate limit. Pool size is the
+number of selectable conditions; budget is the total number of evaluations,
+including repeated indices. Write down both an index allocation and a spend
+allocation before seeing results. A useful starting point is:
+
+| Role | Approximate budget | Index policy | Replay use |
+|---|---:|---|---|
+| Baseline and correctness | 10% | small declared baseline set | inspect |
+| Diagnosis and architecture | 20% | declared development sets | inspect |
+| Capability experiments | 45% | matched control/candidate selectors | inspect |
+| Frozen confirmation | 25% | pre-reserved unseen train indices | aggregates only |
+
+Adapt percentages to the budget, but reserve at least two meaningful
+submissions for frozen confirmation when limits allow, or one when the budget
+is very small. Reserve their indices before development and do not inspect
+them early. Never borrow the entire reserve to continue an attractive
+experiment. Record every submission's preassigned role and exact selector in
+the evidence ledger. Keep that ledger in working reasoning rather than adding
+non-Policy artifacts to the submitted `program/`.
+
+## Run development experiments
+
+1. Record the control Program digest and an exact inverse edit or restore
+   method allowed by the workspace. Do not add backups inside `program/`.
+2. State one hypothesis, eligible public states, decisions it may change,
+   safety guards, and rejection conditions.
+3. Before spending Episodes, use development replay or a counterfactual audit.
+   Count eligible states and changed actions. Drop behavior-neutral ideas unless
+   they are correctness or architecture work.
+4. Choose a small, predeclared development selector. Submit the exact control
+   digest and candidate digest on the same indices. Restore and verify the
+   control digest before its submission when needed.
+5. Compare outcomes only after matching each public `episode_index`. This is a
+   matched train A/B, not access to the hidden seed or Case.
+6. If promising, repeat the comparison on a second predeclared selector. Pool
+   only identical digests, retain per-index deltas, and check consistency
+   across selectors.
+7. Treat results from different selectors as unmatched noisy evidence. Never
+   claim a paired improvement unless the index sets match exactly.
+8. Revert rejected work exactly and verify the restored digest.
+
+Use replay counterfactuals for action-level comparison and repeated immutable
+digests for environment-level confidence.
+
+## Enter frozen confirmation once
+
+Before consuming the reserved confirmation budget:
+
+1. Stop adding capabilities.
+2. Freeze a credible shortlist of immutable digests represented by published
+   submissions and the rule for ordering them.
+3. Evaluate each feasible frozen candidate on the same pre-reserved,
+   previously unseen train selector. Verify every restored digest before
+   measuring it.
+4. Inspect only terminal aggregates. Do not open confirmation replay to design
+   another patch.
+5. Use confirmation to reject brittle candidates or adjust shortlist order,
+   not to resume threshold tuning. At `finish`, include at most one published
+   submission ID for each distinct candidate digest.
+
+Confirmation is still train evidence, not true validation. Its protection comes
+from reserving it before development and stopping adaptive edits when it begins.
+If a Policy failure appears, prefer a previously published safe candidate.
+
+## Report the right metrics
+
+Balatro run reward is `rounds_cleared + 1000` on a win. A completed Ante 8 run
+therefore normally has reward 1024. Report reward and progress separately:
+
+- immutable Program digest, submission IDs, evidence role, selected indices,
+  and Episodes;
+- wins and Policy failures;
+- mean and median Blinds cleared;
+- early deaths (`≤5`);
+- mid-game completions (`≥12`);
+- late-game completions (`≥18`);
+- repeated-submission consistency for the same digest.
+
+A rare win demonstrates ceiling, not a stable win rate. Do not rank candidates
+only by the largest submission mean.
+
+## Hand off to the Host
+
+Consume the legal Episode budget, then call `finish` with the strongest
+published submission or ordered credible shortlist allowed by the task. The
+Host evaluates shortlisted Programs on identical private Validation Episodes
+after Agent exit and selects by the declared metric and tie-breaks. Assessment
+then measures only the selected Program and never changes selection.
+
+Do not attempt to reproduce either stage from train Feedback. Never expect,
+inspect, or adapt to Host Validation or Assessment evidence.
+
+## Keep an evidence ledger
+
+Use one row per immutable digest, selector, and evidence role:
+
+| Digest | Submission IDs | Selector | Role | Episodes | Mean / median | ≤5 | ≥12 | ≥18 | Wins | Failures | Decision |
+|---|---|---|---|---:|---|---:|---:|---:|---:|---:|---|
+
+Link public artifacts and record whether replay was inspected. Keep rejected
+experiments so later agents do not repeat the same adaptive overfit.

--- a/skills/optimize-balatro-policy/references/strategy-lessons.md
+++ b/skills/optimize-balatro-policy/references/strategy-lessons.md
@@ -1,0 +1,66 @@
+# Reusable Balatro strategy lessons
+
+Apply these lessons as model invariants, not as a list of named encounter
+patches.
+
+## Couple scoring to the decision horizon
+
+- A more exact immediate hand score can make a myopic selector worse. Whenever
+  scoring changes, test the play/discard choice and remaining-hands horizon,
+  not calibration alone.
+- Separate base Chips/Mult, scored-card triggers, held-card triggers, main
+  additive Mult, and main XMult into resolution phases. Reorder only effects
+  whose phase and dependency are modeled.
+- Use `last_hand` to find systematic prediction error on development replays.
+  Prioritize effects that occur often enough to change decisions.
+- Treat unknown effects as uncertainty. Do not silently score them as zero.
+
+## Preserve information boundaries
+
+- Face-down cards with missing rank or suit are unknown, not equal. Never form
+  a Pair, Flush group, or deterministic out from shared `None` values.
+- Draw-pile composition supports probabilities, not future-card prediction.
+- Keep all indices ephemeral and rebuild intents from the current observation.
+
+## Optimize draw throughput safely
+
+- Compare discard value with playing a nonlethal hand when extra played cards
+  can cycle weak kickers and improve the next draw.
+- Add kickers only when they are legal, unmodified low-value junk, outside the
+  scoring hand and valuable draws, and enough future hands remain.
+- Guard throughput changes by Ante, remaining hands/discards, Blind deficit,
+  Boss rules, and score confidence. Broad early activation creates severe
+  regressions.
+
+## Plan the build and shop jointly
+
+- Value a Joker by marginal survival and growth in the current build, not by a
+  standalone tier. Include role coverage, activation rate, scaling horizon,
+  slot opportunity cost, sell proceeds, interest, and replacement sequence.
+- When slots are full and cash is safely above reserve, a bounded paid reroll
+  can search for upgrades. Record rerolls per shop and cap them.
+- A purchase rule that never triggers is not an optimization. Count eligible
+  shops and changed decisions before evaluating it.
+- Conservative Planet and consumable use is safer than speculative targets,
+  but behavior-neutral safety code is not evidence of strength.
+
+## Handle Joker order as a dependency problem
+
+- Put main-stage additive Mult before main-stage XMult when no other dependency
+  overrides that order.
+- Treat Blueprint, Brainstorm, retriggers, per-card effects, and multi-copy
+  chains as explicit dependency graphs. Do not apply a generic sort while copy
+  semantics are unresolved.
+- Move at most one adjacent inversion per observation unless action semantics
+  guarantee an atomic full reorder.
+
+## Learn correctly from failures
+
+- Diagnose only from submissions assigned to baseline, diagnosis, or capability
+  development. Frozen-confirmation regression tells you to reject or reorder a
+  shortlist, not how to patch.
+- Prefer a narrow guarded capability that holds up across several fresh
+  submissions over a broad rule with a larger pooled mean and catastrophic
+  early regressions.
+- Separate engineering correctness, average survival, late-tail reach, and win
+  rate. A change may improve one without demonstrating another.

--- a/skills/optimize-balatro-policy/scripts/summarize_evidence.py
+++ b/skills/optimize-balatro-policy/scripts/summarize_evidence.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Summarize public Balatro EvaluationResult or paired-comparison JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+from typing import Any
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument(
+        "--side",
+        choices=("auto", "candidate", "baseline", "direct"),
+        default="auto",
+        help="select a side from comparison JSON; auto prefers candidate",
+    )
+    parser.add_argument(
+        "--win-bonus",
+        type=float,
+        default=1000.0,
+        help="Benchmark win bonus to remove from ordinary progress",
+    )
+    parser.add_argument(
+        "--allow-mixed-digests",
+        action="store_true",
+        help="permit pooling evidence from more than one Program digest",
+    )
+    return parser.parse_args()
+
+
+def _mapping(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _selected(document: dict[str, Any], side: str) -> dict[str, Any]:
+    if side == "direct":
+        return document
+    if side in {"candidate", "baseline"}:
+        return _mapping(document.get(side), side)
+    candidate = document.get("candidate")
+    return _mapping(candidate, "candidate") if candidate is not None else document
+
+
+def _reward(episode: dict[str, Any]) -> float | None:
+    value = episode.get("reward")
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("Episode reward must be numeric or null")
+    return float(value)
+
+
+def _episode_index(episode: dict[str, Any]) -> int | None:
+    value = episode.get("episode_index")
+    if value is None:
+        return None
+    if type(value) is not int or value < 0:
+        raise ValueError("episode_index must be a non-negative integer")
+    return value
+
+
+def _progress(reward: float | None, win_bonus: float) -> tuple[float, bool]:
+    if reward is None:
+        return 0.0, False
+    won = reward >= win_bonus
+    return (reward - win_bonus if won else reward), won
+
+
+def _summary(values: list[float]) -> dict[str, float | int]:
+    return {
+        "episodes": len(values),
+        "mean_blinds": statistics.fmean(values),
+        "median_blinds": statistics.median(values),
+        "early_le5": sum(value <= 5 for value in values),
+        "ge12": sum(value >= 12 for value in values),
+        "ge18": sum(value >= 18 for value in values),
+        "max_blinds": max(values),
+    }
+
+
+def main() -> int:
+    arguments = _arguments()
+    progress: list[float] = []
+    raw_rewards: list[float] = []
+    failures = 0
+    wins = 0
+    digests: set[str] = set()
+    paired_deltas: list[float] = []
+
+    for path in arguments.paths:
+        document = _mapping(json.loads(path.read_text(encoding="utf-8")), str(path))
+        selected = _selected(document, arguments.side)
+        digest = selected.get("program_digest")
+        if isinstance(digest, str):
+            digests.add(digest)
+        episodes = selected.get("episodes")
+        if not isinstance(episodes, list):
+            raise ValueError(f"{path}: selected result has no Episode list")
+
+        selected_progress: list[float] = []
+        selected_indices: list[int | None] = []
+        for value in episodes:
+            episode = _mapping(value, "Episode")
+            selected_indices.append(_episode_index(episode))
+            reward = _reward(episode)
+            item_progress, won = _progress(reward, arguments.win_bonus)
+            selected_progress.append(item_progress)
+            progress.append(item_progress)
+            raw_rewards.append(0.0 if reward is None else reward)
+            wins += won
+            failures += episode.get("failure") is not None
+
+        compare_candidate = (
+            arguments.side in {"auto", "candidate"}
+            and "baseline" in document
+            and "candidate" in document
+        )
+        if compare_candidate:
+            baseline = _mapping(document["baseline"], "baseline")
+            baseline_episodes = baseline.get("episodes")
+            if not isinstance(baseline_episodes, list):
+                raise ValueError(f"{path}: baseline has no Episode list")
+            if len(baseline_episodes) != len(selected_progress):
+                raise ValueError(f"{path}: paired Episode counts differ")
+            for index, selected_value in enumerate(selected_progress):
+                baseline_value = _mapping(
+                    baseline_episodes[index],
+                    "Episode",
+                )
+                baseline_index = _episode_index(baseline_value)
+                selected_index = selected_indices[index]
+                if (
+                    (baseline_index is None) != (selected_index is None)
+                    or baseline_index != selected_index
+                ):
+                    raise ValueError(
+                        f"{path}: paired Episode indices differ"
+                    )
+                baseline_reward = _reward(baseline_value)
+                baseline_progress, _ = _progress(
+                    baseline_reward, arguments.win_bonus
+                )
+                paired_deltas.append(selected_value - baseline_progress)
+
+    if not progress:
+        raise ValueError("no Episodes found")
+    if len(digests) > 1 and not arguments.allow_mixed_digests:
+        raise ValueError("refusing to pool multiple Program digests")
+
+    output: dict[str, Any] = {
+        **_summary(progress),
+        "wins": wins,
+        "policy_failures": failures,
+        "mean_run_reward": statistics.fmean(raw_rewards),
+        "program_digests": sorted(digests),
+    }
+    if paired_deltas:
+        output["paired"] = {
+            "improved": sum(value > 0 for value in paired_deltas),
+            "unchanged": sum(value == 0 for value in paired_deltas),
+            "regressed": sum(value < 0 for value in paired_deltas),
+            "mean_delta_blinds": statistics.fmean(paired_deltas),
+            "min_delta_blinds": min(paired_deltas),
+            "max_delta_blinds": max(paired_deltas),
+        }
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_repository_skills.py
+++ b/tests/test_repository_skills.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 from evopolicygym.skills import AgentSkill
 
@@ -30,9 +35,123 @@ class RepositorySkillTests(unittest.TestCase):
         )
 
         self.assertIn("agents/openai.yaml", skill.files)
+        self.assertIn("references/experiment-protocol.md", skill.files)
+        self.assertIn("references/strategy-lessons.md", skill.files)
+        self.assertIn("scripts/summarize_evidence.py", skill.files)
         instructions = skill.read_bytes("SKILL.md").decode()
         self.assertIn("expected Episode score", instructions)
         self.assertIn("Pool repeated evidence by digest", instructions)
+        self.assertIn(
+            "partitioning a train-only Episode pool and budget",
+            instructions,
+        )
+        self.assertIn(
+            "can choose and reuse Run-local Episode indices",
+            instructions,
+        )
+        self.assertIn("Host Validation and Assessment", instructions)
+        protocol = skill.read_bytes(
+            "references/experiment-protocol.md"
+        ).decode()
+        self.assertIn("receives only train submissions", protocol)
+        self.assertIn("matched train A/B", protocol)
+        self.assertIn("pre-reserved unseen train indices", protocol)
+        self.assertIn("Confirmation is still train evidence", protocol)
+
+    def test_balatro_evidence_summarizer_separates_wins_from_progress(
+        self,
+    ) -> None:
+        digest = f"sha256:{'a' * 64}"
+        document: dict[str, Any] = {
+            "baseline": {
+                "program_digest": f"sha256:{'b' * 64}",
+                "episodes": [
+                    {
+                        "episode_index": 0,
+                        "reward": 5,
+                        "failure": None,
+                    },
+                    {
+                        "episode_index": 1,
+                        "reward": 12,
+                        "failure": None,
+                    },
+                    {
+                        "episode_index": 2,
+                        "reward": 7,
+                        "failure": None,
+                    },
+                ],
+            },
+            "candidate": {
+                "program_digest": digest,
+                "episodes": [
+                    {
+                        "episode_index": 0,
+                        "reward": 11,
+                        "failure": None,
+                    },
+                    {
+                        "episode_index": 1,
+                        "reward": 1024,
+                        "failure": None,
+                    },
+                    {
+                        "episode_index": 2,
+                        "reward": None,
+                        "failure": "invalid_action",
+                    },
+                ],
+            },
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "comparison.json"
+            source.write_text(json.dumps(document), encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(
+                        SKILLS
+                        / "optimize-balatro-policy"
+                        / "scripts"
+                        / "summarize_evidence.py"
+                    ),
+                    str(source),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            document["baseline"]["episodes"][0]["episode_index"] = 9
+            source.write_text(json.dumps(document), encoding="utf-8")
+            mismatched = subprocess.run(
+                [
+                    sys.executable,
+                    str(
+                        SKILLS
+                        / "optimize-balatro-policy"
+                        / "scripts"
+                        / "summarize_evidence.py"
+                    ),
+                    str(source),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        summary = json.loads(completed.stdout)
+        self.assertEqual(summary["program_digests"], [digest])
+        self.assertEqual(summary["wins"], 1)
+        self.assertEqual(summary["policy_failures"], 1)
+        self.assertEqual(summary["mean_blinds"], 35 / 3)
+        self.assertEqual(summary["paired"]["improved"], 2)
+        self.assertEqual(summary["paired"]["regressed"], 1)
+        self.assertNotEqual(mismatched.returncode, 0)
+        self.assertIn(
+            "paired Episode indices differ",
+            mismatched.stderr,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

Publish the repository's Balatro policy-system lab and align its experiment
workflow with the Kernel's indexed training Episode pool.

## Changes

- add the human-in-the-loop Balatro policy system, analysis tools, evidence
  record, and 64-test policy suite
- update the Balatro optimization Skill for fixed Run-local Episode selectors,
  matched Program comparisons, budget partitioning, and reserved confirmation
  indices
- add reusable experiment and strategy references plus an evidence summarizer
  that validates paired `episode_index` values
- extend repository Skill tests for the indexed protocol
- record separately reviewed future Environment candidates

## Impact

The repository now contains a concrete, inspectable strategy-system reference
and a reproducible workflow for using public indexed Feedback without exposing
Environment or Policy seeds.

## Validation

- `uv run ruff check src tests skills/optimize-balatro-policy/scripts/summarize_evidence.py human-in-loop/balatro/analysis human-in-loop/balatro/program`
- `uv run mypy`
- `uv run python -m unittest discover -s tests` — 100 passed
- `uv run python -m unittest discover -s tests` in
  `human-in-loop/balatro/program` — 64 passed
- `git diff --check`

## Limitations

The Balatro lab is research/reference material. `ProcessExecution` remains
explicitly unsafe for hostile code and provides no isolation.
