### PR TITLE
site: stabilize docs sidebar navigation

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -92,7 +92,7 @@ const config: Config = {
     docs: {
       sidebar: {
         hideable: true,
-        autoCollapseCategories: true,
+        autoCollapseCategories: false,
       },
     },
     image: "og.png",

--- a/site/sidebars.ts
+++ b/site/sidebars.ts
@@ -6,16 +6,19 @@ const sidebars: SidebarsConfig = {
     {
       type: "category",
       label: "Start",
+      collapsed: false,
       items: ["getting-started", "concepts"],
     },
     {
       type: "category",
       label: "Core reference",
+      collapsed: false,
       items: ["policy", "evaluation", "runtime"],
     },
     {
       type: "category",
       label: "Extend",
+      collapsed: false,
       items: ["authoring"],
     },
   ],

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -3518,6 +3518,8 @@ body {
   border-right: 0.5px solid var(--epg-rule-strong) !important;
   background: var(--epg-page);
   box-shadow: none;
+  transition: none !important;
+  will-change: auto;
 }
 
 .theme-doc-sidebar-container .thin-scrollbar {


### PR DESCRIPTION
Summary

- Keep Docs sidebar categories expanded by default.
- Stop route changes from auto-collapsing the previous category.
- Remove the sidebar container width rebound transition.

Root cause

Docusaurus category auto-collapse and the sidebar width transition were both active during Docs navigation, producing a distracting reverse motion.

Validation

- npm run typecheck
- npm run build (English and zh-CN)