### PR TITLE
site: link evopolicygym skill

### DIFF
--- a/site/src/content/docs/en/getting-started.md
+++ b/site/src/content/docs/en/getting-started.md
@@ -137,3 +137,4 @@ The actual seeds remain hidden.
 - [Read the Policy ABI →](../policy/)
 - [Understand Evaluation and Runs →](../evaluation/)
 - [Choose and configure an Environment →](../../environments/)
+- [Use the `$evopolicygym` Skill with an AI coding assistant →](https://github.com/Linzwcs/EvoPolicyGym/tree/main/skills/evopolicygym)

--- a/site/src/content/docs/zh/getting-started.md
+++ b/site/src/content/docs/zh/getting-started.md
@@ -126,3 +126,4 @@ evopolicygym-session submit program --episodes "0:2,4:8"
 - [阅读 Policy ABI →](../policy/)
 - [理解 Evaluation 与 Runs →](../evaluation/)
 - [选择并配置 Environment →](../../environments/)
+- [通过 AI Coding Assistant 使用 `$evopolicygym` Skill →](https://github.com/Linzwcs/EvoPolicyGym/tree/main/skills/evopolicygym)

--- a/site/src/pages/docs/index.astro
+++ b/site/src/pages/docs/index.astro
@@ -116,6 +116,10 @@ const toc = [
         <strong>Environments</strong>
         <small><Copy en="Independent Benchmark distributions." zh="独立 Benchmark distributions。" /></small>
       </a>
+      <a href="https://github.com/Linzwcs/EvoPolicyGym/tree/main/skills/evopolicygym" target="_blank" rel="noreferrer">
+        <strong>EvoPolicyGym Skill</strong>
+        <small><Copy en="Canonical $evopolicygym workflow guidance." zh="$evopolicygym 工作流指南的唯一事实来源。" /></small>
+      </a>
     </div>
   </section>
 </ReferenceLayout>


### PR DESCRIPTION
## Purpose

Expose the canonical `$evopolicygym` Skill from the public documentation site
without duplicating its maintained instructions into Site content.

## Changes

- add an EvoPolicyGym Skill source-of-truth card to the documentation landing
  page
- add the canonical Skill link to the English getting-started next steps
- add the same link to the Chinese getting-started next steps

All links point to `skills/evopolicygym` on the repository `main` branch.

## Validation

- synchronized dependencies from the latest Site lockfile
- `npm run build` — 37 static pages
- verified the generated documentation landing page and both localized
  getting-started sections contain the canonical link
- `git diff --check`
