### PR TITLE
agents: add Claude Code and Kimi Code

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,7 +53,9 @@ evopolicygym/
 │
 ├── agents/                     Coding Agent providers
 │   ├── base.py                 Agent contract and shared command helpers
-│   └── codex.py                Codex selection and CLI translation
+│   ├── claude_code.py          Claude Code selection and CLI translation
+│   ├── codex.py                Codex selection and CLI translation
+│   └── kimi_code.py            Kimi Code selection and CLI translation
 │
 ├── evaluation/                 complete direct-Evaluation use case
 │   ├── __init__.py             EvaluationConfig and evaluate()
@@ -230,7 +232,7 @@ The rules are:
 - `evaluation/_service.py` reports only sanitized Episode completion through a
   narrow callback and performs no terminal or file I/O;
 - `execution/process` owns only generic process mechanisms and never imports a
-  Codex, Claude, or other provider integration;
+  Codex, Claude Code, Kimi Code, or other provider integration;
 - `agents.base.CodingAgent` is the supported structural integration template:
   the Host supplies an `AgentTask`, and the provider returns a validated
   `AgentInvocation`;

--- a/README.md
+++ b/README.md
@@ -161,6 +161,23 @@ one.
 
 ## Run a coding agent
 
+First-party command-line integrations are available for Codex, Claude Code,
+and Kimi Code:
+
+```python
+from evopolicygym.agents import ClaudeCode, Codex, KimiCode
+
+codex = Codex(model="gpt-5.6-luna", reasoning_effort="high")
+claude = ClaudeCode(model="sonnet", effort="high")
+kimi = KimiCode(model="kimi-code/kimi-for-coding")
+```
+
+Each selection translates the same Host-owned task into a non-interactive CLI
+invocation; the Run protocol and process supervision remain provider-neutral.
+Authenticate the selected CLI before starting a Run. For Kimi Code, set
+`KIMI_CODE_HOME` to a caller-owned isolated directory when retained CLI
+configuration and session history must not share state with other Runs.
+
 After authenticating the Codex CLI, start a small budgeted CartPole Run:
 
 ```console

--- a/site/docs/runs.md
+++ b/site/docs/runs.md
@@ -37,6 +37,21 @@ result = run(
 )
 ```
 
+The same Run can select either of the other first-party command-line
+integrations without changing the Benchmark or Run configuration:
+
+```python
+from evopolicygym.agents import ClaudeCode, KimiCode
+
+claude = ClaudeCode(model="sonnet", effort="high")
+kimi = KimiCode(model="kimi-code/kimi-for-coding")
+```
+
+All three providers run non-interactively and retain their structured stdout
+as Agent evidence. Claude Code runs in bare mode without session persistence.
+Kimi Code currently persists CLI state, so set `KIMI_CODE_HOME` to a dedicated
+caller-owned directory when Runs must not share its configuration or history.
+
 The Host creates the Episode pool before the Agent starts. The Agent can edit
 `workspace/program/`, submit candidates, read committed Feedback, and finish
 with published candidates.

--- a/site/docs/runtime.md
+++ b/site/docs/runtime.md
@@ -49,8 +49,9 @@ Policy state and scratch never intentionally cross Episode boundaries.
 - adversarial execution of third-party Agent or Policy code;
 - bit-for-bit determinism for arbitrary Python Programs.
 
-The Agent process is also local and unisolated. In the current Codex
-integration it has the authority of the current operating-system user.
+The Agent process is also local and unisolated. Codex, Claude Code, Kimi Code,
+and custom command integrations have the authority of the current
+operating-system user.
 
 ## Failure domains
 

--- a/site/i18n/zh-CN/docusaurus-plugin-content-docs/current/runs.md
+++ b/site/i18n/zh-CN/docusaurus-plugin-content-docs/current/runs.md
@@ -37,6 +37,19 @@ result = run(
 )
 ```
 
+无需修改 Benchmark 或 Run 配置，也可以选择另外两个第一方命令行集成：
+
+```python
+from evopolicygym.agents import ClaudeCode, KimiCode
+
+claude = ClaudeCode(model="sonnet", effort="high")
+kimi = KimiCode(model="kimi-code/kimi-for-coding")
+```
+
+三个 provider 都以非交互方式运行，并将结构化 stdout 保留为 Agent 证据。
+Claude Code 使用 bare 模式且不持久化 session。Kimi Code 当前会持久化 CLI 状态；
+如果 Run 之间不能共享其配置或历史，请将 `KIMI_CODE_HOME` 指向调用者管理的独立目录。
+
 Host 在 Agent 启动前创建 Episode 池。Agent 可以修改 `workspace/program/`、提交
 候选、读取已发布 Feedback，并以已发布候选结束 Run。
 

--- a/site/i18n/zh-CN/docusaurus-plugin-content-docs/current/runtime.md
+++ b/site/i18n/zh-CN/docusaurus-plugin-content-docs/current/runtime.md
@@ -48,8 +48,8 @@ Policy 状态与 scratch 不会被有意带入其他 Episode。
 - 第三方 Agent 或 Policy 代码的对抗性执行；
 - 任意 Python Program 的 bit-for-bit 确定性。
 
-Agent 进程同样在本地运行且没有隔离。当前 Codex integration 具有当前操作系统
-用户的权限。
+Agent 进程同样在本地运行且没有隔离。Codex、Claude Code、Kimi Code 和自定义
+command integration 都具有当前操作系统用户的权限。
 
 ## 故障域
 

--- a/skills/evopolicygym/references/providers.md
+++ b/skills/evopolicygym/references/providers.md
@@ -3,6 +3,13 @@
 Integrate another command-line Coding Agent through the public structural
 `CodingAgent` contract.
 
+The Kernel includes first-party `Codex`, `ClaudeCode`, and `KimiCode`
+translations. They all retain the unchanged Host task and use the same generic
+process runner. `ClaudeCode` selects bare, non-persistent print mode. Kimi Code
+does not currently expose an equivalent no-session-persistence flag, so callers
+that require isolated CLI configuration and session history should set a
+dedicated `KIMI_CODE_HOME` before the Run.
+
 Translate the Host-owned `AgentTask` into an `AgentInvocation`. Do not author
 Run instructions, duplicate Agent Session syntax, or move process supervision
 into the provider.

--- a/src/evopolicygym/agents/__init__.py
+++ b/src/evopolicygym/agents/__init__.py
@@ -11,13 +11,17 @@ from .base import (
     command_invocation,
     resolve_executable,
 )
+from .claude_code import ClaudeCode
 from .codex import Codex
+from .kimi_code import KimiCode
 
 __all__ = [
     "AgentInvocation",
     "AgentTask",
     "CodingAgent",
+    "ClaudeCode",
     "Codex",
+    "KimiCode",
     "command_invocation",
     "resolve_executable",
 ]

--- a/src/evopolicygym/agents/claude_code.py
+++ b/src/evopolicygym/agents/claude_code.py
@@ -1,0 +1,105 @@
+"""Public caller-owned Claude Code Agent selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import AgentInvocation, AgentTask, resolve_executable
+
+_CLAUDE_CODE_ENVIRONMENT_ALLOWLIST = (
+    "HOME",
+    "CLAUDE_CONFIG_DIR",
+    "CLAUDE_CODE_TMPDIR",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ClaudeCode:
+    """Select the Claude Code model, effort, and CLI used by a Run."""
+
+    model: str
+    effort: str
+    executable: str = "claude"
+
+    def __post_init__(self) -> None:
+        _validate_identifier(self.model, name="model", max_bytes=128)
+        _validate_identifier(self.effort, name="effort", max_bytes=64)
+        _validate_executable(self.executable)
+
+    def build_invocation(self, task: AgentTask) -> AgentInvocation:
+        """Translate one Host-authored task into a Claude Code invocation."""
+
+        if type(task) is not AgentTask:
+            raise TypeError("task must be AgentTask")
+        resolved_executable = resolve_executable(self.executable)
+        command_prefix = (
+            resolved_executable,
+            "--print",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--model",
+            self.model,
+            "--effort",
+            self.effort,
+            "--permission-mode",
+            "bypassPermissions",
+            "--no-session-persistence",
+            "--no-chrome",
+            "--bare",
+            "--strict-mcp-config",
+        )
+        return AgentInvocation(
+            command=(*command_prefix, task.instructions),
+            recorded_command=(*command_prefix, "@agent/instructions.md"),
+            identity={
+                "provider": "claude-code",
+                "model": self.model,
+                "effort": self.effort,
+            },
+            instructions=task.instructions,
+            inherited_environment=_CLAUDE_CODE_ENVIRONMENT_ALLOWLIST,
+            stdout_media_type="application/x-ndjson",
+        )
+
+
+def _validate_identifier(value: str, *, name: str, max_bytes: int) -> None:
+    if (
+        type(value) is not str
+        or not value
+        or len(value.encode("utf-8", errors="strict")) > max_bytes
+        or any(character.isspace() for character in value)
+        or "\0" in value
+    ):
+        raise ValueError(f"{name} must be a non-empty bounded identifier")
+
+
+def _validate_executable(value: str) -> None:
+    if (
+        type(value) is not str
+        or not value
+        or len(value.encode("utf-8", errors="strict")) > 4_096
+        or "\0" in value
+        or "\r" in value
+        or "\n" in value
+    ):
+        raise ValueError("executable must be a bounded command or path")
+
+
+__all__ = ["ClaudeCode"]

--- a/src/evopolicygym/agents/kimi_code.py
+++ b/src/evopolicygym/agents/kimi_code.py
@@ -1,0 +1,85 @@
+"""Public caller-owned Kimi Code Agent selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import AgentInvocation, AgentTask, resolve_executable
+
+_KIMI_CODE_ENVIRONMENT_ALLOWLIST = (
+    "HOME",
+    "KIMI_CODE_HOME",
+    "KIMI_CODE_OAUTH_HOST",
+    "KIMI_OAUTH_HOST",
+    "KIMI_CODE_BASE_URL",
+    "KIMI_DISABLE_TELEMETRY",
+    "KIMI_CODE_NO_AUTO_UPDATE",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class KimiCode:
+    """Select the Kimi Code model and CLI used by a Run."""
+
+    model: str
+    executable: str = "kimi"
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.model) is not str
+            or not self.model
+            or len(self.model.encode("utf-8", errors="strict")) > 128
+            or any(character.isspace() for character in self.model)
+            or "\0" in self.model
+        ):
+            raise ValueError("model must be a non-empty bounded identifier")
+        if (
+            type(self.executable) is not str
+            or not self.executable
+            or len(self.executable.encode("utf-8", errors="strict")) > 4_096
+            or "\0" in self.executable
+            or "\r" in self.executable
+            or "\n" in self.executable
+        ):
+            raise ValueError("executable must be a bounded command or path")
+
+    def build_invocation(self, task: AgentTask) -> AgentInvocation:
+        """Translate one Host-authored task into a Kimi Code invocation."""
+
+        if type(task) is not AgentTask:
+            raise TypeError("task must be AgentTask")
+        resolved_executable = resolve_executable(self.executable)
+        command_prefix = (
+            resolved_executable,
+            "--model",
+            self.model,
+            "--output-format",
+            "stream-json",
+            "--prompt",
+        )
+        return AgentInvocation(
+            command=(*command_prefix, task.instructions),
+            recorded_command=(*command_prefix, "@agent/instructions.md"),
+            identity={
+                "provider": "kimi-code",
+                "model": self.model,
+            },
+            instructions=task.instructions,
+            inherited_environment=_KIMI_CODE_ENVIRONMENT_ALLOWLIST,
+            stdout_media_type="application/x-ndjson",
+        )
+
+
+__all__ = ["KimiCode"]

--- a/tests/test_cli_agent_integrations.py
+++ b/tests/test_cli_agent_integrations.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from evopolicygym.agents import (
+    AgentTask,
+    ClaudeCode,
+    CodingAgent,
+    KimiCode,
+)
+from evopolicygym.authoring import BenchmarkSpec
+from evopolicygym.run import RunConfig
+from evopolicygym.run._task import build_agent_task
+
+
+def _task() -> AgentTask:
+    return build_agent_task(
+        BenchmarkSpec(
+            id="example/cli-agent-v1",
+            description="Command-line Agent integration fixture.",
+            observation_space={"shape": [4]},
+            action_space={"enum": [0, 1]},
+            metadata={},
+            max_episode_steps=10,
+            primary_metric="reward",
+            score_direction="maximize",
+        ),
+        RunConfig(episode_budget=7),
+    )
+
+
+def _executable(directory: str, name: str) -> Path:
+    executable = Path(directory) / name
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o700)
+    return executable
+
+
+class ClaudeCodeIntegrationTests(unittest.TestCase):
+    def test_selection_becomes_a_bare_non_persistent_invocation(self) -> None:
+        task = _task()
+        with tempfile.TemporaryDirectory() as temporary:
+            executable = _executable(temporary, "claude")
+            invocation = ClaudeCode(
+                model="sonnet",
+                effort="high",
+                executable=str(executable),
+            ).build_invocation(task)
+
+        self.assertIsInstance(
+            ClaudeCode(model="sonnet", effort="medium"),
+            CodingAgent,
+        )
+        self.assertEqual(invocation.instructions, task.instructions)
+        self.assertEqual(invocation.identity["provider"], "claude-code")
+        self.assertEqual(invocation.identity["model"], "sonnet")
+        self.assertEqual(invocation.identity["effort"], "high")
+        self.assertEqual(invocation.stdout_media_type, "application/x-ndjson")
+        self.assertIn("--print", invocation.command)
+        self.assertIn("--verbose", invocation.command)
+        self.assertIn("--bare", invocation.command)
+        self.assertIn("--strict-mcp-config", invocation.command)
+        self.assertIn("--no-session-persistence", invocation.command)
+        self.assertEqual(
+            invocation.command[
+                invocation.command.index("--permission-mode") + 1
+            ],
+            "bypassPermissions",
+        )
+        self.assertEqual(
+            invocation.recorded_command[-1],
+            "@agent/instructions.md",
+        )
+        self.assertNotIn(task.instructions, invocation.recorded_command)
+        self.assertIn("ANTHROPIC_API_KEY", invocation.inherited_environment)
+        self.assertIn(
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            invocation.inherited_environment,
+        )
+        self.assertIn("CLAUDE_CONFIG_DIR", invocation.inherited_environment)
+
+    def test_rejects_invalid_selections_and_tasks(self) -> None:
+        for invalid in ("", "extra high", "high\n", "x" * 129):
+            with self.subTest(model=invalid):
+                with self.assertRaisesRegex(ValueError, "model"):
+                    ClaudeCode(model=invalid, effort="high")
+        for invalid in ("", "extra high", "high\n", "x" * 65):
+            with self.subTest(effort=invalid):
+                with self.assertRaisesRegex(ValueError, "effort"):
+                    ClaudeCode(model="sonnet", effort=invalid)
+        with self.assertRaisesRegex(TypeError, "task must be AgentTask"):
+            ClaudeCode(model="sonnet", effort="high").build_invocation(
+                object()  # type: ignore[arg-type]
+            )
+
+
+class KimiCodeIntegrationTests(unittest.TestCase):
+    def test_selection_becomes_a_non_interactive_stream_invocation(self) -> None:
+        task = _task()
+        with tempfile.TemporaryDirectory() as temporary:
+            executable = _executable(temporary, "kimi")
+            invocation = KimiCode(
+                model="kimi-code/kimi-for-coding",
+                executable=str(executable),
+            ).build_invocation(task)
+
+        self.assertIsInstance(
+            KimiCode(model="kimi-code/kimi-for-coding"),
+            CodingAgent,
+        )
+        self.assertEqual(invocation.instructions, task.instructions)
+        self.assertEqual(invocation.identity["provider"], "kimi-code")
+        self.assertEqual(
+            invocation.identity["model"],
+            "kimi-code/kimi-for-coding",
+        )
+        self.assertEqual(invocation.stdout_media_type, "application/x-ndjson")
+        self.assertEqual(
+            invocation.command[
+                invocation.command.index("--output-format") + 1
+            ],
+            "stream-json",
+        )
+        self.assertEqual(invocation.command[-2], "--prompt")
+        self.assertEqual(invocation.command[-1], task.instructions)
+        self.assertEqual(
+            invocation.recorded_command[-1],
+            "@agent/instructions.md",
+        )
+        self.assertNotIn(task.instructions, invocation.recorded_command)
+        self.assertIn("KIMI_CODE_HOME", invocation.inherited_environment)
+        self.assertNotIn(
+            "KIMI_MODEL_THINKING_EFFORT",
+            invocation.inherited_environment,
+        )
+        self.assertNotIn("KIMI_API_KEY", invocation.inherited_environment)
+
+    def test_rejects_invalid_selections_and_tasks(self) -> None:
+        for invalid in ("", "two models", "model\n", "x" * 129):
+            with self.subTest(model=invalid):
+                with self.assertRaisesRegex(ValueError, "model"):
+                    KimiCode(model=invalid)
+        with self.assertRaisesRegex(TypeError, "task must be AgentTask"):
+            KimiCode(model="kimi-code/kimi-for-coding").build_invocation(
+                object()  # type: ignore[arg-type]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -87,7 +87,9 @@ assert not any(name in sys.modules for name in forbidden)
         }
         script = """\
 import sys
+from evopolicygym.agents.claude_code import ClaudeCode
 from evopolicygym.agents.codex import Codex
+from evopolicygym.agents.kimi_code import KimiCode
 from evopolicygym.evaluation import EvaluationConfig
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import (
@@ -107,7 +109,9 @@ assert ValidationConfig.__module__ == "evopolicygym.run"
 assert ConsoleProgress.__module__ == "evopolicygym.run.progress"
 assert RunEvent.__module__ == "evopolicygym.run.progress"
 assert RunObserver.__module__ == "evopolicygym.run.progress"
+assert ClaudeCode.__module__ == "evopolicygym.agents.claude_code"
 assert Codex.__module__ == "evopolicygym.agents.codex"
+assert KimiCode.__module__ == "evopolicygym.agents.kimi_code"
 assert AgentSkill.__module__ == "evopolicygym.skills"
 assert ProcessExecution.__module__ == "evopolicygym.execution"
 


### PR DESCRIPTION
## Summary

- add first-party Claude Code and Kimi Code command-line Agent selections
- preserve the Host-owned task, generic process runner, and existing Run protocol
- retain structured JSONL Agent output and narrow provider authentication environments
- document provider selection and Kimi Code session-isolation requirements in English and Chinese

## Limitations

- ProcessExecution remains explicitly unsafe and provides no sandbox
- Kimi Code currently persists CLI state; callers should use an isolated KIMI_CODE_HOME when Runs must not share configuration or history
- ZCode is not included because it has no supported headless CLI contract

## Validation

- Ruff over src and tests
- strict MyPy over 79 source files
- 121 Kernel unit tests
- Docusaurus production build for English and Chinese