### PR TITLE
docs: invite coding-agent contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,20 @@
 # Contributing
 
+Contributions of all sizes are welcome, including new interactive environment
+integrations, Kernel improvements, documentation, tests, and representative
+test data.
+
+## Contribute with coding agents
+
+We recommend using a coding agent to contribute to EvoPolicyGym. Claude Code
+and Codex can use the repository's
+[`evopolicygym` Agent Skill](skills/evopolicygym/) for project-specific
+guidance on Benchmark authoring, provider integration, Run diagnostics, and
+Kernel development. Ask the agent to read the Skill and the repository
+instructions before it starts making changes.
+
+## Development setup
+
 EvoPolicyGym requires Python 3.12 and uses `uv`.
 
 ```console
@@ -8,6 +23,8 @@ uv run ruff check src tests
 uv run mypy
 uv run python -m unittest discover -s tests
 ```
+
+## Project boundaries
 
 The supported package lives under `src/evopolicygym/`. External Benchmark
 distributions integrate only through `evopolicygym.authoring`; the active
@@ -21,3 +38,9 @@ and do not add compatibility namespaces for removed implementations.
 
 `ProcessExecution` is intentionally unsafe for hostile code. Changes involving
 runtime semantics must test typed failure behavior and cleanup paths.
+
+## Contact
+
+To propose an environment integration, coordinate a larger change, or ask
+where to start, open a GitHub issue or email
+[zhilin.nlp@gmail.com](mailto:zhilin.nlp@gmail.com).

--- a/README.md
+++ b/README.md
@@ -270,6 +270,30 @@ Use `check_benchmark()` before distribution. See the
 the [CartPole](environments/gymnasium/classic_control/cartpole/) or
 [FrozenLake](environments/gymnasium/toy_text/frozen_lake/) packages.
 
+## Join us
+
+Contributions of all sizes are welcome. Areas where help is especially
+valuable include integrating new interactive environments, improving the
+Kernel, clarifying and extending the documentation, and expanding test
+coverage and representative test data.
+
+### Contribute with coding agents
+
+We recommend using a coding agent to contribute to EvoPolicyGym. Claude Code
+and Codex can use the repository's
+[`evopolicygym` Agent Skill](skills/evopolicygym/) for project-specific
+guidance on Benchmark authoring, provider integration, Run diagnostics, and
+Kernel development. Ask the agent to read the Skill before it starts making
+changes.
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+
+### Contact
+
+To propose an environment integration, coordinate a larger change, or ask
+where to start, open a GitHub issue or email
+[zhilin.nlp@gmail.com](mailto:zhilin.nlp@gmail.com).
+
 ## Development
 
 ```console


### PR DESCRIPTION
## Summary

- add a welcoming contribution entry to the README
- recommend using Claude Code or Codex with the repository's `evopolicygym` Agent Skill
- expand `CONTRIBUTING.md` with contribution areas, project guidance, and contact information

## Why

Make it easier for new contributors, including coding-agent users, to discover useful contribution areas and the repository-specific guidance they should follow.

## Validation

- `git diff --check`
