### PR TITLE
site: feature experiment replays on homepage

### DIFF
--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -765,7 +765,7 @@ body {
 .home-demo-grid {
   display: grid;
   overflow: hidden;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   border-left: 0.5px solid var(--epg-rule);
 }
 
@@ -793,11 +793,21 @@ body {
 .home-demo-tile img {
   display: block;
   width: 100%;
-  aspect-ratio: 4 / 3;
-  object-fit: cover;
+  aspect-ratio: 16 / 10;
+  object-fit: contain;
   border-bottom: 0.5px solid var(--epg-rule);
+  background: #10171c;
   filter: saturate(0.82) contrast(0.96);
   transition: filter 180ms ease;
+}
+
+.home-demo-tile--balatro img {
+  background: #f5f7f3;
+}
+
+.home-demo-tile--crafter img {
+  background: #080b09;
+  image-rendering: pixelated;
 }
 
 .home-demo-tile:hover img {
@@ -4761,7 +4771,7 @@ body {
   }
 
   .home-demo-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 1fr;
   }
 
   .home-notes {

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -3,7 +3,6 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 import Layout from "@theme/Layout";
 import {Localized} from "../components/Localized";
 import {paperMeta} from "../data/project";
-import {formatScore, showcase} from "../lib/showcase";
 
 const notes = [
   {
@@ -32,19 +31,44 @@ const notes = [
   },
 ];
 
+const featuredRuns = [
+  {
+    id: "balatro-sol",
+    kind: "balatro",
+    path: "/blog/balatro-policy-evolution/",
+    media: "images/blog/balatro-sol-winning-replay.gif",
+    titleEn: "Balatro",
+    titleZh: "小丑牌",
+    metaEn: "Sol final Policy · score 1021",
+    metaZh: "Sol 最终 Policy · 得分 1021",
+    alt: "Sol-authored Balatro Policy completing a held-out run with score 1021",
+  },
+  {
+    id: "crafter-deep-iron",
+    kind: "crafter",
+    path: "/environments/",
+    media: "images/home/crafter-deep-iron-combat.gif",
+    titleEn: "Crafter · Deep iron combat",
+    titleZh: "Crafter · 深层铁矿战斗",
+    metaEn: "Development submission 15 · Episode 10",
+    metaZh: "开发 Submission 15 · Episode 10",
+    alt: "Agent-authored Crafter Policy navigating a deep-iron combat development episode",
+  },
+  {
+    id: "nethack-sol",
+    kind: "nethack",
+    path: "/blog/nethack-policy-evolution/",
+    media: "images/blog/nle-sol-policy-training-replay.gif",
+    titleEn: "NetHack · Sol Policy",
+    titleZh: "NetHack · Sol Policy",
+    metaEn: "1,269 steps · dungeon depth 11",
+    metaZh: "1,269 steps · 地下城深度 11",
+    alt: "Sol-authored NetHack Policy completing a 1,269-step training episode at dungeon depth 11",
+  },
+];
+
 export default function HomePage() {
   const mediaBaseUrl = useBaseUrl("/");
-  const featuredClips = [
-    ["gpt_5_5", "minigrid_doorkey"],
-    ["claude_opus_4_7", "bipedal"],
-    ["deepseek_v4_pro", "parking"],
-    ["claude_opus_4_7", "fetch_push"],
-  ].flatMap(([modelSlug, environmentId]) => {
-    const clip = showcase.clips.find(
-      (candidate) => candidate.model_slug === modelSlug && candidate.env_id === environmentId,
-    );
-    return clip ? [clip] : [];
-  });
 
   return (
     <Layout
@@ -87,20 +111,22 @@ export default function HomePage() {
 
           <div className="home-hero-demo">
             <div className="home-demo-grid">
-              {featuredClips.map((clip) => (
+              {featuredRuns.map((run, index) => (
                 <Link
-                  key={clip.id}
-                  className="home-demo-tile"
-                  to={`/results/environments/${clip.env_id}/`}
-                  aria-label={`Open the ${clip.env_display} held-out rerun record`}
+                  key={run.id}
+                  className={`home-demo-tile home-demo-tile--${run.kind}`}
+                  to={run.path}
+                  aria-label={`Open the ${run.titleEn} experiment record`}
                 >
                   <img
-                    src={`${mediaBaseUrl}${clip.media}`}
-                    alt={`${clip.model_display}-authored Policy running in the ${clip.env_display} environment`}
+                    src={`${mediaBaseUrl}${run.media}`}
+                    alt={run.alt}
+                    loading={index === 0 ? "eager" : "lazy"}
+                    decoding="async"
                   />
                   <span>
-                    <strong>{clip.env_display}</strong>
-                    <small>{clip.model_display} · {formatScore(clip.score)}</small>
+                    <strong><Localized en={run.titleEn} zh={run.titleZh} /></strong>
+                    <small><Localized en={run.metaEn} zh={run.metaZh} /></small>
                   </span>
                 </Link>
               ))}
@@ -108,12 +134,12 @@ export default function HomePage() {
             <div className="home-demo-caption">
               <span>
                 <Localized
-                  en="Four selected Policies · original-Environment reruns"
-                  zh="四个选中 Policy · 原始 Environment 重跑"
+                  en="Three autonomous Policies · real experiment replays"
+                  zh="三个自主 Policy · 真实实验回放"
                 />
               </span>
-              <Link to="/results/core16/">
-                <Localized en="Open archive" zh="打开档案" /> →
+              <Link to="/blog/">
+                <Localized en="Open experiments" zh="查看实验" /> →
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## What changed

- replace the four generated showcase tiles on the homepage with three real experiment replays
- feature Balatro, Crafter deep-iron combat, and NetHack Sol results
- add responsive three-column presentation and media-specific rendering

## Why

The homepage should foreground recognizable experiment evidence and connect visitors directly to the corresponding research records.

## Impact

The homepage now presents three real Policy replays with localized captions and direct experiment links. No runtime or benchmark behavior changes.

## Validation

- `npm run typecheck`
- `npm run build` (English and zh-CN)
- `git diff --check`
