### PR TITLE
benchmarks: score environment returns

### DIFF
--- a/environments/gymnasium_robotics/robotics/README.md
+++ b/environments/gymnasium_robotics/robotics/README.md
@@ -23,10 +23,12 @@ benchmark = RoboticsBenchmark(
 )
 ```
 
-The primary metric is success rate: an Episode counts as solved if the upstream
-success condition is reached on any step. Most profiles continue after success,
-so current success, first success, successful-step fraction, and later loss of
-the goal are reported separately. Goal-conditioned profiles expose current,
+The primary metric is mean Episode return from the upstream environment.
+Success rate remains separately reported: an Episode counts as solved if the
+upstream success condition is reached on any step. A Policy failure receives a
+profile-specific return below a valid unsuccessful Episode. Most profiles
+continue after success, so current success, first success, successful-step
+fraction, and later loss of the goal are reported separately. Goal-conditioned profiles expose current,
 initial, and best goal errors plus per-step improvement. Adroit profiles retain
 their upstream dense shaping and add public-state task progress where the
 observation supports it. Control diagnostics report action magnitude,

--- a/environments/gymnasium_robotics/robotics/src/robotics_benchmarks/benchmark.py
+++ b/environments/gymnasium_robotics/robotics/src/robotics_benchmarks/benchmark.py
@@ -52,7 +52,7 @@ _KITCHEN_GOALS: dict[str, PolicyValue] = {
 
 
 class RoboticsBenchmark:
-    """Success rate for one fixed Gymnasium-Robotics profile."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: RoboticsConfig | None = None) -> None:
         if config is None:
@@ -60,7 +60,8 @@ class RoboticsBenchmark:
         if type(config) is not RoboticsConfig:
             raise TypeError("config must be RoboticsConfig")
         self._config = config
-        self._spec = _spec(config)
+        self._failure_return = _failure_return(config)
+        self._spec = _spec(config, failure_return=self._failure_return)
 
     @property
     def spec(self) -> BenchmarkSpec:
@@ -95,7 +96,11 @@ class RoboticsBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        score = statistics.fmean(
+            record.total_reward if record.policy_failure is None else self._failure_return
+            for record in records
+        )
         traced = records[:_MAX_TRACED_EPISODES]
         trace, traced_transitions, omitted_transitions = _trace(
             traced,
@@ -140,12 +145,10 @@ class RoboticsBenchmark:
                 "summary": (
                     f"Solved {successes}/{len(records)} "
                     f"{self._config.profile} Episodes "
-                    f"({score:.3f} success rate)."
+                    f"({success_rate:.3f} success rate) with {score:.3f} mean return."
                 ),
-                "success_rate": score,
-                "mean_return": statistics.fmean(
-                    r.total_reward if r.policy_failure is None else 0.0 for r in records
-                ),
+                "success_rate": success_rate,
+                "mean_return": score,
                 "mean_steps": statistics.fmean(r.steps for r in records),
                 "mean_steps_to_first_success": _mean_present(
                     tuple(
@@ -219,6 +222,7 @@ class RoboticsBenchmark:
                 "terminated_episodes": sum(_terminated(r) for r in records),
                 "truncated_episodes": sum(_truncated(r) for r in records),
                 "policy_failures": sum(r.policy_failure is not None for r in records),
+                "failure_return": self._failure_return,
                 "traced_episodes": len(traced),
                 "trace_episodes_omitted": len(records) - len(traced),
                 "trace_prefix_steps": _TRACE_PREFIX_STEPS,
@@ -249,13 +253,13 @@ def _artifact_episode_count(manifests: Sequence[PolicyValue], key: str) -> int:
     )
 
 
-def _spec(config: RoboticsConfig) -> BenchmarkSpec:
+def _spec(config: RoboticsConfig, *, failure_return: float) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id=f"gymnasium-robotics/{config.environment_id}/success-rate-v1",
+        id=f"gymnasium-robotics/{config.environment_id}/mean-return-v1",
         description=(
             f"Complete Gymnasium-Robotics' {config.profile} task. "
-            "Maximize the fraction of Episodes that reach the public task "
-            "success condition."
+            "Maximize mean upstream Episode return; success rate remains a "
+            "reported task-completion outcome."
         ),
         observation_space=_observation_space(config),
         action_space={
@@ -272,6 +276,7 @@ def _spec(config: RoboticsConfig) -> BenchmarkSpec:
             "provider": "Gymnasium-Robotics",
             "upstream_version": "1.4.2",
             "reward_mode": _reward_mode(config),
+            "failure_return": failure_return,
             "success_persistence": (
                 "Success is scored if any transition reports the upstream "
                 "success condition; most profiles continue until TimeLimit, "
@@ -303,7 +308,7 @@ def _spec(config: RoboticsConfig) -> BenchmarkSpec:
             ),
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 
@@ -429,6 +434,14 @@ def _reward_mode(config: RoboticsConfig) -> str:
     if config.family == "franka-kitchen":
         return "newly completed task count"
     return "upstream sparse goal reward"
+
+
+def _failure_return(config: RoboticsConfig) -> float:
+    if config.family in {"fetch", "shadow-hand", "shadow-hand-touch"}:
+        return -float(config.max_episode_steps + 1)
+    if config.family in {"maze", "franka-kitchen"}:
+        return -1.0
+    return -1_000_000.0
 
 
 def _reward_semantics(config: RoboticsConfig) -> str:

--- a/environments/gymnasium_robotics/robotics/tests/test_robotics_benchmarks.py
+++ b/environments/gymnasium_robotics/robotics/tests/test_robotics_benchmarks.py
@@ -268,6 +268,9 @@ class RoboticsBenchmarkTests(unittest.TestCase):
 
         self.assertIsInstance(feedback.content, dict)
         assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.score, feedback.content["mean_return"])
+        self.assertEqual(benchmark.spec.primary_metric, "mean_return")
+        self.assertTrue(benchmark.spec.id.endswith("/mean-return-v1"))
         self.assertEqual(feedback.content["traced_transitions"], 160)
         self.assertEqual(feedback.content["trace_transitions_omitted"], 140)
         documents = [json.loads(line) for line in feedback.artifacts[0].read_bytes().splitlines()]
@@ -377,6 +380,9 @@ class RoboticsBenchmarkTests(unittest.TestCase):
         )
         self.assertEqual([artifact.name for artifact in feedback.artifacts], ["trace.jsonl"])
         assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.score, -51.0)
+        self.assertEqual(feedback.content["mean_return"], -51.0)
+        self.assertEqual(feedback.content["failure_return"], -51.0)
         self.assertEqual(feedback.content["video_episode_results"], 1)
         self.assertEqual(feedback.content["video_episodes_without_gif"], 1)
         manifests = feedback.content["video_artifacts"]

--- a/environments/metaworld/metaworld/README.md
+++ b/environments/metaworld/metaworld/README.md
@@ -29,8 +29,9 @@ and show the packed little-endian `float64` decoding pattern for Policies.
 Run-visible traces retain only the Policy-visible state and task one-hot; they
 never include Episode seeds, Host scenarios, or other private Case identity.
 
-The primary metric is success rate. Mean return and public reward-component
-traces provide intermediate optimization feedback. Current values, per-step
+The primary metric is mean Episode return from MetaWorld's upstream dense
+reward. Success rate remains a separately reported task-completion outcome.
+Public reward-component traces provide intermediate optimization feedback. Current values, per-step
 changes, and Episode-best values are reported for reach/contact, grasp,
 in-place progress, object-to-target distance, and dense reward. Feedback also
 distinguishes current versus ever-achieved success/grasp, first achievement,

--- a/environments/metaworld/metaworld/src/metaworld_benchmarks/benchmark.py
+++ b/environments/metaworld/metaworld/src/metaworld_benchmarks/benchmark.py
@@ -41,7 +41,7 @@ _TRACE_SUFFIX_STEPS = 32
 
 
 class MetaWorldBenchmark:
-    """Success rate for one fixed MetaWorld MT task collection."""
+    """Mean environment return for one fixed MetaWorld MT task collection."""
 
     def __init__(self, config: MetaWorldConfig | None = None) -> None:
         if config is None:
@@ -92,7 +92,11 @@ class MetaWorldBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        score = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         traced = records[:_MAX_TRACED_EPISODES]
         trace, traced_transitions, omitted_transitions = _trace(
             traced,
@@ -155,12 +159,10 @@ class MetaWorldBenchmark:
             content={
                 "summary": (
                     f"Solved {successes}/{len(records)} MetaWorld Episodes "
-                    f"({score:.3f} success rate)."
+                    f"({success_rate:.3f} success rate) with {score:.3f} mean return."
                 ),
-                "success_rate": score,
-                "mean_return": statistics.fmean(
-                    r.total_reward if r.policy_failure is None else 0.0 for r in records
-                ),
+                "success_rate": success_rate,
+                "mean_return": score,
                 "mean_steps": statistics.fmean(r.steps for r in records),
                 "mean_steps_on_success": (
                     statistics.fmean(record.steps for record in successful) if successful else None
@@ -289,11 +291,11 @@ def _spec(config: MetaWorldConfig) -> BenchmarkSpec:
         else config.collection_name.upper()
     )
     return BenchmarkSpec(
-        id=f"metaworld/{benchmark_name}/success-rate-v1",
+        id=f"metaworld/{benchmark_name}/mean-return-v1",
         description=(
             f"Complete tasks from MetaWorld's {benchmark_name} collection. "
-            "Maximize the fraction of Episodes reaching the public success "
-            "condition."
+            "Maximize mean upstream Episode return; success rate remains a "
+            "reported task-completion outcome."
         ),
         observation_space=observation,
         action_space={
@@ -349,7 +351,7 @@ def _spec(config: MetaWorldConfig) -> BenchmarkSpec:
             ),
         },
         max_episode_steps=_MAX_EPISODE_STEPS,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/metaworld/metaworld/tests/test_metaworld_benchmarks.py
+++ b/environments/metaworld/metaworld/tests/test_metaworld_benchmarks.py
@@ -241,6 +241,9 @@ class MetaWorldBenchmarkTests(unittest.TestCase):
 
         self.assertIsInstance(feedback.content, dict)
         assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.score, feedback.content["mean_return"])
+        self.assertEqual(benchmark.spec.primary_metric, "mean_return")
+        self.assertTrue(benchmark.spec.id.endswith("/mean-return-v1"))
         self.assertEqual(feedback.content["traced_transitions"], 160)
         self.assertEqual(feedback.content["trace_transitions_omitted"], 340)
         documents = [json.loads(line) for line in feedback.artifacts[0].read_bytes().splitlines()]

--- a/environments/minigrid/babyai/README.md
+++ b/environments/minigrid/babyai/README.md
@@ -14,6 +14,9 @@ benchmark = BabyAIBenchmark(
 
 The Host selects the profile before a Run. The profile and family are visible
 to the Agent, fixed for the Run, and included in the environment digest.
+The primary metric is mean upstream Episode return, which rewards successful
+completion and the upstream time efficiency bonus. Success rate remains a
+separately reported task-completion outcome.
 Upstream-generated natural-language missions remain part of the public
 observation; Episode seeds and private identity never enter Feedback.
 Every Episode is procedurally generated from its private seed. Composite

--- a/environments/minigrid/babyai/src/minigrid_babyai/benchmark.py
+++ b/environments/minigrid/babyai/src/minigrid_babyai/benchmark.py
@@ -137,7 +137,7 @@ _FINAL_COUNT_METRICS = (
 
 
 class BabyAIBenchmark:
-    """Success rate for one Host-selected BabyAI task profile."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: BabyAIConfig | None = None) -> None:
         if config is None:
@@ -179,7 +179,11 @@ class BabyAIBenchmark:
             raise TypeError("episodes must contain EpisodeRecord values")
         successful = tuple(record for record in records if _success(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         traced = records[:4]
         event_counts = {
             name: sum(_reached(record, name) for record in records) for name in _EVENT_METRICS
@@ -190,11 +194,11 @@ class BabyAIBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Completed the instruction in {successes}/{len(records)} "
-                f"Episodes ({score:.3f} success rate); "
+                f"Episodes ({success_rate:.3f} success rate); "
                 f"{event_counts['instruction_failure']} instruction failures "
                 f"and {sum(_truncated(record) for record in records)} timeouts."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "mean_return": statistics.fmean(
                 record.total_reward if record.policy_failure is None else 0.0 for record in records
             ),
@@ -228,7 +232,7 @@ class BabyAIBenchmark:
         for name in _FINAL_COUNT_METRICS:
             content[f"mean_{name}"] = _mean_final_int(final_metrics, name)
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace(traced),),
         )
@@ -236,7 +240,7 @@ class BabyAIBenchmark:
 
 def _spec(config: BabyAIConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id=f"minigrid/BabyAI-{config.family}-v0/success-rate-v1",
+        id=f"minigrid/BabyAI-{config.family}-v0/mean-return-v1",
         description=(
             "Interpret the public BabyAI instruction and complete the selected task profile."
         ),
@@ -309,7 +313,7 @@ def _spec(config: BabyAIConfig) -> BenchmarkSpec:
             "state_encoding": {name: code for code, name in enumerate(_STATES)},
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/babyai/tests/test_babyai.py
+++ b/environments/minigrid/babyai/tests/test_babyai.py
@@ -87,11 +87,11 @@ class BabyAITests(unittest.TestCase):
         local = BabyAIBenchmark(BabyAIConfig(profile="GoToLocal"))
         self.assertEqual(
             goto.spec.id,
-            "minigrid/BabyAI-GoTo-v0/success-rate-v1",
+            "minigrid/BabyAI-GoTo-v0/mean-return-v1",
         )
         self.assertEqual(
             opened.spec.id,
-            "minigrid/BabyAI-Open-v0/success-rate-v1",
+            "minigrid/BabyAI-Open-v0/mean-return-v1",
         )
         self.assertEqual(goto.spec.max_episode_steps, 576)
         self.assertNotEqual(
@@ -287,7 +287,8 @@ class BabyAITests(unittest.TestCase):
 
         content = result.feedback.content
         assert isinstance(content, dict)
-        self.assertEqual(result.feedback.score, 1.0)
+        self.assertEqual(result.feedback.content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
         self.assertEqual(content["door_opened_this_step_rate"], 1.0)
         self.assertGreater(_number_metric(content, "mean_unique_observation_count"), 0)
         documents = tuple(

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/benchmark.py
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/src/minigrid_blocked_unlock_pickup/benchmark.py
@@ -171,7 +171,7 @@ class _EpisodeDiagnostics:
 
 
 class BlockedUnlockPickupBenchmark:
-    """Success rate for the complete blocked-door manipulation chain."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self) -> None:
         self._spec = _benchmark_spec()
@@ -211,7 +211,7 @@ class BlockedUnlockPickupBenchmark:
             raise TypeError("episodes must contain EpisodeRecord values")
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
         counts = {name: _milestone_count(records, name) for name in _MILESTONES}
         mean_return = statistics.fmean(
             record.total_reward if record.policy_failure is None else 0.0 for record in records
@@ -229,10 +229,10 @@ class BlockedUnlockPickupBenchmark:
             "summary": (
                 f"Moved the blocker, unlocked the room, and collected the "
                 f"target in {successes}/{len(records)} Episodes "
-                f"({score:.3f} success rate); "
+                f"({success_rate:.3f} success rate); "
                 f"{counts['target_destroyed']} destroyed the target box."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "mean_return": mean_return,
             "mean_steps": mean_steps,
             "mean_steps_on_success": (
@@ -300,7 +300,7 @@ class BlockedUnlockPickupBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -308,7 +308,7 @@ class BlockedUnlockPickupBenchmark:
 
 def _benchmark_spec() -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/BlockedUnlockPickup-v0/success-rate-v1",
+        id="minigrid/BlockedUnlockPickup-v0/mean-return-v1",
         description=(
             "Move the ball obstructing a locked door, acquire the matching "
             "key, unlock the second room, and pick up the mission box."
@@ -384,7 +384,7 @@ def _benchmark_spec() -> BenchmarkSpec:
             "time_limit": 16 * 6**2,
         },
         max_episode_steps=16 * 6**2,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/tests/test_blocked_unlock_pickup.py
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/tests/test_blocked_unlock_pickup.py
@@ -64,7 +64,7 @@ class BlockedUnlockPickupTests(unittest.TestCase):
         benchmark = BlockedUnlockPickupBenchmark()
         self.assertEqual(
             benchmark.spec.id,
-            "minigrid/BlockedUnlockPickup-v0/success-rate-v1",
+            "minigrid/BlockedUnlockPickup-v0/mean-return-v1",
         )
         self.assertEqual(benchmark.spec.max_episode_steps, 576)
         self.assertEqual(
@@ -225,7 +225,8 @@ class BlockedUnlockPickupTests(unittest.TestCase):
                 episode_timeout_seconds=10,
             ),
         )
-        self.assertEqual(result.feedback.score, 1.0)
+        self.assertEqual(result.feedback.content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
         self.assertIsInstance(result.feedback.content, dict)
         assert isinstance(result.feedback.content, dict)
         for field in (

--- a/environments/minigrid/minigrid/crossing/src/minigrid_crossing/benchmark.py
+++ b/environments/minigrid/minigrid/crossing/src/minigrid_crossing/benchmark.py
@@ -89,7 +89,7 @@ class _EpisodeDiagnostics:
 
 
 class CrossingBenchmark:
-    """Safe-navigation success rate across wall or lava rivers."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: CrossingConfig | None = None) -> None:
         if config is None:
@@ -130,7 +130,11 @@ class CrossingBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         goal_found = sum(_reached(r, "goal_found") for r in records)
         hazard_found = sum(_reached(r, "hazard_found") for r in records)
         hazards = sum(_reached(r, "hazard_entered") for r in records)
@@ -143,10 +147,10 @@ class CrossingBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Reached the goal in {successes}/{len(records)} Episodes "
-                f"({score:.3f} success rate); {hazard_found} saw a hazard "
+                f"({success_rate:.3f} success rate); {hazard_found} saw a hazard "
                 f"and {hazards} entered one."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "goal_found_rate": goal_found / len(records),
             "hazard_found_rate": hazard_found / len(records),
             "hazard_entry_rate": hazards / len(records),
@@ -192,7 +196,7 @@ class CrossingBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace(traced),),
         )
@@ -205,7 +209,7 @@ def _spec(config: CrossingConfig) -> BenchmarkSpec:
         else "find the opening and get to the green goal square"
     )
     return BenchmarkSpec(
-        id="minigrid/Crossing-v0/success-rate-v1",
+        id="minigrid/Crossing-v0/mean-return-v1",
         description=(
             "Discover the openings through a generated sequence of wall or "
             "lava rivers and safely reach the opposite-corner goal."
@@ -279,7 +283,7 @@ def _spec(config: CrossingConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/crossing/tests/test_crossing.py
+++ b/environments/minigrid/minigrid/crossing/tests/test_crossing.py
@@ -28,7 +28,7 @@ class CrossingTests(unittest.TestCase):
         large = CrossingBenchmark(CrossingConfig(profile="lava-S11-N5"))
         self.assertEqual(
             default.spec.id,
-            "minigrid/Crossing-v0/success-rate-v1",
+            "minigrid/Crossing-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 324)
         self.assertEqual(large.spec.max_episode_steps, 484)
@@ -185,7 +185,10 @@ class CrossingTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/benchmark.py
+++ b/environments/minigrid/minigrid/dist_shift/src/minigrid_dist_shift/benchmark.py
@@ -89,7 +89,7 @@ class _EpisodeDiagnostics:
 
 
 class DistShiftBenchmark:
-    """Safe-navigation success rate under one selected lava-strip layout."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: DistShiftConfig | None = None) -> None:
         if config is None:
@@ -130,7 +130,11 @@ class DistShiftBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         goal_found = sum(_reached(r, "goal_found") for r in records)
         hazard_found = sum(_reached(r, "hazard_found") for r in records)
         hazards = sum(_reached(r, "hazard_entered") for r in records)
@@ -143,10 +147,10 @@ class DistShiftBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Reached the goal in {successes}/{len(records)} Episodes "
-                f"({score:.3f} success rate); {hazard_found} saw lava "
+                f"({success_rate:.3f} success rate); {hazard_found} saw lava "
                 f"and {hazards} entered it."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "goal_found_rate": goal_found / len(records),
             "hazard_found_rate": hazard_found / len(records),
             "hazard_entry_rate": hazards / len(records),
@@ -192,7 +196,7 @@ class DistShiftBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace(traced),),
         )
@@ -201,7 +205,7 @@ class DistShiftBenchmark:
 def _spec(config: DistShiftConfig) -> BenchmarkSpec:
     mission = "get to the green goal square"
     return BenchmarkSpec(
-        id="minigrid/DistShift-v0/success-rate-v1",
+        id="minigrid/DistShift-v0/mean-return-v1",
         description=(
             "Reach a fixed goal while avoiding one of two distribution-shift lava layouts."
         ),
@@ -275,7 +279,7 @@ def _spec(config: DistShiftConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/dist_shift/tests/test_dist_shift.py
+++ b/environments/minigrid/minigrid/dist_shift/tests/test_dist_shift.py
@@ -27,7 +27,7 @@ class DistShiftTests(unittest.TestCase):
         shifted = DistShiftBenchmark(DistShiftConfig(profile="shift2"))
         self.assertEqual(
             default.spec.id,
-            "minigrid/DistShift-v0/success-rate-v1",
+            "minigrid/DistShift-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 252)
         self.assertEqual(
@@ -182,7 +182,10 @@ class DistShiftTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/doorkey/README.md
+++ b/environments/minigrid/minigrid/doorkey/README.md
@@ -7,7 +7,8 @@ partially observable navigation task.
 The Policy sees the upstream `7 × 7 × 3` egocentric symbolic image, compass
 direction, and mission text. It must explore the room, pick up the yellow key,
 unlock the yellow door, and reach the green goal. The primary score is Episode
-success rate.
+return from the upstream time-decaying reward; success rate remains separately
+reported.
 
 The spec defines image axes `[view_x, view_y, channel]`, channel order
 `[object, color, state]`, agent position `(3,6)`, view orientation, compass

--- a/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/benchmark.py
+++ b/environments/minigrid/minigrid/doorkey/src/minigrid_doorkey/benchmark.py
@@ -101,7 +101,7 @@ class _EpisodeDiagnostics:
 
 
 class DoorKeyBenchmark:
-    """Success rate on a partially observable key-door navigation task."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: DoorKeyConfig | None = None) -> None:
         if config is None:
@@ -147,7 +147,7 @@ class DoorKeyBenchmark:
 
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
         found_keys = sum(_reached_milestone(record, "key_found") for record in records)
         picked_up_keys = sum(_reached_milestone(record, "picked_up_key") for record in records)
         opened_doors = sum(_reached_milestone(record, "opened_door") for record in records)
@@ -171,11 +171,11 @@ class DoorKeyBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Reached the goal in {successes}/{len(records)} Episodes "
-                f"({score:.3f} success rate); {found_keys} saw the key, "
+                f"({success_rate:.3f} success rate); {found_keys} saw the key, "
                 f"{picked_up_keys} picked it up, {opened_doors} opened the "
                 f"door, and {found_goals} saw the goal."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "key_found_rate": found_keys / len(records),
             "key_pickup_rate": picked_up_keys / len(records),
             "door_found_rate": found_doors / len(records),
@@ -238,7 +238,7 @@ class DoorKeyBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -246,11 +246,11 @@ class DoorKeyBenchmark:
 
 def _benchmark_spec(config: DoorKeyConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/DoorKey-v0/success-rate-v1",
+        id="minigrid/DoorKey-v0/mean-return-v1",
         description=(
             "Explore a partially observable room, pick up the yellow key, "
             "unlock the yellow door, and reach the green goal. Maximize "
-            "success rate."
+            "upstream Episode return."
         ),
         observation_space={
             "type": "object",
@@ -320,7 +320,7 @@ def _benchmark_spec(config: DoorKeyConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/doorkey/tests/test_doorkey.py
+++ b/environments/minigrid/minigrid/doorkey/tests/test_doorkey.py
@@ -29,7 +29,7 @@ class DoorKeyBenchmarkTests(unittest.TestCase):
 
         self.assertEqual(
             default.spec.id,
-            "minigrid/DoorKey-v0/success-rate-v1",
+            "minigrid/DoorKey-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 640)
         self.assertEqual(small.spec.max_episode_steps, 250)
@@ -219,13 +219,16 @@ class DoorKeyBenchmarkTests(unittest.TestCase):
 
                 self.assertEqual(
                     result.benchmark_id,
-                    "minigrid/DoorKey-v0/success-rate-v1",
+                    "minigrid/DoorKey-v0/mean-return-v1",
                 )
                 self.assertEqual(
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/dynamic_obstacles/README.md
+++ b/environments/minigrid/minigrid/dynamic_obstacles/README.md
@@ -10,7 +10,8 @@ balls move locally before every action. The only valid actions are left,
 right, and forward. The upstream environment checks the cell ahead, moves the
 balls, then applies the Action; trying to move forward into any cell that was
 occupied by a non-goal object ends the Episode with reward `-1`. This includes
-both a grey ball and a wall. The primary score is Episode success rate.
+both a grey ball and a wall. The primary score is mean upstream Episode return;
+success rate remains separately reported.
 
 ## Install and test
 

--- a/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/benchmark.py
+++ b/environments/minigrid/minigrid/dynamic_obstacles/src/minigrid_dynamic_obstacles/benchmark.py
@@ -98,7 +98,7 @@ class _EpisodeDiagnostics:
 
 
 class DynamicObstaclesBenchmark:
-    """Success rate while avoiding moving obstacles."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(
         self,
@@ -150,7 +150,7 @@ class DynamicObstaclesBenchmark:
 
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
         found_goals = _milestone_count(records, "goal_found")
         found_obstacles = _milestone_count(records, "obstacle_found")
         collisions = _milestone_count(records, "collision")
@@ -177,11 +177,11 @@ class DynamicObstaclesBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Reached the goal in {successes}/{len(records)} Episodes "
-                f"({score:.3f} success rate); {collisions} made a blocked "
+                f"({success_rate:.3f} success rate); {collisions} made a blocked "
                 f"forward move ({obstacle_collisions} into a moving ball, "
                 f"{wall_collisions} into a wall)."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "goal_found_rate": found_goals / len(records),
             "obstacle_found_rate": found_obstacles / len(records),
             "collision_rate": collisions / len(records),
@@ -240,7 +240,7 @@ class DynamicObstaclesBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -248,7 +248,7 @@ class DynamicObstaclesBenchmark:
 
 def _benchmark_spec(config: DynamicObstaclesConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/DynamicObstacles-v0/success-rate-v1",
+        id="minigrid/DynamicObstacles-v0/mean-return-v1",
         description=(
             "Reach the green goal in a partially observable room while grey "
             "balls move locally after the front cell is checked and before "
@@ -335,7 +335,7 @@ def _benchmark_spec(config: DynamicObstaclesConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/dynamic_obstacles/tests/test_dynamic_obstacles.py
+++ b/environments/minigrid/minigrid/dynamic_obstacles/tests/test_dynamic_obstacles.py
@@ -31,7 +31,7 @@ class DynamicObstaclesBenchmarkTests(unittest.TestCase):
 
         self.assertEqual(
             default.spec.id,
-            "minigrid/DynamicObstacles-v0/success-rate-v1",
+            "minigrid/DynamicObstacles-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 256)
         self.assertEqual(small.spec.max_episode_steps, 100)
@@ -268,9 +268,11 @@ class DynamicObstaclesBenchmarkTests(unittest.TestCase):
                 ),
             )
         )
-        self.assertEqual(feedback.score, 0.0)
         self.assertIsInstance(feedback.content, dict)
         assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["success_rate"], 0.0)
+        self.assertEqual(feedback.score, feedback.content["mean_return"])
+        self.assertEqual(feedback.score, -1.0)
         self.assertEqual(feedback.content["collision_rate"], 1.0)
         self.assertEqual(feedback.content["obstacle_collision_rate"], 0.5)
         self.assertEqual(feedback.content["wall_collision_rate"], 0.5)
@@ -331,13 +333,16 @@ class DynamicObstaclesBenchmarkTests(unittest.TestCase):
 
                 self.assertEqual(
                     result.benchmark_id,
-                    "minigrid/DynamicObstacles-v0/success-rate-v1",
+                    "minigrid/DynamicObstacles-v0/mean-return-v1",
                 )
                 self.assertEqual(
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/empty/src/minigrid_empty/benchmark.py
+++ b/environments/minigrid/minigrid/empty/src/minigrid_empty/benchmark.py
@@ -85,7 +85,7 @@ class _EpisodeDiagnostics:
 
 
 class EmptyBenchmark:
-    """Navigation success rate in an empty room."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: EmptyConfig | None = None) -> None:
         if config is None:
@@ -126,7 +126,11 @@ class EmptyBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         goal_found = sum(_reached(r, "goal_found") for r in records)
         diagnostics = tuple(
             _episode_diagnostics(record)
@@ -140,10 +144,10 @@ class EmptyBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Reached the goal in {successes}/{len(records)} Episodes "
-                f"({score:.3f} success rate); saw the goal in "
+                f"({success_rate:.3f} success rate); saw the goal in "
                 f"{goal_found}/{len(records)}."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "goal_found_rate": goal_found / len(records),
             "mean_return": statistics.fmean(
                 r.total_reward if r.policy_failure is None else 0.0 for r in records
@@ -181,7 +185,7 @@ class EmptyBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace(traced),),
         )
@@ -190,7 +194,7 @@ class EmptyBenchmark:
 def _spec(config: EmptyConfig) -> BenchmarkSpec:
     mission = "get to the green goal square"
     return BenchmarkSpec(
-        id="minigrid/Empty-v0/success-rate-v1",
+        id="minigrid/Empty-v0/mean-return-v1",
         description=(
             "Reach the opposite-corner goal from a fixed or random start in "
             "an otherwise empty room."
@@ -261,7 +265,7 @@ def _spec(config: EmptyConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/empty/tests/test_empty.py
+++ b/environments/minigrid/minigrid/empty/tests/test_empty.py
@@ -20,7 +20,7 @@ class EmptyTests(unittest.TestCase):
         random = EmptyBenchmark(EmptyConfig(profile="6x6-random"))
         self.assertEqual(
             default.spec.id,
-            "minigrid/Empty-v0/success-rate-v1",
+            "minigrid/Empty-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 256)
         self.assertEqual(
@@ -114,7 +114,10 @@ class EmptyTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/fetch/README.md
+++ b/environments/minigrid/minigrid/fetch/README.md
@@ -8,7 +8,7 @@ The Policy receives the upstream `7 × 7 × 3` egocentric symbolic image,
 compass direction, and a natural-language mission identifying a colored key or
 ball. It must explore the room and pick up exactly the requested object;
 choosing a distractor ends the Episode with zero reward. The primary score is
-Episode success rate.
+mean upstream Episode return; success rate remains separately reported.
 
 ## Install and test
 

--- a/environments/minigrid/minigrid/fetch/src/minigrid_fetch/benchmark.py
+++ b/environments/minigrid/minigrid/fetch/src/minigrid_fetch/benchmark.py
@@ -129,7 +129,7 @@ class _EpisodeDiagnostics:
 
 
 class FetchBenchmark:
-    """Success rate on a partially observable instruction-following task."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: FetchConfig | None = None) -> None:
         if config is None:
@@ -175,7 +175,7 @@ class FetchBenchmark:
 
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
         found_targets = _milestone_count(records, "target_found")
         wrong_objects = _milestone_count(records, "wrong_object")
         failed_pickups = _milestone_count(records, "failed_pickup")
@@ -197,11 +197,11 @@ class FetchBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Fetched the mission-matching object in {successes}/"
-                f"{len(records)} Episodes ({score:.3f} success rate); "
+                f"{len(records)} Episodes ({success_rate:.3f} success rate); "
                 f"{wrong_objects} picked up a wrong object and "
                 f"{failed_pickups} made at least one failed pickup attempt."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "target_found_rate": found_targets / len(records),
             "wrong_object_rate": wrong_objects / len(records),
             "failed_pickup_episode_rate": failed_pickups / len(records),
@@ -262,7 +262,7 @@ class FetchBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -270,11 +270,11 @@ class FetchBenchmark:
 
 def _benchmark_spec(config: FetchConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/Fetch-v0/success-rate-v1",
+        id="minigrid/Fetch-v0/mean-return-v1",
         description=(
             "Read the natural-language mission, explore the partially "
             "observable room, and pick up the matching colored key or ball "
-            "without picking up a distractor. Maximize success rate."
+            "without picking up a distractor. Maximize upstream Episode return."
         ),
         observation_space={
             "type": "object",
@@ -351,7 +351,7 @@ def _benchmark_spec(config: FetchConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/fetch/tests/test_fetch.py
+++ b/environments/minigrid/minigrid/fetch/tests/test_fetch.py
@@ -26,7 +26,7 @@ class FetchBenchmarkTests(unittest.TestCase):
 
         self.assertEqual(
             default.spec.id,
-            "minigrid/Fetch-v0/success-rate-v1",
+            "minigrid/Fetch-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 320)
         self.assertEqual(small.spec.max_episode_steps, 125)
@@ -248,7 +248,8 @@ class FetchBenchmarkTests(unittest.TestCase):
         self.assertEqual(failed_metrics["terminal_reason"], "none")
 
         feedback = benchmark.feedback((success_record, wrong_record, failed_record))
-        self.assertEqual(feedback.score, 1 / 3)
+        self.assertEqual(feedback.content["success_rate"], 1 / 3)
+        self.assertEqual(feedback.score, feedback.content["mean_return"])
         self.assertIsInstance(feedback.content, dict)
         assert isinstance(feedback.content, dict)
         self.assertEqual(feedback.content["wrong_object_rate"], 1 / 3)
@@ -304,13 +305,16 @@ class FetchBenchmarkTests(unittest.TestCase):
 
                 self.assertEqual(
                     result.benchmark_id,
-                    "minigrid/Fetch-v0/success-rate-v1",
+                    "minigrid/Fetch-v0/mean-return-v1",
                 )
                 self.assertEqual(
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/benchmark.py
+++ b/environments/minigrid/minigrid/four_rooms/src/minigrid_four_rooms/benchmark.py
@@ -85,7 +85,7 @@ class _EpisodeDiagnostics:
 
 
 class FourRoomsBenchmark:
-    """Navigation success rate in the generated four-room maze."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self) -> None:
         self._spec = _spec()
@@ -121,7 +121,11 @@ class FourRoomsBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         goal_found = sum(_reached(r, "goal_found") for r in records)
         diagnostics = tuple(
             _episode_diagnostics(record)
@@ -135,10 +139,10 @@ class FourRoomsBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Reached the goal in {successes}/{len(records)} Episodes "
-                f"({score:.3f} success rate); saw the goal in "
+                f"({success_rate:.3f} success rate); saw the goal in "
                 f"{goal_found}/{len(records)}."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "goal_found_rate": goal_found / len(records),
             "mean_return": statistics.fmean(
                 r.total_reward if r.policy_failure is None else 0.0 for r in records
@@ -176,7 +180,7 @@ class FourRoomsBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace(traced),),
         )
@@ -185,7 +189,7 @@ class FourRoomsBenchmark:
 def _spec() -> BenchmarkSpec:
     mission = "reach the goal"
     return BenchmarkSpec(
-        id="minigrid/FourRooms-v0/success-rate-v1",
+        id="minigrid/FourRooms-v0/mean-return-v1",
         description=(
             "Explore four rooms connected by generated openings and reach a randomly placed goal."
         ),
@@ -254,7 +258,7 @@ def _spec() -> BenchmarkSpec:
             "time_limit": _MAX_EPISODE_STEPS,
         },
         max_episode_steps=_MAX_EPISODE_STEPS,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/four_rooms/tests/test_four_rooms.py
+++ b/environments/minigrid/minigrid/four_rooms/tests/test_four_rooms.py
@@ -18,7 +18,7 @@ class FourRoomsTests(unittest.TestCase):
         default = FourRoomsBenchmark()
         self.assertEqual(
             default.spec.id,
-            "minigrid/FourRooms-v0/success-rate-v1",
+            "minigrid/FourRooms-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 256)
         self.assertEqual(
@@ -87,7 +87,8 @@ class FourRoomsTests(unittest.TestCase):
                 episode_timeout_seconds=10,
             ),
         )
-        self.assertEqual(result.feedback.score, 1.0)
+        self.assertEqual(result.feedback.content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
         self.assertIsInstance(result.feedback.content, dict)
         assert isinstance(result.feedback.content, dict)
         self.assertEqual(

--- a/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/benchmark.py
+++ b/environments/minigrid/minigrid/go_to_door/src/minigrid_go_to_door/benchmark.py
@@ -108,7 +108,7 @@ class _EpisodeDiagnostics:
 
 
 class GoToDoorBenchmark:
-    """Success rate on a partially observable instruction-following task."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: GoToDoorConfig | None = None) -> None:
         if config is None:
@@ -154,7 +154,7 @@ class GoToDoorBenchmark:
 
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
         found_targets = _milestone_count(records, "target_found")
         wrong_completions = _milestone_count(records, "wrong_completion")
         premature_toggles = _milestone_count(records, "premature_toggle")
@@ -177,11 +177,11 @@ class GoToDoorBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Declared completion beside the mission door in "
-                f"{successes}/{len(records)} Episodes ({score:.3f} success "
+                f"{successes}/{len(records)} Episodes ({success_rate:.3f} success "
                 f"rate); {premature_toggles} terminated with toggle and "
                 f"{wrong_done} issued done from a wrong location."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "target_found_rate": found_targets / len(records),
             "wrong_completion_rate": wrong_completions / len(records),
             "premature_toggle_rate": premature_toggles / len(records),
@@ -237,7 +237,7 @@ class GoToDoorBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -245,11 +245,11 @@ class GoToDoorBenchmark:
 
 def _benchmark_spec(config: GoToDoorConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/GoToDoor-v0/success-rate-v1",
+        id="minigrid/GoToDoor-v0/mean-return-v1",
         description=(
             "Read the natural-language mission, explore the partially "
             "observable room, stand next to the matching colored door, and "
-            "declare completion. Maximize success rate."
+            "declare completion. Maximize upstream Episode return."
         ),
         observation_space={
             "type": "object",
@@ -324,7 +324,7 @@ def _benchmark_spec(config: GoToDoorConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/go_to_door/tests/test_go_to_door.py
+++ b/environments/minigrid/minigrid/go_to_door/tests/test_go_to_door.py
@@ -25,7 +25,7 @@ class GoToDoorBenchmarkTests(unittest.TestCase):
 
         self.assertEqual(
             default.spec.id,
-            "minigrid/GoToDoor-v0/success-rate-v1",
+            "minigrid/GoToDoor-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 256)
         self.assertEqual(small.spec.max_episode_steps, 100)
@@ -277,13 +277,16 @@ class GoToDoorBenchmarkTests(unittest.TestCase):
 
                 self.assertEqual(
                     result.benchmark_id,
-                    "minigrid/GoToDoor-v0/success-rate-v1",
+                    "minigrid/GoToDoor-v0/mean-return-v1",
                 )
                 self.assertEqual(
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/benchmark.py
+++ b/environments/minigrid/minigrid/go_to_object/src/minigrid_go_to_object/benchmark.py
@@ -110,7 +110,7 @@ class _EpisodeDiagnostics:
 
 
 class GoToObjectBenchmark:
-    """Success rate on a partially observable instruction-following task."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: GoToObjectConfig | None = None) -> None:
         if config is None:
@@ -156,7 +156,7 @@ class GoToObjectBenchmark:
 
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
         found_targets = _milestone_count(records, "target_found")
         wrong_completions = _milestone_count(records, "wrong_completion")
         premature_toggles = _milestone_count(records, "premature_toggle")
@@ -179,11 +179,11 @@ class GoToObjectBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Declared completion beside the mission target in "
-                f"{successes}/{len(records)} Episodes ({score:.3f} success "
+                f"{successes}/{len(records)} Episodes ({success_rate:.3f} success "
                 f"rate); {premature_toggles} terminated with toggle and "
                 f"{wrong_done} issued done from a wrong location."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "target_found_rate": found_targets / len(records),
             "wrong_completion_rate": wrong_completions / len(records),
             "premature_toggle_rate": premature_toggles / len(records),
@@ -239,7 +239,7 @@ class GoToObjectBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -247,11 +247,11 @@ class GoToObjectBenchmark:
 
 def _benchmark_spec(config: GoToObjectConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/GoToObject-v0/success-rate-v1",
+        id="minigrid/GoToObject-v0/mean-return-v1",
         description=(
             "Read the natural-language mission, explore the partially "
             "observable room, stand next to the matching colored key, ball, "
-            "or box, and declare completion. Maximize success rate."
+            "or box, and declare completion. Maximize upstream Episode return."
         ),
         observation_space={
             "type": "object",
@@ -326,7 +326,7 @@ def _benchmark_spec(config: GoToObjectConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/go_to_object/tests/test_go_to_object.py
+++ b/environments/minigrid/minigrid/go_to_object/tests/test_go_to_object.py
@@ -25,7 +25,7 @@ class GoToObjectBenchmarkTests(unittest.TestCase):
 
         self.assertEqual(
             default.spec.id,
-            "minigrid/GoToObject-v0/success-rate-v1",
+            "minigrid/GoToObject-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 320)
         self.assertEqual(small.spec.max_episode_steps, 180)
@@ -277,13 +277,16 @@ class GoToObjectBenchmarkTests(unittest.TestCase):
 
                 self.assertEqual(
                     result.benchmark_id,
-                    "minigrid/GoToObject-v0/success-rate-v1",
+                    "minigrid/GoToObject-v0/mean-return-v1",
                 )
                 self.assertEqual(
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/keycorridor/README.md
+++ b/environments/minigrid/minigrid/keycorridor/README.md
@@ -9,7 +9,8 @@ compass direction, and a mission naming the target ball color. It must explore
 multiple rooms, acquire the key matching the locked door, unlock the target
 room, free its carrying slot, and pick up the mission-matching ball. The key
 and locked-door color match each other; they are independent of the mission
-ball color. The primary score is Episode success rate.
+ball color. The primary score is mean upstream Episode return; success rate
+remains separately reported.
 
 ## Install and test
 

--- a/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/benchmark.py
+++ b/environments/minigrid/minigrid/keycorridor/src/minigrid_keycorridor/benchmark.py
@@ -165,7 +165,7 @@ class _EpisodeDiagnostics:
 
 
 class KeyCorridorBenchmark:
-    """Success rate on a multi-room matching-key search task."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: KeyCorridorConfig | None = None) -> None:
         if config is None:
@@ -211,7 +211,7 @@ class KeyCorridorBenchmark:
 
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
         counts = {name: _milestone_count(records, name) for name in _MILESTONES}
         found_keys = counts["found_key"]
         picked_up_keys = counts["picked_up_key"]
@@ -235,13 +235,13 @@ class KeyCorridorBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Picked up the target object in {successes}/"
-                f"{len(records)} Episodes ({score:.3f} success rate); "
+                f"{len(records)} Episodes ({success_rate:.3f} success rate); "
                 f"{picked_up_keys} acquired the door-matching key, "
                 f"{opened_doors} opened the target door, and "
                 f"{counts['target_pickup_blocked_by_carried_object']} "
                 f"attempted the target pickup with occupied hands."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "key_found_rate": found_keys / len(records),
             "key_pickup_rate": picked_up_keys / len(records),
             "key_drop_rate": counts["key_dropped"] / len(records),
@@ -325,7 +325,7 @@ class KeyCorridorBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -333,11 +333,11 @@ class KeyCorridorBenchmark:
 
 def _benchmark_spec(config: KeyCorridorConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/KeyCorridor-v0/success-rate-v1",
+        id="minigrid/KeyCorridor-v0/mean-return-v1",
         description=(
             "Search multiple partially observable rooms for the key matching "
             "the locked door, unlock the target room, free the carrying slot, "
-            "and pick up the mission-colored ball. Maximize success rate."
+            "and pick up the mission-colored ball. Maximize upstream Episode return."
         ),
         observation_space={
             "type": "object",
@@ -420,7 +420,7 @@ def _benchmark_spec(config: KeyCorridorConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/keycorridor/tests/test_keycorridor.py
+++ b/environments/minigrid/minigrid/keycorridor/tests/test_keycorridor.py
@@ -52,7 +52,7 @@ class KeyCorridorBenchmarkTests(unittest.TestCase):
 
         self.assertEqual(
             default.spec.id,
-            "minigrid/KeyCorridor-v0/success-rate-v1",
+            "minigrid/KeyCorridor-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 480)
         self.assertEqual(small.spec.max_episode_steps, 270)
@@ -370,13 +370,16 @@ class KeyCorridorBenchmarkTests(unittest.TestCase):
 
                 self.assertEqual(
                     result.benchmark_id,
-                    "minigrid/KeyCorridor-v0/success-rate-v1",
+                    "minigrid/KeyCorridor-v0/mean-return-v1",
                 )
                 self.assertEqual(
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/benchmark.py
+++ b/environments/minigrid/minigrid/lava_gap/src/minigrid_lava_gap/benchmark.py
@@ -89,7 +89,7 @@ class _EpisodeDiagnostics:
 
 
 class LavaGapBenchmark:
-    """Safe-navigation success rate through one generated lava barrier."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: LavaGapConfig | None = None) -> None:
         if config is None:
@@ -130,7 +130,11 @@ class LavaGapBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         goal_found = sum(_reached(r, "goal_found") for r in records)
         hazard_found = sum(_reached(r, "hazard_found") for r in records)
         hazards = sum(_reached(r, "hazard_entered") for r in records)
@@ -143,10 +147,10 @@ class LavaGapBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Reached the goal in {successes}/{len(records)} Episodes "
-                f"({score:.3f} success rate); {hazard_found} saw lava "
+                f"({success_rate:.3f} success rate); {hazard_found} saw lava "
                 f"and {hazards} entered it."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "goal_found_rate": goal_found / len(records),
             "hazard_found_rate": hazard_found / len(records),
             "hazard_entry_rate": hazards / len(records),
@@ -192,7 +196,7 @@ class LavaGapBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace(traced),),
         )
@@ -201,7 +205,7 @@ class LavaGapBenchmark:
 def _spec(config: LavaGapConfig) -> BenchmarkSpec:
     mission = "avoid the lava and get to the green goal square"
     return BenchmarkSpec(
-        id="minigrid/LavaGap-v0/success-rate-v1",
+        id="minigrid/LavaGap-v0/mean-return-v1",
         description=(
             "Discover the single opening in a generated vertical lava strip "
             "and safely reach the opposite-corner goal."
@@ -273,7 +277,7 @@ def _spec(config: LavaGapConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/lava_gap/tests/test_lava_gap.py
+++ b/environments/minigrid/minigrid/lava_gap/tests/test_lava_gap.py
@@ -27,7 +27,7 @@ class LavaGapTests(unittest.TestCase):
         small = LavaGapBenchmark(LavaGapConfig(profile="S5"))
         self.assertEqual(
             default.spec.id,
-            "minigrid/LavaGap-v0/success-rate-v1",
+            "minigrid/LavaGap-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 196)
         self.assertEqual(small.spec.max_episode_steps, 100)
@@ -175,7 +175,10 @@ class LavaGapTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/benchmark.py
+++ b/environments/minigrid/minigrid/locked_room/src/minigrid_locked_room/benchmark.py
@@ -163,7 +163,7 @@ class _EpisodeDiagnostics:
 
 
 class LockedRoomBenchmark:
-    """Success rate for the six-room key-conditioned navigation task."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self) -> None:
         self._spec = _spec()
@@ -199,7 +199,11 @@ class LockedRoomBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         counts = {name: sum(_reached(record, name) for record in records) for name in _MILESTONES}
         successful = tuple(record for record in records if _success(record))
         diagnostics = tuple(
@@ -212,9 +216,9 @@ class LockedRoomBenchmark:
             "summary": (
                 f"Recovered the mission key, unlocked its room, and reached "
                 f"the goal in {successes}/{len(records)} Episodes "
-                f"({score:.3f} success rate)."
+                f"({success_rate:.3f} success rate)."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "mean_unique_door_color_count_opened": _mean_or_none(
                 tuple(float(item.unique_door_color_count_opened) for item in diagnostics)
             ),
@@ -287,7 +291,7 @@ class LockedRoomBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace(traced),),
         )
@@ -295,7 +299,7 @@ class LockedRoomBenchmark:
 
 def _spec() -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/LockedRoom-v0/success-rate-v1",
+        id="minigrid/LockedRoom-v0/mean-return-v1",
         description=(
             "Search six rooms according to the mission, recover the key "
             "matching the locked room, unlock it, and reach its goal."
@@ -373,7 +377,7 @@ def _spec() -> BenchmarkSpec:
             "time_limit": 190,
         },
         max_episode_steps=190,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/locked_room/tests/test_locked_room.py
+++ b/environments/minigrid/minigrid/locked_room/tests/test_locked_room.py
@@ -73,7 +73,7 @@ class LockedRoomTests(unittest.TestCase):
         benchmark = LockedRoomBenchmark()
         self.assertEqual(
             benchmark.spec.id,
-            "minigrid/LockedRoom-v0/success-rate-v1",
+            "minigrid/LockedRoom-v0/mean-return-v1",
         )
         self.assertEqual(benchmark.spec.max_episode_steps, 190)
         self.assertEqual(
@@ -211,7 +211,8 @@ class LockedRoomTests(unittest.TestCase):
         self.assertEqual(final.metrics["terminal_reason"], "success")
 
         feedback = benchmark.feedback((record,))
-        self.assertEqual(feedback.score, 1.0)
+        self.assertEqual(feedback.content["success_rate"], 1.0)
+        self.assertEqual(feedback.score, feedback.content["mean_return"])
         document = json.loads(feedback.artifacts[0].read_bytes().splitlines()[0])
         self.assertEqual(document["outcome"], "success")
         self.assertEqual(document["target_color"], "grey")
@@ -247,7 +248,8 @@ class LockedRoomTests(unittest.TestCase):
                 episode_timeout_seconds=10,
             ),
         )
-        self.assertEqual(result.feedback.score, 1.0)
+        self.assertEqual(result.feedback.content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
         self.assertIsInstance(result.feedback.content, dict)
         assert isinstance(result.feedback.content, dict)
         for name in (

--- a/environments/minigrid/minigrid/memory/README.md
+++ b/environments/minigrid/minigrid/memory/README.md
@@ -7,7 +7,7 @@ partially observable T-maze.
 The Policy sees the upstream `7 × 7 × 3` egocentric symbolic image, compass
 direction, and mission text. It must remember whether the green cue was a key
 or a ball, walk down the corridor, and select the matching object. The primary
-score is Episode success rate.
+score is mean upstream Episode return; success rate remains separately reported.
 
 Only `turn_left`, `turn_right`, and `move_forward` are public Actions. The
 upstream environment silently rewrites its nominal `pickup` Action into

--- a/environments/minigrid/minigrid/memory/src/minigrid_memory/benchmark.py
+++ b/environments/minigrid/minigrid/memory/src/minigrid_memory/benchmark.py
@@ -96,7 +96,7 @@ class _EpisodeDiagnostics:
 
 
 class MemoryBenchmark:
-    """Success rate on a partially observable object-memory T-maze."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: MemoryConfig | None = None) -> None:
         if config is None:
@@ -142,7 +142,7 @@ class MemoryBenchmark:
 
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
         mean_return = statistics.fmean(
             record.total_reward if record.policy_failure is None else 0.0 for record in records
         )
@@ -168,11 +168,11 @@ class MemoryBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Reached the matching object in {successes}/{len(records)} "
-                f"Episodes ({score:.3f} success rate); {wrong_targets} chose "
+                f"Episodes ({success_rate:.3f} success rate); {wrong_targets} chose "
                 f"the wrong target, {key_found} saw a green key, and "
                 f"{ball_found} saw a green ball."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "wrong_target_rate": wrong_targets / len(records),
             "green_key_found_rate": key_found / len(records),
             "green_ball_found_rate": ball_found / len(records),
@@ -231,7 +231,7 @@ class MemoryBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -239,11 +239,11 @@ class MemoryBenchmark:
 
 def _benchmark_spec(config: MemoryConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/Memory-v0/success-rate-v1",
+        id="minigrid/Memory-v0/mean-return-v1",
         description=(
             "Remember whether the green cue is a key or ball, traverse the "
             "partially observable hallway, and choose the matching object at "
-            "the T-junction. Maximize success rate."
+            "the T-junction. Maximize upstream Episode return."
         ),
         observation_space={
             "type": "object",
@@ -318,7 +318,7 @@ def _benchmark_spec(config: MemoryConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/memory/tests/test_memory.py
+++ b/environments/minigrid/minigrid/memory/tests/test_memory.py
@@ -30,7 +30,7 @@ class MemoryBenchmarkTests(unittest.TestCase):
 
         self.assertEqual(
             default.spec.id,
-            "minigrid/Memory-v0/success-rate-v1",
+            "minigrid/Memory-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 845)
         self.assertEqual(large.spec.max_episode_steps, 1_445)
@@ -294,13 +294,16 @@ class MemoryBenchmarkTests(unittest.TestCase):
 
                 self.assertEqual(
                     result.benchmark_id,
-                    "minigrid/Memory-v0/success-rate-v1",
+                    "minigrid/Memory-v0/mean-return-v1",
                 )
                 self.assertEqual(
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/multiroom/README.md
+++ b/environments/minigrid/minigrid/multiroom/README.md
@@ -7,7 +7,7 @@ navigation task.
 The Policy receives the upstream `7 × 7 × 3` egocentric symbolic image,
 compass direction, and fixed mission. It must discover a chain of rooms, open
 the connecting doors, and reach the green goal in the final room. The primary
-score is Episode success rate.
+score is mean upstream Episode return; success rate remains separately reported.
 
 The image uses `image[view_x, view_y, channel]`: the agent is at `(3, 6)`,
 forward decreases `view_y`, and right increases `view_x`. Actions `3`

--- a/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/benchmark.py
+++ b/environments/minigrid/minigrid/multiroom/src/minigrid_multiroom/benchmark.py
@@ -195,7 +195,7 @@ class _EpisodeDiagnostics:
 
 
 class MultiRoomBenchmark:
-    """Success rate on a partially observable connected-room task."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: MultiRoomConfig | None = None) -> None:
         if config is None:
@@ -241,7 +241,11 @@ class MultiRoomBenchmark:
 
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         milestones = {
             name: sum(_reached_bool_milestone(record, metric) for record in records)
             for name, metric in _MILESTONES.items()
@@ -255,11 +259,11 @@ class MultiRoomBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Reached the final-room goal in {successes}/{len(records)} "
-                f"Episodes ({score:.3f} success rate); recorded "
+                f"Episodes ({success_rate:.3f} success rate); recorded "
                 f"{sum(item.door_open_event_count for item in diagnostics)} "
                 "door-opening events."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "mean_door_open_event_count": _mean_or_none(
                 tuple(float(item.door_open_event_count) for item in diagnostics)
             ),
@@ -323,7 +327,7 @@ class MultiRoomBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -331,11 +335,11 @@ class MultiRoomBenchmark:
 
 def _benchmark_spec(config: MultiRoomConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/MultiRoom-v0/success-rate-v1",
+        id="minigrid/MultiRoom-v0/mean-return-v1",
         description=(
             "Explore a chain of partially observable rooms, open successive "
             "doors, and reach the green goal in the final room. Maximize "
-            "success rate."
+            "upstream Episode return."
         ),
         observation_space={
             "type": "object",
@@ -415,7 +419,7 @@ def _benchmark_spec(config: MultiRoomConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/multiroom/tests/test_multiroom.py
+++ b/environments/minigrid/minigrid/multiroom/tests/test_multiroom.py
@@ -29,7 +29,7 @@ class MultiRoomBenchmarkTests(unittest.TestCase):
         fixed = MultiRoomBenchmark(MultiRoomConfig(profile="N4-S5"))
         legacy = MultiRoomBenchmark(MultiRoomConfig(profile="N4-S5-v0-legacy-N6"))
 
-        self.assertEqual(default.spec.id, "minigrid/MultiRoom-v0/success-rate-v1")
+        self.assertEqual(default.spec.id, "minigrid/MultiRoom-v0/mean-return-v1")
         self.assertEqual(default.spec.max_episode_steps, 120)
         self.assertEqual(small.spec.max_episode_steps, 40)
         self.assertEqual(fixed.spec.max_episode_steps, 80)
@@ -264,10 +264,13 @@ class MultiRoomBenchmarkTests(unittest.TestCase):
 
                 self.assertEqual(
                     result.benchmark_id,
-                    "minigrid/MultiRoom-v0/success-rate-v1",
+                    "minigrid/MultiRoom-v0/mean-return-v1",
                 )
                 self.assertEqual(result.environment_digest, benchmark.spec.environment_digest)
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["goal_found_rate"], 1.0)

--- a/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/benchmark.py
+++ b/environments/minigrid/minigrid/obstructed_maze/src/minigrid_obstructed_maze/benchmark.py
@@ -227,7 +227,7 @@ class _EpisodeDiagnostics:
 
 
 class ObstructedMazeBenchmark:
-    """Success rate for the complete blocked-door manipulation chain."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: ObstructedMazeConfig | None = None) -> None:
         if config is None:
@@ -272,7 +272,11 @@ class ObstructedMazeBenchmark:
             raise TypeError("episodes must contain EpisodeRecord values")
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         counts = {name: _milestone_count(records, name) for name in _MILESTONES}
         diagnostics = tuple(
             _episode_diagnostics(record)
@@ -283,9 +287,9 @@ class ObstructedMazeBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Collected the blue target ball in {successes}/{len(records)} "
-                f"Episodes ({score:.3f} success rate)."
+                f"Episodes ({success_rate:.3f} success rate)."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "profile_requires_key_box_opening": self._config.key_in_box,
             "profile_requires_blocker_relocation": self._config.blocked,
             "upstream_key_blocker_overlap_possible": (self._config.key_blocker_overlap_possible),
@@ -357,7 +361,7 @@ class ObstructedMazeBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -372,7 +376,7 @@ def _benchmark_spec(config: ObstructedMazeConfig) -> BenchmarkSpec:
         else None
     )
     return BenchmarkSpec(
-        id="minigrid/ObstructedMaze-v0/success-rate-v1",
+        id="minigrid/ObstructedMaze-v0/mean-return-v1",
         description=(
             "Navigate a room maze, optionally open grey boxes containing "
             "keys and relocate green balls obstructing doors, unlock the "
@@ -469,7 +473,7 @@ def _benchmark_spec(config: ObstructedMazeConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/obstructed_maze/tests/test_obstructed_maze.py
+++ b/environments/minigrid/minigrid/obstructed_maze/tests/test_obstructed_maze.py
@@ -83,7 +83,7 @@ class ObstructedMazeTests(unittest.TestCase):
         benchmark = ObstructedMazeBenchmark()
         self.assertEqual(
             benchmark.spec.id,
-            "minigrid/ObstructedMaze-v0/success-rate-v1",
+            "minigrid/ObstructedMaze-v0/mean-return-v1",
         )
         self.assertEqual(benchmark.spec.max_episode_steps, 288)
         full = ObstructedMazeBenchmark(ObstructedMazeConfig(profile="Full-v1"))
@@ -294,7 +294,10 @@ class ObstructedMazeTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertEqual(result.feedback.artifacts[0].name, "trace.jsonl")
                 documents = tuple(
                     json.loads(line)

--- a/environments/minigrid/minigrid/put_near/README.md
+++ b/environments/minigrid/minigrid/put_near/README.md
@@ -11,7 +11,7 @@ Picking up a wrong object terminates immediately. Every drop attempted while
 carrying also terminates: an actual adjacent drop succeeds, an actual
 non-adjacent drop is misplaced, and a drop into an occupied cell is a distinct
 blocked-drop failure that leaves the object carried. The primary score is
-Episode success rate.
+mean upstream Episode return; success rate remains separately reported.
 
 Although upstream documentation labels `toggle` unused, toggling an empty box
 destroys it without termination. Destroying either named mission object makes

--- a/environments/minigrid/minigrid/put_near/src/minigrid_put_near/benchmark.py
+++ b/environments/minigrid/minigrid/put_near/src/minigrid_put_near/benchmark.py
@@ -191,7 +191,7 @@ class _EpisodeDiagnostics:
 
 
 class PutNearBenchmark:
-    """Success rate on instruction-conditioned object rearrangement."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: PutNearConfig | None = None) -> None:
         if config is None:
@@ -236,7 +236,11 @@ class PutNearBenchmark:
             raise TypeError("episodes must contain EpisodeRecord values")
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         counts = {name: _milestone_count(records, name) for name in _MILESTONES}
         diagnostics = tuple(
             _episode_diagnostics(record)
@@ -247,12 +251,12 @@ class PutNearBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Placed the requested object near its target in "
-                f"{successes}/{len(records)} Episodes ({score:.3f} success rate); "
+                f"{successes}/{len(records)} Episodes ({success_rate:.3f} success rate); "
                 f"{counts['wrong_object_picked_up']} wrong pickups, "
                 f"{counts['misplaced_drop']} misplaced drops, and "
                 f"{counts['blocked_terminal_drop']} blocked terminal drops."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "mean_return": statistics.fmean(
                 record.total_reward if record.policy_failure is None else 0.0 for record in records
             ),
@@ -307,7 +311,7 @@ class PutNearBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -315,11 +319,11 @@ class PutNearBenchmark:
 
 def _benchmark_spec(config: PutNearConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/PutNear-v0/success-rate-v1",
+        id="minigrid/PutNear-v0/mean-return-v1",
         description=(
             "Parse a relational mission, pick up exactly the requested "
             "colored object, and drop it in an empty cell adjacent to the "
-            "named target object. Maximize success rate."
+            "named target object. Maximize upstream Episode return."
         ),
         observation_space={
             "type": "object",
@@ -412,7 +416,7 @@ def _benchmark_spec(config: PutNearConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/put_near/tests/test_put_near.py
+++ b/environments/minigrid/minigrid/put_near/tests/test_put_near.py
@@ -26,7 +26,7 @@ class PutNearBenchmarkTests(unittest.TestCase):
         default = PutNearBenchmark()
         small = PutNearBenchmark(PutNearConfig(profile="6x6-N2"))
 
-        self.assertEqual(default.spec.id, "minigrid/PutNear-v0/success-rate-v1")
+        self.assertEqual(default.spec.id, "minigrid/PutNear-v0/mean-return-v1")
         self.assertEqual(default.spec.max_episode_steps, 40)
         self.assertEqual(small.spec.max_episode_steps, 30)
         self.assertNotEqual(default.spec.environment_digest, small.spec.environment_digest)
@@ -263,10 +263,13 @@ class PutNearBenchmarkTests(unittest.TestCase):
                 assert isinstance(content, dict)
                 self.assertEqual(
                     result.benchmark_id,
-                    "minigrid/PutNear-v0/success-rate-v1",
+                    "minigrid/PutNear-v0/mean-return-v1",
                 )
                 self.assertEqual(result.environment_digest, benchmark.spec.environment_digest)
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertEqual(content["wrong_object_picked_up_rate"], 0.0)
                 self.assertEqual(content["misplaced_drop_rate"], 0.0)
                 self.assertEqual(content["blocked_terminal_drop_rate"], 0.0)

--- a/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/benchmark.py
+++ b/environments/minigrid/minigrid/red_blue_doors/src/minigrid_red_blue_doors/benchmark.py
@@ -110,7 +110,7 @@ class _EpisodeDiagnostics:
 
 
 class RedBlueDoorsBenchmark:
-    """Success rate for opening two colored doors in order."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(
         self,
@@ -158,7 +158,7 @@ class RedBlueDoorsBenchmark:
             raise TypeError("episodes must contain EpisodeRecord values")
         successful = tuple(record for record in records if _successful(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
         red_found = _milestone_count(records, "red_door_found")
         blue_found = _milestone_count(records, "blue_door_found")
         red_opened = _milestone_count(records, "red_door_opened")
@@ -188,11 +188,11 @@ class RedBlueDoorsBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Opened red then blue in {successes}/{len(records)} "
-                f"Episodes ({score:.3f} success rate); {blue_before_red} "
+                f"Episodes ({success_rate:.3f} success rate); {blue_before_red} "
                 f"opened blue before ever opening red and "
                 f"{blue_after_reclose} opened blue after reclosing red."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "red_door_found_rate": red_found / len(records),
             "blue_door_found_rate": blue_found / len(records),
             "red_door_opened_rate": red_opened / len(records),
@@ -259,7 +259,7 @@ class RedBlueDoorsBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace_artifact(traced),),
         )
@@ -267,10 +267,10 @@ class RedBlueDoorsBenchmark:
 
 def _benchmark_spec(config: RedBlueDoorsConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/RedBlueDoors-v0/success-rate-v1",
+        id="minigrid/RedBlueDoors-v0/mean-return-v1",
         description=(
             "Explore the central room, open the red door, then open the blue "
-            "door. Opening blue first fails immediately. Maximize success rate."
+            "door. Opening blue first fails immediately. Maximize upstream Episode return."
         ),
         observation_space={
             "type": "object",
@@ -343,7 +343,7 @@ def _benchmark_spec(config: RedBlueDoorsConfig) -> BenchmarkSpec:
             "time_limit": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/red_blue_doors/tests/test_red_blue_doors.py
+++ b/environments/minigrid/minigrid/red_blue_doors/tests/test_red_blue_doors.py
@@ -28,7 +28,7 @@ class RedBlueDoorsBenchmarkTests(unittest.TestCase):
         small = RedBlueDoorsBenchmark(RedBlueDoorsConfig(profile="6x6"))
         self.assertEqual(
             default.spec.id,
-            "minigrid/RedBlueDoors-v0/success-rate-v1",
+            "minigrid/RedBlueDoors-v0/mean-return-v1",
         )
         self.assertEqual(default.spec.max_episode_steps, 1_280)
         self.assertEqual(small.spec.max_episode_steps, 720)
@@ -223,7 +223,10 @@ class RedBlueDoorsBenchmarkTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertIsInstance(result.feedback.content, dict)
                 assert isinstance(result.feedback.content, dict)
                 self.assertEqual(

--- a/environments/minigrid/minigrid/unlock/src/minigrid_unlock/benchmark.py
+++ b/environments/minigrid/minigrid/unlock/src/minigrid_unlock/benchmark.py
@@ -136,7 +136,7 @@ class _EpisodeDiagnostics:
 
 
 class UnlockBenchmark:
-    """Success rate for finding a matching key and opening a locked door."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self) -> None:
         self._spec = _spec()
@@ -172,7 +172,11 @@ class UnlockBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         counts = {name: sum(_reached(record, name) for record in records) for name in _MILESTONES}
         successful = tuple(record for record in records if _success(record))
         diagnostics = tuple(
@@ -184,9 +188,9 @@ class UnlockBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Opened the locked door in {successes}/{len(records)} "
-                f"Episodes ({score:.3f} success rate)."
+                f"Episodes ({success_rate:.3f} success rate)."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "mean_return": statistics.fmean(
                 record.total_reward if record.policy_failure is None else 0.0 for record in records
             ),
@@ -244,7 +248,7 @@ class UnlockBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace(traced),),
         )
@@ -252,10 +256,10 @@ class UnlockBenchmark:
 
 def _spec() -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/Unlock-v0/success-rate-v1",
+        id="minigrid/Unlock-v0/mean-return-v1",
         description=(
             "Explore the first room, pick up the key matching the locked "
-            "door, and unlock it. Maximize Episode success rate."
+            "door, and unlock it. Maximize upstream Episode return."
         ),
         observation_space={
             "type": "object",
@@ -328,7 +332,7 @@ def _spec() -> BenchmarkSpec:
             "time_limit": 8 * 6**2,
         },
         max_episode_steps=8 * 6**2,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/unlock/tests/test_unlock.py
+++ b/environments/minigrid/minigrid/unlock/tests/test_unlock.py
@@ -25,7 +25,7 @@ class UnlockTests(unittest.TestCase):
         benchmark = UnlockBenchmark()
         self.assertEqual(
             benchmark.spec.id,
-            "minigrid/Unlock-v0/success-rate-v1",
+            "minigrid/Unlock-v0/mean-return-v1",
         )
         self.assertEqual(benchmark.spec.max_episode_steps, 288)
         self.assertEqual(
@@ -140,7 +140,8 @@ class UnlockTests(unittest.TestCase):
         self.assertEqual(final.metrics["terminal_reason"], "success")
 
         feedback = benchmark.feedback((record,))
-        self.assertEqual(feedback.score, 1.0)
+        self.assertEqual(feedback.content["success_rate"], 1.0)
+        self.assertEqual(feedback.score, feedback.content["mean_return"])
         document = json.loads(feedback.artifacts[0].read_bytes().splitlines()[0])
         self.assertEqual(document["outcome"], "success")
         self.assertEqual(document["key_color_found"], "green")
@@ -176,7 +177,8 @@ class UnlockTests(unittest.TestCase):
                 episode_timeout_seconds=10,
             ),
         )
-        self.assertEqual(result.feedback.score, 1.0)
+        self.assertEqual(result.feedback.content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
         self.assertIsInstance(result.feedback.content, dict)
         assert isinstance(result.feedback.content, dict)
         self.assertEqual(

--- a/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/benchmark.py
+++ b/environments/minigrid/minigrid/unlock_pickup/src/minigrid_unlock_pickup/benchmark.py
@@ -157,7 +157,7 @@ class _EpisodeDiagnostics:
 
 
 class UnlockPickupBenchmark:
-    """Success rate for unlocking a room and collecting its target box."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self) -> None:
         self._spec = _spec()
@@ -193,7 +193,11 @@ class UnlockPickupBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         counts = {name: sum(_reached(record, name) for record in records) for name in _MILESTONES}
         successful = tuple(record for record in records if _success(record))
         diagnostics = tuple(
@@ -206,10 +210,10 @@ class UnlockPickupBenchmark:
             "summary": (
                 f"Unlocked the room and collected the target in "
                 f"{successes}/{len(records)} Episodes "
-                f"({score:.3f} success rate); "
+                f"({success_rate:.3f} success rate); "
                 f"{counts['target_destroyed']} destroyed the target box."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "mean_return": statistics.fmean(
                 record.total_reward if record.policy_failure is None else 0.0 for record in records
             ),
@@ -270,7 +274,7 @@ class UnlockPickupBenchmark:
                 )
             )
         return Feedback(
-            score=score,
+            score=mean_return,
             content=content,
             artifacts=(_trace(traced),),
         )
@@ -278,7 +282,7 @@ class UnlockPickupBenchmark:
 
 def _spec() -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/UnlockPickup-v0/success-rate-v1",
+        id="minigrid/UnlockPickup-v0/mean-return-v1",
         description=(
             "Find the key matching a locked door, unlock the second room, "
             "free the carrying slot, and pick up the mission box."
@@ -354,7 +358,7 @@ def _spec() -> BenchmarkSpec:
             "time_limit": 8 * 6**2,
         },
         max_episode_steps=8 * 6**2,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/unlock_pickup/tests/test_unlock_pickup.py
+++ b/environments/minigrid/minigrid/unlock_pickup/tests/test_unlock_pickup.py
@@ -45,7 +45,7 @@ class UnlockPickupTests(unittest.TestCase):
         benchmark = UnlockPickupBenchmark()
         self.assertEqual(
             benchmark.spec.id,
-            "minigrid/UnlockPickup-v0/success-rate-v1",
+            "minigrid/UnlockPickup-v0/mean-return-v1",
         )
         self.assertEqual(benchmark.spec.max_episode_steps, 288)
         self.assertEqual(
@@ -217,7 +217,8 @@ class UnlockPickupTests(unittest.TestCase):
                 episode_timeout_seconds=10,
             ),
         )
-        self.assertEqual(result.feedback.score, 1.0)
+        self.assertEqual(result.feedback.content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
         self.assertIsInstance(result.feedback.content, dict)
         assert isinstance(result.feedback.content, dict)
         for name in (

--- a/environments/minigrid/minigrid/wfc/src/minigrid_wfc/benchmark.py
+++ b/environments/minigrid/minigrid/wfc/src/minigrid_wfc/benchmark.py
@@ -126,7 +126,7 @@ class _EpisodeDiagnostics:
 
 
 class WFCBenchmark:
-    """Navigation success rate in a selected WFC-generated maze family."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: WFCConfig | None = None) -> None:
         if config is None:
@@ -168,7 +168,11 @@ class WFCBenchmark:
             raise TypeError("episodes must contain EpisodeRecord values")
         successful = tuple(record for record in records if _success(record))
         successes = len(successful)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        mean_return = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         milestones = {
             name: sum(_reached(record, name) for record in records) for name in _MILESTONES
         }
@@ -181,9 +185,9 @@ class WFCBenchmark:
         content: dict[str, PolicyValue] = {
             "summary": (
                 f"Reached the generated goal in {successes}/{len(records)} "
-                f"Episodes ({score:.3f} success rate)."
+                f"Episodes ({success_rate:.3f} success rate)."
             ),
-            "success_rate": score,
+            "success_rate": success_rate,
             "goal_found_rate": milestones["goal_found"] / len(records),
             "mean_return": statistics.fmean(
                 record.total_reward if record.policy_failure is None else 0.0 for record in records
@@ -232,12 +236,12 @@ class WFCBenchmark:
                     for item in diagnostics
                 )
             )
-        return Feedback(score=score, content=content, artifacts=(_trace(traced),))
+        return Feedback(score=mean_return, content=content, artifacts=(_trace(traced),))
 
 
 def _spec(config: WFCConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id="minigrid/WFC-v0/success-rate-v1",
+        id="minigrid/WFC-v0/mean-return-v1",
         description=(
             "Generate a fresh Wave Function Collapse level from the selected "
             "public pattern preset, navigate its connected component, and "
@@ -320,7 +324,7 @@ def _spec(config: WFCConfig) -> BenchmarkSpec:
             "natural_termination": ("moving forward onto the green goal terminates with success"),
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/minigrid/minigrid/wfc/tests/test_wfc.py
+++ b/environments/minigrid/minigrid/wfc/tests/test_wfc.py
@@ -61,7 +61,7 @@ class WFCTests(unittest.TestCase):
         spec = WFCBenchmark().spec
         parameters = spec.environment_parameters
 
-        self.assertEqual(spec.id, "minigrid/WFC-v0/success-rate-v1")
+        self.assertEqual(spec.id, "minigrid/WFC-v0/mean-return-v1")
         self.assertEqual(spec.max_episode_steps, 2500)
         self.assertEqual(spec.metadata["environment"], "MiniGrid-WFC-MazeSimple-v0")
         self.assertEqual(parameters["procedurally_generated_each_episode"], True)
@@ -251,7 +251,10 @@ class WFCTests(unittest.TestCase):
                 )
                 content = result.feedback.content
                 assert isinstance(content, dict)
-                self.assertEqual(result.feedback.score, 1.0)
+                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                self.assertEqual(
+                    result.feedback.score, result.feedback.content["mean_return"]
+                )
                 self.assertEqual(content["goal_found_rate"], 1.0)
                 documents = tuple(
                     json.loads(line)

--- a/environments/robosuite/robosuite/README.md
+++ b/environments/robosuite/robosuite/README.md
@@ -6,7 +6,8 @@ robosuite 1.5.2 through EvoPolicyGym's public authoring API.
 `RobosuiteConfig.profile` selects one fixed task for a Run. Single-arm tasks
 use one Panda; two-arm tasks use two opposed Pandas. All profiles use the
 upstream BASIC composite controller with OSC pose control, state observations,
-upstream dense shaping where implemented, and success-rate scoring.
+upstream dense shaping where implemented, and mean-return scoring. Success
+rate remains a separately reported task-completion outcome.
 
 ```python
 from robosuite_benchmarks import RobosuiteBenchmark, RobosuiteConfig

--- a/environments/robosuite/robosuite/src/robosuite_benchmarks/benchmark.py
+++ b/environments/robosuite/robosuite/src/robosuite_benchmarks/benchmark.py
@@ -38,7 +38,7 @@ _TRACE_SUFFIX_STEPS = 8
 
 
 class RobosuiteBenchmark:
-    """Success rate for one fixed robosuite manipulation profile."""
+    """Mean upstream Episode return for this Benchmark."""
 
     def __init__(self, config: RobosuiteConfig | None = None) -> None:
         if config is None:
@@ -82,7 +82,11 @@ class RobosuiteBenchmark:
         if any(type(record) is not EpisodeRecord for record in records):
             raise TypeError("episodes must contain EpisodeRecord values")
         successes = sum(_success(record) for record in records)
-        score = successes / len(records)
+        success_rate = successes / len(records)
+        score = statistics.fmean(
+            record.total_reward if record.policy_failure is None else 0.0
+            for record in records
+        )
         final_metrics = tuple(
             metrics for record in records if (metrics := _final_metrics(record)) is not None
         )
@@ -106,14 +110,11 @@ class RobosuiteBenchmark:
             content={
                 "summary": (
                     f"Solved {successes}/{len(records)} robosuite Episodes "
-                    f"({score:.3f} success rate)."
+                    f"({success_rate:.3f} success rate) with {score:.3f} mean return."
                 ),
                 "profile": self._config.profile,
-                "success_rate": score,
-                "mean_return": statistics.fmean(
-                    record.total_reward if record.policy_failure is None else 0.0
-                    for record in records
-                ),
+                "success_rate": success_rate,
+                "mean_return": score,
                 "mean_steps": statistics.fmean(record.steps for record in records),
                 "mean_steps_to_first_success": _mean_present(
                     tuple(
@@ -175,7 +176,7 @@ def _artifact_episode_count(manifests: Sequence[PolicyValue], key: str) -> int:
 
 def _spec(config: RobosuiteConfig) -> BenchmarkSpec:
     return BenchmarkSpec(
-        id=f"robosuite/{config.environment_id}/panda-state/success-rate-v1",
+        id=f"robosuite/{config.environment_id}/panda-state/mean-return-v1",
         description=(
             f"Complete robosuite {config.environment_id} with fixed Panda "
             "robots and the BASIC operational-space controller."
@@ -238,7 +239,7 @@ def _spec(config: RobosuiteConfig) -> BenchmarkSpec:
             "max_episode_steps": config.max_episode_steps,
         },
         max_episode_steps=config.max_episode_steps,
-        primary_metric="success_rate",
+        primary_metric="mean_return",
         score_direction="maximize",
     )
 

--- a/environments/robosuite/robosuite/tests/test_robosuite_benchmarks.py
+++ b/environments/robosuite/robosuite/tests/test_robosuite_benchmarks.py
@@ -247,6 +247,9 @@ class RobosuiteBenchmarkTests(unittest.TestCase):
             ],
         )
         assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.score, feedback.content["mean_return"])
+        self.assertEqual(benchmark.spec.primary_metric, "mean_return")
+        self.assertTrue(benchmark.spec.id.endswith("/mean-return-v1"))
         self.assertEqual(feedback.content["video_episodes"], 3)
         self.assertEqual(feedback.content["video_episode_results"], 3)
         self.assertEqual(feedback.content["video_episodes_without_gif"], 0)


### PR DESCRIPTION
## What changed

- use mean upstream Episode return as the primary score for MetaWorld, robosuite, Gymnasium-Robotics, and 22 MiniGrid/BabyAI Benchmarks
- retain success rate as a separately reported task-completion outcome
- add profile-specific Policy-failure returns for Gymnasium-Robotics
- rename affected Benchmark identities from `success-rate-v1` to `mean-return-v1`
- update tests and environment documentation

## Why

Success rate loses selection signal when candidates are all unsolved or all successful. Environment return preserves progress, time efficiency, and sustained task quality while success rate remains visible for interpretation and leaderboard reporting.

## Impact

Validation now selects candidates using mean environment return for the affected Benchmarks. FrozenLake remains success-rate-scored because its binary return is numerically equivalent to success rate.

## Validation

- 359 unit tests passed across the Kernel and affected environment packages
- `uv run ruff check ...`
- `uv run mypy`
- `git diff --check`
- Luna end-to-end MetaWorld `reach-v3` Run: validation `4833.61`, held-out assessment `4846.22`, zero Policy failures
