### PR TITLE
cli: split session command and cover environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Check CLI and build
         run: |
           uv run evopolicygym --version
+          uv run evopolicygym-session --version
           uv build
 
   cartpole:
@@ -88,36 +89,36 @@ jobs:
           uv build
 
   minigrid:
-    name: MiniGrid ${{ matrix.benchmark }} Benchmark (${{ matrix.os }})
+    name: ${{ matrix.project }} Benchmark (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        benchmark:
-          - blocked_unlock_pickup
-          - crossing
-          - dist_shift
-          - doorkey
-          - dynamic_obstacles
-          - empty
-          - fetch
-          - four_rooms
-          - go_to_door
-          - go_to_object
-          - keycorridor
-          - lava_gap
-          - locked_room
-          - memory
-          - multiroom
-          - obstructed_maze
-          - playground
-          - put_near
-          - red_blue_doors
-          - unlock
-          - unlock_pickup
-          - wfc
+        project:
+          - environments/minigrid/minigrid/blocked_unlock_pickup
+          - environments/minigrid/minigrid/crossing
+          - environments/minigrid/minigrid/dist_shift
+          - environments/minigrid/minigrid/doorkey
+          - environments/minigrid/minigrid/dynamic_obstacles
+          - environments/minigrid/minigrid/empty
+          - environments/minigrid/minigrid/fetch
+          - environments/minigrid/minigrid/four_rooms
+          - environments/minigrid/minigrid/go_to_door
+          - environments/minigrid/minigrid/go_to_object
+          - environments/minigrid/minigrid/keycorridor
+          - environments/minigrid/minigrid/lava_gap
+          - environments/minigrid/minigrid/locked_room
+          - environments/minigrid/minigrid/memory
+          - environments/minigrid/minigrid/multiroom
+          - environments/minigrid/minigrid/obstructed_maze
+          - environments/minigrid/minigrid/playground
+          - environments/minigrid/minigrid/put_near
+          - environments/minigrid/minigrid/red_blue_doors
+          - environments/minigrid/minigrid/unlock
+          - environments/minigrid/minigrid/unlock_pickup
+          - environments/minigrid/minigrid/wfc
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -134,12 +135,12 @@ jobs:
       - name: Sync locked Benchmark environment
         run: >-
           uv sync
-          --project environments/minigrid/minigrid/${{ matrix.benchmark }}
+          --project ${{ matrix.project }}
           --locked
           --extra dev
 
       - name: Check and test external Benchmark
-        working-directory: environments/minigrid/minigrid/${{ matrix.benchmark }}
+        working-directory: ${{ matrix.project }}
         run: |
           uv run ruff check src tests
           uv run mypy
@@ -159,8 +160,31 @@ jobs:
           - environments/atcoder/ahc057/molecules
           - environments/atcoder/ahc058/apple_incremental_game
           - environments/codechef/june18/warehouseman
+          - environments/gymnasium/box2d/bipedal_walker
+          - environments/gymnasium/box2d/car_racing
+          - environments/gymnasium/box2d/lunar_lander
+          - environments/gymnasium/classic_control/acrobot
+          - environments/gymnasium/classic_control/mountain_car
+          - environments/gymnasium/classic_control/mountain_car_continuous
+          - environments/gymnasium/classic_control/pendulum
+          - environments/gymnasium/mujoco/ant
+          - environments/gymnasium/mujoco/half_cheetah
+          - environments/gymnasium/mujoco/hopper
+          - environments/gymnasium/mujoco/humanoid
+          - environments/gymnasium/mujoco/humanoid_standup
+          - environments/gymnasium/mujoco/inverted_double_pendulum
+          - environments/gymnasium/mujoco/inverted_pendulum
+          - environments/gymnasium/mujoco/pusher
+          - environments/gymnasium/mujoco/reacher
+          - environments/gymnasium/mujoco/swimmer
+          - environments/gymnasium/mujoco/walker2d
+          - environments/gymnasium/toy_text/blackjack
+          - environments/gymnasium/toy_text/cliff_walking
+          - environments/gymnasium/toy_text/frozen_lake
+          - environments/gymnasium/toy_text/taxi
           - environments/gymnasium_robotics/robotics
           - environments/highway_env/highway_env
+          - environments/jackdaw/balatro
           - environments/metaworld/metaworld
           - environments/minigrid/babyai
           - environments/stable_retro/airstriker

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,6 +70,7 @@ evopolicygym/
 │   ├── _feedback.py            Feedback and Artifact publication
 │   ├── _json.py                retained public-value JSON projection
 │   ├── _socket.py              active Agent Session transport
+│   ├── _session_cli.py         Agent-facing Session presentation
 │   └── _task.py                provider-independent Agent instructions
 │
 ├── execution/                  public execution selections
@@ -86,13 +87,18 @@ evopolicygym/
 │   ├── _framing.py             shared bounded JSON frame mechanism
 │   ├── policy.py               Policy process framing and PolicyValue codec
 │   └── session.py              versioned Agent Session framing
-└── cli.py                      Agent-facing Session presentation
+└── cli.py                      Host/operator presentation over the public SDK
 ```
 
 There is no parallel private shadow package for a public use case.
 `evopolicygym.evaluation`, `evopolicygym.run`, and
 `evopolicygym.execution` are both their stable public entry points and their
 implementation ownership boundaries.
+
+The `evopolicygym` executable is the Host/operator command surface. The
+separate `evopolicygym-session` executable is projected into an active Agent
+Run and owns only `submit` and `finish`; it is a presentation over
+`agent-session/v3`, not an operator workflow or Benchmark registry.
 
 ## Environment distributions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Expanded CI to test and build all 57 first-party Benchmark distributions,
+  including the Gymnasium Classic Control, Toy Text, Box2D, and MuJoCo suites
+  plus Balatro, and added a repository test that rejects unlisted Environment
+  projects.
+- Split the Host/operator `evopolicygym` executable from the Agent-facing
+  `evopolicygym-session submit|finish` client without changing the
+  `agent-session/v3` wire protocol.
 - Added a deterministic, Host-owned indexed training Episode pool. Agents now
   select arbitrary singleton and half-open range unions through
   `agent-session/v3`; repeated indices preserve Episode and Policy seeds across

--- a/README.md
+++ b/README.md
@@ -209,9 +209,13 @@ During the Run, the agent evaluates immutable submissions and hands candidates
 to the Host with:
 
 ```console
-evopolicygym submit program --episodes "0:2,4:8"
-evopolicygym finish submission-000002 submission-000007
+evopolicygym-session submit program --episodes "0:2,4:8"
+evopolicygym-session finish submission-000002 submission-000007
 ```
+
+`evopolicygym-session` is the Agent-facing client for one active Run. The
+separate `evopolicygym` command is reserved for Host/operator workflows over
+the public SDK; it never submits to an Agent Session.
 
 `RunConfig.seed` deterministically creates one fixed Host-owned training
 Episode pool before the Agent starts. `episode_pool_size` defaults to the total

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = []
 
 [project.scripts]
 evopolicygym = "evopolicygym.cli:main"
+evopolicygym-session = "evopolicygym.run._session_cli:main"
 
 [build-system]
 requires = ["hatchling==1.31.0"]

--- a/site/src/content/docs/en/evaluation.md
+++ b/site/src/content/docs/en/evaluation.md
@@ -94,7 +94,7 @@ Episode pool from `RunConfig.seed`. The Agent submits public Run-local
 singleton and half-open range unions such as:
 
 ```console
-evopolicygym submit program --episodes "0:2,4:8"
+evopolicygym-session submit program --episodes "0:2,4:8"
 ```
 
 That selector expands to indices `0, 1, 4, 5, 6, 7`. The same index preserves

--- a/site/src/content/docs/en/getting-started.md
+++ b/site/src/content/docs/en/getting-started.md
@@ -109,7 +109,7 @@ Inside the active Agent Session, a Submission uses singleton indices and
 half-open ranges:
 
 ```console
-evopolicygym submit program --episodes "0:2,4:8"
+evopolicygym-session submit program --episodes "0:2,4:8"
 ```
 
 The selector above evaluates indices `0, 1, 4, 5, 6, 7`. Reusing an index in a

--- a/site/src/content/docs/zh/evaluation.md
+++ b/site/src/content/docs/zh/evaluation.md
@@ -91,7 +91,7 @@ Agent 执行前，Host 根据 `RunConfig.seed` 确定性地构建一个固定训
 Agent 使用公开的 Run-local 单点与半开区间并集提交，例如：
 
 ```console
-evopolicygym submit program --episodes "0:2,4:8"
+evopolicygym-session submit program --episodes "0:2,4:8"
 ```
 
 该选择器展开为编号 `0, 1, 4, 5, 6, 7`。同一编号在不同 Submission 中保持隐藏

--- a/site/src/content/docs/zh/getting-started.md
+++ b/site/src/content/docs/zh/getting-started.md
@@ -101,7 +101,7 @@ Host 会在 Agent 启动前构建 60 个固定的 Run-local 训练 Episode ident
 在有效的 Agent Session 内，Submission 使用单点编号与半开区间：
 
 ```console
-evopolicygym submit program --episodes "0:2,4:8"
+evopolicygym-session submit program --episodes "0:2,4:8"
 ```
 
 上述 selector 会评估编号 `0, 1, 4, 5, 6, 7`。在后续 Submission 中复用编号可以

--- a/skills/optimize-balatro-policy/SKILL.md
+++ b/skills/optimize-balatro-policy/SKILL.md
@@ -259,8 +259,8 @@ Before every submission:
 Test shop, pack, consumable, full-slot, zero-money, no-discard, face-down,
 debuffed, ordering, and Boss paths. Do not submit a known failing path merely
 because its mean score is promising. If any gate fails, stop before
-`evopolicygym submit`; shell command sequencing must not continue after the
-failure.
+`evopolicygym-session submit`; shell command sequencing must not continue
+after the failure.
 
 ## Iterate by capability
 

--- a/skills/use-evopolicygym/SKILL.md
+++ b/skills/use-evopolicygym/SKILL.md
@@ -94,9 +94,9 @@ authority.
   Policy.
 - Add `ConsoleProgress()` when interactive progress is useful.
 - Require the Agent to publish candidates through
-  `evopolicygym submit program --episodes "0:2,4:8"` and finish by handing the
-  Host one or more published IDs with
-  `evopolicygym finish SUBMISSION_ID [SUBMISSION_ID ...]`.
+  `evopolicygym-session submit program --episodes "0:2,4:8"` and finish by
+  handing the Host one or more published IDs with
+  `evopolicygym-session finish SUBMISSION_ID [SUBMISSION_ID ...]`.
 - Treat submit selectors as public Run-local Episode indices: comma joins
   singleton or half-open range items, each request is strictly increasing and
   duplicate-free, and reusing an index in a later Submission consumes budget

--- a/skills/use-evopolicygym/references/api.md
+++ b/skills/use-evopolicygym/references/api.md
@@ -105,8 +105,8 @@ repository discovery or attach a Skill to `BenchmarkSpec`.
 During search, the Agent uses:
 
 ```console
-evopolicygym submit program --episodes "0:2,4:6"
-evopolicygym finish submission-000003 submission-000011
+evopolicygym-session submit program --episodes "0:2,4:6"
+evopolicygym-session finish submission-000003 submission-000011
 ```
 
 The submit selector addresses the fixed Run-local training Episode pool.

--- a/src/evopolicygym/cli.py
+++ b/src/evopolicygym/cli.py
@@ -1,216 +1,33 @@
-"""Agent-facing command-line presentation for an active local Session."""
+"""Operator-facing command-line presentation over the public SDK."""
 
 from __future__ import annotations
 
 import argparse
-import json
-import os
-import re
-import socket
-import sys
-from pathlib import Path
-from typing import cast
 
-from ._protocol.session import (
-    SESSION_MAX_EPISODE_INDICES,
-    SESSION_PROTOCOL,
-)
 from ._version import __version__
-from .run._socket import (
-    receive_session_message,
-    send_session_message,
-)
-
-_SESSION_SOCKET_VARIABLE = "EVOPOLICYGYM_SESSION_SOCKET"
-_WORKSPACE_VARIABLE = "EVOPOLICYGYM_WORKSPACE"
-_UNSIGNED_DECIMAL = re.compile(r"[0-9]+")
-_MAX_EPISODE_INDEX = 2**64 - 1
 
 
 def main(arguments: list[str] | None = None) -> int:
     parser = _parser()
-    namespace = parser.parse_args(arguments)
-    try:
-        request = _request(namespace)
-        response = _call_session(request)
-    except (OSError, RuntimeError, ValueError) as error:
-        print(
-            json.dumps(
-                {
-                    "ok": False,
-                    "error": {
-                        "code": "client_error",
-                        "message": str(error),
-                    },
-                },
-                separators=(",", ":"),
-                sort_keys=True,
-            ),
-            file=sys.stderr,
-        )
-        return 2
-
-    serialized = json.dumps(
-        response,
-        allow_nan=False,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    )
-    if response.get("ok") is True:
-        print(serialized)
-        return 0
-    print(serialized, file=sys.stderr)
-    return 1
+    parser.parse_args(arguments)
+    parser.print_help()
+    return 0
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="evopolicygym")
+    parser = argparse.ArgumentParser(
+        prog="evopolicygym",
+        description=(
+            "Operator commands for EvoPolicyGym. Evaluation and Run workflows "
+            "are currently available through the public Python SDK."
+        ),
+    )
     parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
     )
-    subcommands = parser.add_subparsers(dest="command", required=True)
-
-    submit = subcommands.add_parser(
-        "submit",
-        help="evaluate the fixed workspace Policy Program directory",
-    )
-    submit.add_argument(
-        "program",
-        help="must resolve to $EVOPOLICYGYM_WORKSPACE/program",
-    )
-    submit.add_argument(
-        "--episodes",
-        type=_parse_episode_selector,
-        required=True,
-        metavar="SELECTOR",
-        help='Run-local Episode indices, for example "0:2,4:8"',
-    )
-
-    finish = subcommands.add_parser(
-        "finish",
-        help="finish search with one or more published candidates",
-    )
-    finish.add_argument("submission_ids", nargs="+")
     return parser
-
-
-def _request(namespace: argparse.Namespace) -> dict[str, object]:
-    if namespace.command == "submit":
-        workspace = _required_path(_WORKSPACE_VARIABLE)
-        expected = (workspace / "program").resolve(strict=True)
-        supplied = Path(cast(str, namespace.program)).resolve(strict=True)
-        if supplied != expected:
-            raise ValueError("submitted Program must be workspace/program")
-        return {
-            "protocol": SESSION_PROTOCOL,
-            "method": "submit",
-            "episode_indices": list(
-                cast(tuple[int, ...], namespace.episodes)
-            ),
-        }
-    if namespace.command == "finish":
-        return {
-            "protocol": SESSION_PROTOCOL,
-            "method": "finish",
-            "submission_ids": cast(list[str], namespace.submission_ids),
-        }
-    raise RuntimeError("unknown command")
-
-
-def _call_session(request: dict[str, object]) -> dict[str, object]:
-    socket_path = _required_path(_SESSION_SOCKET_VARIABLE)
-    connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    try:
-        connection.connect(str(socket_path))
-        send_session_message(connection, request)
-        response = receive_session_message(connection)
-        if (
-            response.get("protocol") != SESSION_PROTOCOL
-            or type(response.get("ok")) is not bool
-        ):
-            raise ValueError("Session returned an invalid protocol response")
-        return response
-    finally:
-        connection.close()
-
-
-def _required_path(variable: str) -> Path:
-    raw = os.environ.get(variable)
-    if not raw:
-        raise RuntimeError(f"{variable} is not set; no Agent Session is active")
-    return Path(raw)
-
-
-def _parse_episode_selector(value: str) -> tuple[int, ...]:
-    if not value or any(character.isspace() for character in value):
-        raise argparse.ArgumentTypeError(
-            "Episode selector must not be empty or contain whitespace"
-        )
-    indices: list[int] = []
-    for item in value.split(","):
-        if not item:
-            raise argparse.ArgumentTypeError(
-                "Episode selector contains an empty item"
-            )
-        parts = item.split(":")
-        if len(parts) == 1:
-            index = _parse_unsigned(parts[0], endpoint=False)
-            _append_index(indices, index)
-            continue
-        if len(parts) != 2:
-            raise argparse.ArgumentTypeError(
-                "Episode ranges must use START:END"
-            )
-        start = _parse_unsigned(parts[0], endpoint=False)
-        end = _parse_unsigned(parts[1], endpoint=True)
-        if start >= end:
-            raise argparse.ArgumentTypeError(
-                "Episode ranges must be non-empty and increasing"
-            )
-        count = end - start
-        if count > SESSION_MAX_EPISODE_INDICES - len(indices):
-            raise argparse.ArgumentTypeError(
-                "Episode selector contains too many indices"
-            )
-        if indices and start <= indices[-1]:
-            raise argparse.ArgumentTypeError(
-                "Episode selector must be strictly increasing without overlap"
-            )
-        indices.extend(range(start, end))
-    if len(indices) > SESSION_MAX_EPISODE_INDICES:
-        raise argparse.ArgumentTypeError(
-            "Episode selector contains too many indices"
-        )
-    return tuple(indices)
-
-
-def _parse_unsigned(value: str, *, endpoint: bool) -> int:
-    if _UNSIGNED_DECIMAL.fullmatch(value) is None:
-        raise argparse.ArgumentTypeError(
-            "Episode indices must use unsigned decimal integers"
-        )
-    parsed = int(value)
-    limit = 2**64 if endpoint else _MAX_EPISODE_INDEX
-    if parsed > limit:
-        raise argparse.ArgumentTypeError(
-            "Episode index exceeds the unsigned 64-bit range"
-        )
-    return parsed
-
-
-def _append_index(indices: list[int], index: int) -> None:
-    if len(indices) == SESSION_MAX_EPISODE_INDICES:
-        raise argparse.ArgumentTypeError(
-            "Episode selector contains too many indices"
-        )
-    if indices and index <= indices[-1]:
-        raise argparse.ArgumentTypeError(
-            "Episode selector must be strictly increasing without overlap"
-        )
-    indices.append(index)
 
 
 if __name__ == "__main__":

--- a/src/evopolicygym/run/_session_cli.py
+++ b/src/evopolicygym/run/_session_cli.py
@@ -1,0 +1,217 @@
+"""Agent-facing command-line presentation for an active local Session."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import socket
+import sys
+from pathlib import Path
+from typing import cast
+
+from .._protocol.session import (
+    SESSION_MAX_EPISODE_INDICES,
+    SESSION_PROTOCOL,
+)
+from .._version import __version__
+from ._socket import (
+    receive_session_message,
+    send_session_message,
+)
+
+_SESSION_SOCKET_VARIABLE = "EVOPOLICYGYM_SESSION_SOCKET"
+_WORKSPACE_VARIABLE = "EVOPOLICYGYM_WORKSPACE"
+_UNSIGNED_DECIMAL = re.compile(r"[0-9]+")
+_MAX_EPISODE_INDEX = 2**64 - 1
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = _parser()
+    namespace = parser.parse_args(arguments)
+    try:
+        request = _request(namespace)
+        response = _call_session(request)
+    except (OSError, RuntimeError, ValueError) as error:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": "client_error",
+                        "message": str(error),
+                    },
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+    serialized = json.dumps(
+        response,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if response.get("ok") is True:
+        print(serialized)
+        return 0
+    print(serialized, file=sys.stderr)
+    return 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="evopolicygym-session")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    submit = subcommands.add_parser(
+        "submit",
+        help="evaluate the fixed workspace Policy Program directory",
+    )
+    submit.add_argument(
+        "program",
+        help="must resolve to $EVOPOLICYGYM_WORKSPACE/program",
+    )
+    submit.add_argument(
+        "--episodes",
+        type=_parse_episode_selector,
+        required=True,
+        metavar="SELECTOR",
+        help='Run-local Episode indices, for example "0:2,4:8"',
+    )
+
+    finish = subcommands.add_parser(
+        "finish",
+        help="finish search with one or more published candidates",
+    )
+    finish.add_argument("submission_ids", nargs="+")
+    return parser
+
+
+def _request(namespace: argparse.Namespace) -> dict[str, object]:
+    if namespace.command == "submit":
+        workspace = _required_path(_WORKSPACE_VARIABLE)
+        expected = (workspace / "program").resolve(strict=True)
+        supplied = Path(cast(str, namespace.program)).resolve(strict=True)
+        if supplied != expected:
+            raise ValueError("submitted Program must be workspace/program")
+        return {
+            "protocol": SESSION_PROTOCOL,
+            "method": "submit",
+            "episode_indices": list(
+                cast(tuple[int, ...], namespace.episodes)
+            ),
+        }
+    if namespace.command == "finish":
+        return {
+            "protocol": SESSION_PROTOCOL,
+            "method": "finish",
+            "submission_ids": cast(list[str], namespace.submission_ids),
+        }
+    raise RuntimeError("unknown command")
+
+
+def _call_session(request: dict[str, object]) -> dict[str, object]:
+    socket_path = _required_path(_SESSION_SOCKET_VARIABLE)
+    connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        connection.connect(str(socket_path))
+        send_session_message(connection, request)
+        response = receive_session_message(connection)
+        if (
+            response.get("protocol") != SESSION_PROTOCOL
+            or type(response.get("ok")) is not bool
+        ):
+            raise ValueError("Session returned an invalid protocol response")
+        return response
+    finally:
+        connection.close()
+
+
+def _required_path(variable: str) -> Path:
+    raw = os.environ.get(variable)
+    if not raw:
+        raise RuntimeError(f"{variable} is not set; no Agent Session is active")
+    return Path(raw)
+
+
+def _parse_episode_selector(value: str) -> tuple[int, ...]:
+    if not value or any(character.isspace() for character in value):
+        raise argparse.ArgumentTypeError(
+            "Episode selector must not be empty or contain whitespace"
+        )
+    indices: list[int] = []
+    for item in value.split(","):
+        if not item:
+            raise argparse.ArgumentTypeError(
+                "Episode selector contains an empty item"
+            )
+        parts = item.split(":")
+        if len(parts) == 1:
+            index = _parse_unsigned(parts[0], endpoint=False)
+            _append_index(indices, index)
+            continue
+        if len(parts) != 2:
+            raise argparse.ArgumentTypeError(
+                "Episode ranges must use START:END"
+            )
+        start = _parse_unsigned(parts[0], endpoint=False)
+        end = _parse_unsigned(parts[1], endpoint=True)
+        if start >= end:
+            raise argparse.ArgumentTypeError(
+                "Episode ranges must be non-empty and increasing"
+            )
+        count = end - start
+        if count > SESSION_MAX_EPISODE_INDICES - len(indices):
+            raise argparse.ArgumentTypeError(
+                "Episode selector contains too many indices"
+            )
+        if indices and start <= indices[-1]:
+            raise argparse.ArgumentTypeError(
+                "Episode selector must be strictly increasing without overlap"
+            )
+        indices.extend(range(start, end))
+    if len(indices) > SESSION_MAX_EPISODE_INDICES:
+        raise argparse.ArgumentTypeError(
+            "Episode selector contains too many indices"
+        )
+    return tuple(indices)
+
+
+def _parse_unsigned(value: str, *, endpoint: bool) -> int:
+    if _UNSIGNED_DECIMAL.fullmatch(value) is None:
+        raise argparse.ArgumentTypeError(
+            "Episode indices must use unsigned decimal integers"
+        )
+    parsed = int(value)
+    limit = 2**64 if endpoint else _MAX_EPISODE_INDEX
+    if parsed > limit:
+        raise argparse.ArgumentTypeError(
+            "Episode index exceeds the unsigned 64-bit range"
+        )
+    return parsed
+
+
+def _append_index(indices: list[int], index: int) -> None:
+    if len(indices) == SESSION_MAX_EPISODE_INDICES:
+        raise argparse.ArgumentTypeError(
+            "Episode selector contains too many indices"
+        )
+    if indices and index <= indices[-1]:
+        raise argparse.ArgumentTypeError(
+            "Episode selector must be strictly increasing without overlap"
+        )
+    indices.append(index)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/evopolicygym/run/_task.py
+++ b/src/evopolicygym/run/_task.py
@@ -53,7 +53,7 @@ def build_agent_task(
         finish_guidance = """\
 When you have selected the best published submission, end the Run with:
 
-    evopolicygym finish SUBMISSION_ID
+    evopolicygym-session finish SUBMISSION_ID
 
 finish accepts exactly one published submission. A successful finish closes
 your authority; the Host selects that sole candidate only after your process
@@ -64,7 +64,7 @@ has exited.
 When you are ready to end search, pass an ordered set of one to
 {validation.max_candidates} published candidates:
 
-    evopolicygym finish SUBMISSION_ID [SUBMISSION_ID ...]
+    evopolicygym-session finish SUBMISSION_ID [SUBMISSION_ID ...]
 
 A successful finish closes your authority. Only after your process has exited,
 the Host evaluates every candidate on identical private Validation Episodes and
@@ -124,7 +124,7 @@ The Host publishes authorized evaluation data under:
 
 Do not modify feedback/. Evaluate the current Program with:
 
-    evopolicygym submit program --episodes "{_selector_example(pool_size)}"
+    evopolicygym-session submit program --episodes "{_selector_example(pool_size)}"
 
 The available Run-local training Episode indices are 0 through
 {pool_size - 1}. A singleton like "7" selects one index; START:END is a

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,28 @@
 from __future__ import annotations
 
 import argparse
+import io
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 
 from evopolicygym._protocol.session import SESSION_MAX_EPISODE_INDICES
-from evopolicygym.cli import _parse_episode_selector
+from evopolicygym.cli import main as operator_main
+from evopolicygym.run._session_cli import _parse_episode_selector
+
+
+class OperatorCommandTests(unittest.TestCase):
+    def test_operator_command_does_not_expose_agent_session_methods(self) -> None:
+        standard_output = io.StringIO()
+        with redirect_stdout(standard_output):
+            self.assertEqual(operator_main([]), 0)
+        self.assertIn("public Python SDK", standard_output.getvalue())
+
+        standard_error = io.StringIO()
+        with redirect_stderr(standard_error):
+            with self.assertRaises(SystemExit) as raised:
+                operator_main(["submit"])
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("unrecognized arguments: submit", standard_error.getvalue())
 
 
 class EpisodeSelectorTests(unittest.TestCase):

--- a/tests/test_codex_integration.py
+++ b/tests/test_codex_integration.py
@@ -178,7 +178,8 @@ description: Improve the example Policy.
         )
 
         self.assertIn(
-            "evopolicygym finish SUBMISSION_ID [SUBMISSION_ID ...]",
+            "evopolicygym-session finish "
+            "SUBMISSION_ID [SUBMISSION_ID ...]",
             task.instructions,
         )
         self.assertIn(

--- a/tests/test_environment_ci_coverage.py
+++ b/tests/test_environment_ci_coverage.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).parents[1]
+_ENVIRONMENTS = _ROOT / "environments"
+_CI_WORKFLOW = _ROOT / ".github" / "workflows" / "ci.yml"
+
+
+class EnvironmentCICoverageTests(unittest.TestCase):
+    def test_every_environment_distribution_is_named_by_ci(self) -> None:
+        projects = {
+            pyproject.parent.relative_to(_ROOT).as_posix()
+            for pyproject in _ENVIRONMENTS.rglob("pyproject.toml")
+            if ".venv" not in pyproject.parts
+            and "vendor" not in pyproject.parts
+        }
+        workflow = _CI_WORKFLOW.read_text(encoding="utf-8")
+
+        missing = tuple(
+            sorted(project for project in projects if project not in workflow)
+        )
+
+        self.assertEqual(missing, ())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_public_contract.py
+++ b/tests/test_public_contract.py
@@ -1040,7 +1040,12 @@ workspace = Path(os.environ["EVOPOLICYGYM_WORKSPACE"])
 
 def call(*arguments):
     completed = subprocess.run(
-        [sys.executable, "-m", "evopolicygym.cli", *arguments],
+        [
+            sys.executable,
+            "-m",
+            "evopolicygym.run._session_cli",
+            *arguments,
+        ],
         check=True,
         capture_output=True,
         text=True,
@@ -1344,7 +1349,7 @@ subprocess.run(
     [
         sys.executable,
         "-m",
-        "evopolicygym.cli",
+        "evopolicygym.run._session_cli",
         "submit",
         "program",
         "--episodes",
@@ -1467,7 +1472,7 @@ assert Path.cwd() == workspace
 assert os.environ["EVOPOLICYGYM_SESSION_SOCKET"] == os.path.join(
     "..", "control", "session.sock"
 )
-assert shutil.which("evopolicygym") is not None
+assert shutil.which("evopolicygym-session") is not None
 assert arguments[:5] == [
     "--ask-for-approval",
     "never",
@@ -1490,8 +1495,8 @@ prompt = arguments[-1]
 assert "program/" in prompt
 assert "feedback/" in prompt
 assert "skills/improve-counter/SKILL.md" in prompt
-assert 'evopolicygym submit program --episodes "0"' in prompt
-assert "evopolicygym finish SUBMISSION_ID" in prompt
+assert 'evopolicygym-session submit program --episodes "0"' in prompt
+assert "evopolicygym-session finish SUBMISSION_ID" in prompt
 assert os.environ["CODEX_API_KEY"] == {api_key!r}
 assert "EVOPOLICYGYM_TEST_SECRET" not in os.environ
 
@@ -1505,7 +1510,7 @@ assert (skill / "references" / "model.md").read_text() == "Count calls.\\n"
 
 def call(*arguments):
     completed = subprocess.run(
-        ["evopolicygym", *arguments],
+        ["evopolicygym-session", *arguments],
         check=True,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Purpose

Separate Host/operator CLI commands from Agent Session submission commands, and close first-party environment CI coverage gaps.

## Changes

- keep `evopolicygym` as the Host/operator entry point
- add `evopolicygym-session` for Agent-owned `submit` and `finish` commands while retaining the `agent-session/v3` protocol
- update task instructions, public docs, site docs, skills, and contract tests for the split
- cover all 57 independently installable first-party Benchmark distributions in CI
- add a repository test that discovers environment `pyproject.toml` files and fails when a distribution is absent from the CI workflow

## Validation

- `uv run python -m unittest discover -s tests` — 103 tests
- `uv run ruff check src tests`
- `uv run mypy`
- 205 tests across the 23 distributions newly added to CI
- Ruff and strict mypy across those 23 distributions
- representative wheel/sdist builds for Acrobot, Blackjack, BipedalWalker, Ant, and Balatro
- site build — 37 pages
- Kernel and CartPole lock checks; CartPole tests, Ruff, mypy, and build

## Security note

`ProcessExecution` remains explicitly unsafe for hostile code; this change does not present it as a sandbox or add a virtualization boundary.