### PR TITLE
ci: use EGL for HalfCheetah rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,8 @@ jobs:
         include:
           - project: environments/dm_control/control_suite
             mujoco_gl: egl
+          - project: environments/gymnasium/mujoco/half_cheetah
+            mujoco_gl: egl
           - project: environments/gymnasium_robotics/robotics
             mujoco_gl: egl
           - project: environments/metaworld/metaworld

--- a/tests/test_environment_ci_coverage.py
+++ b/tests/test_environment_ci_coverage.py
@@ -24,6 +24,23 @@ class EnvironmentCICoverageTests(unittest.TestCase):
 
         self.assertEqual(missing, ())
 
+    def test_headless_mujoco_renderers_use_egl(self) -> None:
+        workflow = _CI_WORKFLOW.read_text(encoding="utf-8")
+        projects = (
+            "environments/dm_control/control_suite",
+            "environments/gymnasium/mujoco/half_cheetah",
+            "environments/gymnasium_robotics/robotics",
+            "environments/metaworld/metaworld",
+            "environments/robosuite/robosuite",
+        )
+
+        for project in projects:
+            with self.subTest(project=project):
+                self.assertIn(
+                    f"- project: {project}\n            mujoco_gl: egl",
+                    workflow,
+                )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- run the HalfCheetah Benchmark job with the Linux headless MuJoCo EGL backend
- install the existing EGL runtime for that matrix entry
- add a Kernel regression test covering every CI project that requires EGL

## Root cause

The Ubuntu runner used the matrix default `MUJOCO_GL=glfw`. HalfCheetah now captures real rendered feedback, so its test initialized GLFW without `DISPLAY` and aborted with exit 134.

## Validation

- HalfCheetah: ruff, strict mypy, 12 unit tests, wheel/sdist build
- Kernel: ruff, strict mypy, 122 unit tests