### PR TITLE
site: generate environment domains from catalog

### DIFF
--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -2337,40 +2337,139 @@ body {
 }
 
 .environment-catalog-page .environment-domain-summary {
-  padding: 32px var(--epg-sheet-padding) 38px;
+  padding: 38px var(--epg-sheet-padding) 44px;
   border-bottom: 1px solid var(--epg-rule-strong);
 }
 
 .environment-catalog-page .environment-domain-summary > header {
-  margin-bottom: 14px;
+  display: grid;
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.7fr);
+  gap: 32px;
+  align-items: end;
+  border-bottom: 1px solid var(--epg-rule-strong);
+}
+
+.environment-catalog-page .environment-domain-summary > header h2 {
+  margin: 0;
+  color: var(--epg-ink);
+  font-family: var(--font-sans);
+  font-size: 1.375rem;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+  text-transform: none;
+}
+
+.environment-catalog-page .environment-domain-summary > header p {
+  max-width: 300px;
+  margin: 0;
+  justify-self: end;
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-ui);
+  letter-spacing: 0;
+  line-height: 1.5;
+  text-align: right;
 }
 
 .environment-catalog-page .environment-domain-grid {
-  gap: 0;
-  border: 1px solid var(--epg-rule-strong);
-  background: transparent;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1px;
+  border: 0;
+  border-block: 1px solid var(--epg-rule-strong);
+  background: var(--epg-rule);
 }
 
 .environment-catalog-page .environment-domain-grid article {
-  padding: 17px 18px;
-  border-right: 1px solid var(--epg-rule);
-  background: transparent;
+  min-height: 250px;
+  padding: 24px 22px 20px;
+  border-right: 0;
+  background: var(--epg-sheet);
 }
 
 .environment-catalog-page .environment-domain-grid article:last-child {
   border-right: 0;
 }
 
-.environment-catalog-page .environment-domain-title h3 {
-  font-size: 0.98rem;
-  font-weight: 500;
+.environment-catalog-page .environment-domain-title {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.environment-catalog-page .environment-domain-title > span {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid var(--epg-accent-rule);
+  background: var(--epg-accent-soft);
+  color: var(--epg-accent-dark);
+  font-size: var(--font-size-micro);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.02em;
+  line-height: 1;
+}
+
+.environment-catalog-page
+  .environment-domain-grid
+  .environment-domain-title
+  h3 {
+  margin: 3px 0 0;
+  font-size: 1.0625rem;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: -0.012em;
+  line-height: 1.35;
 }
 
 .environment-catalog-page .environment-domain-grid article > p {
-  margin-top: 9px;
+  margin: 16px 0 24px 42px;
   color: var(--epg-prose);
-  font-size: 12px;
-  line-height: 1.58;
+  font-size: 0.9375rem;
+  line-height: 1.62;
+}
+
+.environment-catalog-page .environment-domain-grid dl {
+  display: grid;
+  margin: 0 0 0 42px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  border-top: 1px solid var(--epg-rule);
+}
+
+.environment-catalog-page .environment-domain-grid dl > div {
+  display: grid;
+  padding: 11px 10px 0 0;
+  align-content: start;
+  gap: 4px;
+}
+
+.environment-catalog-page .environment-domain-grid dl > div + div {
+  padding-right: 0;
+  padding-left: 12px;
+  border-left: 1px solid var(--epg-rule);
+}
+
+.environment-catalog-page .environment-domain-grid dt {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-micro);
+  font-weight: var(--font-weight-regular);
+  letter-spacing: 0.01em;
+  line-height: 1.35;
+  text-transform: none;
+}
+
+.environment-catalog-page .environment-domain-grid dd {
+  color: var(--color-text-primary);
+  font-family: var(--font-sans);
+  font-size: 1.125rem;
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
 }
 
 .environment-catalog-page .environment-catalog-list {
@@ -4897,9 +4996,28 @@ body {
     padding: 28px 24px 32px;
   }
 
+  .environment-catalog-page .environment-domain-summary > header {
+    padding-bottom: 14px;
+    grid-template-columns: 1fr;
+    gap: 7px;
+    align-items: start;
+  }
+
+  .environment-catalog-page .environment-domain-summary > header p {
+    max-width: none;
+    justify-self: start;
+    text-align: left;
+  }
+
+  .environment-catalog-page .environment-domain-grid {
+    grid-template-columns: 1fr;
+  }
+
   .environment-catalog-page .environment-domain-grid article {
+    min-height: 0;
+    padding: 22px 0 20px;
     border-right: 0;
-    border-bottom: 1px solid var(--epg-rule);
+    border-bottom: 0;
   }
 
   .environment-catalog-page .environment-domain-grid article:last-child {

--- a/site/src/data/environmentCatalog.ts
+++ b/site/src/data/environmentCatalog.ts
@@ -1,5 +1,3 @@
-export type EnvironmentDomain = "control" | "planning" | "games";
-
 export interface LocalizedText {
   en: string;
   zh: string;
@@ -12,7 +10,7 @@ export interface EnvironmentItem {
 
 export interface EnvironmentCollection {
   id: string;
-  domain: EnvironmentDomain;
+  domain: string;
   ecosystem: string;
   suite: string;
   distributions: number;
@@ -27,37 +25,23 @@ export interface EnvironmentCollection {
 }
 
 export interface EnvironmentDomainGroup {
-  id: EnvironmentDomain;
+  id: string;
   title: LocalizedText;
-  summary: LocalizedText;
 }
 
-export const environmentDomains: EnvironmentDomainGroup[] = [
-  {
-    id: "control",
-    title: { en: "Control and robotics", zh: "控制与机器人" },
-    summary: {
-      en: "Compact control, physics, locomotion, manipulation, and multi-task robotics.",
-      zh: "紧凑控制、物理、运动、操作与多任务机器人。",
-    },
-  },
-  {
-    id: "planning",
-    title: { en: "Navigation and planning", zh: "导航与规划" },
-    summary: {
-      en: "Discrete planning, partial observability, memory, procedural layouts, and language-conditioned tasks.",
-      zh: "离散规划、部分可观测、记忆、程序化地图与语言条件任务。",
-    },
-  },
-  {
-    id: "games",
-    title: { en: "Interactive simulation and games", zh: "交互模拟与游戏" },
-    summary: {
-      en: "Driving, first-person control, arcade games, and long-horizon strategic play.",
-      zh: "驾驶、第一人称控制、街机游戏与长时程策略游戏。",
-    },
-  },
-];
+const environmentDomainTitles: Readonly<Record<string, LocalizedText>> = {
+  control: { en: "Control and robotics", zh: "控制与机器人" },
+  planning: { en: "Navigation and planning", zh: "导航与规划" },
+  games: { en: "Interactive simulation and games", zh: "交互模拟与游戏" },
+};
+
+function humanizeDomainId(domainId: string): string {
+  return domainId
+    .split(/[-_]/u)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
 
 export const environmentCollections: EnvironmentCollection[] = [
   {
@@ -615,6 +599,20 @@ export const environmentCollections: EnvironmentCollection[] = [
     items: [{ name: "Red Deck · White Stake" }],
   },
 ];
+
+export const environmentDomains: EnvironmentDomainGroup[] = Array.from(
+  new Set(environmentCollections.map((collection) => collection.domain)),
+  (domainId) => {
+    const fallbackTitle = humanizeDomainId(domainId);
+    return {
+      id: domainId,
+      title: environmentDomainTitles[domainId] ?? {
+        en: fallbackTitle,
+        zh: fallbackTitle,
+      },
+    };
+  },
+);
 
 export const environmentDistributionCount = environmentCollections.reduce(
   (total, collection) => total + collection.distributions,

--- a/site/src/pages/environments/index.tsx
+++ b/site/src/pages/environments/index.tsx
@@ -18,6 +18,9 @@ export default function EnvironmentCatalogPage() {
       return {
         ...domain,
         collectionCount: collections.length,
+        ecosystems: Array.from(
+          new Set(collections.map((collection) => collection.ecosystem)),
+        ).sort((left, right) => left.localeCompare(right)),
         taskProfileCount: collections.reduce(
           (total, collection) => total + collection.taskProfiles,
           0,
@@ -80,7 +83,7 @@ export default function EnvironmentCatalogPage() {
                 <span>{String(index + 1).padStart(2, "0")}</span>
                 <h3>{pickLocalized(language, domain.title)}</h3>
               </div>
-              <p>{pickLocalized(language, domain.summary)}</p>
+              <p>{domain.ecosystems.join(" · ")}</p>
               <dl>
                 <div>
                   <dt><Localized en="Collections" zh="Collections" /></dt>


### PR DESCRIPTION
## What changed

- derive the Domain inventory from the environment catalog instead of a fixed page list
- aggregate ecosystems, collection counts, and task-profile counts from matching environment records
- add readable fallback titles for newly introduced Domain identifiers
- refine the Domain section hierarchy and make its grid adapt to any number of categories

## Why

The previous section duplicated the catalog taxonomy in a fixed array. Adding a new Domain required editing both the environment data and the page configuration.

## Impact

New Domain identifiers now appear automatically when environment collections reference them. Existing localized titles remain presentation metadata, while membership and statistics come from the catalog.

## Validation

- `npm run typecheck`
- `npm run build` (English and zh-CN)
- `git diff --check`
