### PR TITLE
tests: narrow MiniGrid feedback content

### DIFF
--- a/environments/minigrid/babyai/tests/test_babyai.py
+++ b/environments/minigrid/babyai/tests/test_babyai.py
@@ -287,8 +287,8 @@ class BabyAITests(unittest.TestCase):
 
         content = result.feedback.content
         assert isinstance(content, dict)
-        self.assertEqual(result.feedback.content["success_rate"], 1.0)
-        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
+        self.assertEqual(content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, content["mean_return"])
         self.assertEqual(content["door_opened_this_step_rate"], 1.0)
         self.assertGreater(_number_metric(content, "mean_unique_observation_count"), 0)
         documents = tuple(

--- a/environments/minigrid/minigrid/blocked_unlock_pickup/tests/test_blocked_unlock_pickup.py
+++ b/environments/minigrid/minigrid/blocked_unlock_pickup/tests/test_blocked_unlock_pickup.py
@@ -225,10 +225,10 @@ class BlockedUnlockPickupTests(unittest.TestCase):
                 episode_timeout_seconds=10,
             ),
         )
-        self.assertEqual(result.feedback.content["success_rate"], 1.0)
-        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
-        self.assertIsInstance(result.feedback.content, dict)
-        assert isinstance(result.feedback.content, dict)
+        content = result.feedback.content
+        assert isinstance(content, dict)
+        self.assertEqual(content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, content["mean_return"])
         for field in (
             "blocker_moved_rate",
             "blocker_dropped_rate",
@@ -238,14 +238,14 @@ class BlockedUnlockPickupTests(unittest.TestCase):
             "door_opened_rate",
             "target_found_rate",
         ):
-            self.assertEqual(result.feedback.content[field], 1.0)
+            self.assertEqual(content[field], 1.0)
         for field in (
             "target_destroyed_rate",
             "failed_pickup_rate",
             "failed_drop_rate",
             "failed_toggle_rate",
         ):
-            self.assertEqual(result.feedback.content[field], 0.0)
+            self.assertEqual(content[field], 0.0)
         self.assertEqual(
             result.feedback.artifacts[0].name,
             "trace.jsonl",

--- a/environments/minigrid/minigrid/crossing/tests/test_crossing.py
+++ b/environments/minigrid/minigrid/crossing/tests/test_crossing.py
@@ -185,12 +185,12 @@ class CrossingTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(
                     result.feedback.content["hazard_rate"],
                     0.0,

--- a/environments/minigrid/minigrid/dist_shift/tests/test_dist_shift.py
+++ b/environments/minigrid/minigrid/dist_shift/tests/test_dist_shift.py
@@ -182,12 +182,12 @@ class DistShiftTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(
                     result.feedback.content["hazard_rate"],
                     0.0,

--- a/environments/minigrid/minigrid/doorkey/tests/test_doorkey.py
+++ b/environments/minigrid/minigrid/doorkey/tests/test_doorkey.py
@@ -225,12 +225,12 @@ class DoorKeyBenchmarkTests(unittest.TestCase):
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(
                     result.feedback.content["key_pickup_rate"],
                     1.0,

--- a/environments/minigrid/minigrid/dynamic_obstacles/tests/test_dynamic_obstacles.py
+++ b/environments/minigrid/minigrid/dynamic_obstacles/tests/test_dynamic_obstacles.py
@@ -339,12 +339,12 @@ class DynamicObstaclesBenchmarkTests(unittest.TestCase):
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(
                     result.feedback.content["collision_rate"],
                     0.0,

--- a/environments/minigrid/minigrid/empty/tests/test_empty.py
+++ b/environments/minigrid/minigrid/empty/tests/test_empty.py
@@ -114,14 +114,12 @@ class EmptyTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
-                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                content = result.feedback.content
+                assert isinstance(content, dict)
+                self.assertEqual(content["success_rate"], 1.0)
+                self.assertEqual(result.feedback.score, content["mean_return"])
                 self.assertEqual(
-                    result.feedback.score, result.feedback.content["mean_return"]
-                )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
-                self.assertEqual(
-                    result.feedback.content["episodes_goal_found_but_not_reached"],
+                    content["episodes_goal_found_but_not_reached"],
                     0,
                 )
 

--- a/environments/minigrid/minigrid/fetch/tests/test_fetch.py
+++ b/environments/minigrid/minigrid/fetch/tests/test_fetch.py
@@ -248,10 +248,10 @@ class FetchBenchmarkTests(unittest.TestCase):
         self.assertEqual(failed_metrics["terminal_reason"], "none")
 
         feedback = benchmark.feedback((success_record, wrong_record, failed_record))
-        self.assertEqual(feedback.content["success_rate"], 1 / 3)
-        self.assertEqual(feedback.score, feedback.content["mean_return"])
         self.assertIsInstance(feedback.content, dict)
         assert isinstance(feedback.content, dict)
+        self.assertEqual(feedback.content["success_rate"], 1 / 3)
+        self.assertEqual(feedback.score, feedback.content["mean_return"])
         self.assertEqual(feedback.content["wrong_object_rate"], 1 / 3)
         self.assertEqual(
             feedback.content["failed_pickup_episode_rate"],
@@ -311,12 +311,12 @@ class FetchBenchmarkTests(unittest.TestCase):
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(
                     result.feedback.content["target_found_rate"],
                     1.0,

--- a/environments/minigrid/minigrid/four_rooms/tests/test_four_rooms.py
+++ b/environments/minigrid/minigrid/four_rooms/tests/test_four_rooms.py
@@ -87,12 +87,12 @@ class FourRoomsTests(unittest.TestCase):
                 episode_timeout_seconds=10,
             ),
         )
-        self.assertEqual(result.feedback.content["success_rate"], 1.0)
-        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
-        self.assertIsInstance(result.feedback.content, dict)
-        assert isinstance(result.feedback.content, dict)
+        content = result.feedback.content
+        assert isinstance(content, dict)
+        self.assertEqual(content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, content["mean_return"])
         self.assertEqual(
-            result.feedback.content["episodes_goal_found_but_not_reached"],
+            content["episodes_goal_found_but_not_reached"],
             0,
         )
 

--- a/environments/minigrid/minigrid/go_to_door/tests/test_go_to_door.py
+++ b/environments/minigrid/minigrid/go_to_door/tests/test_go_to_door.py
@@ -283,12 +283,12 @@ class GoToDoorBenchmarkTests(unittest.TestCase):
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(
                     result.feedback.content["target_found_rate"],
                     1.0,

--- a/environments/minigrid/minigrid/go_to_object/tests/test_go_to_object.py
+++ b/environments/minigrid/minigrid/go_to_object/tests/test_go_to_object.py
@@ -283,12 +283,12 @@ class GoToObjectBenchmarkTests(unittest.TestCase):
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(
                     result.feedback.content["target_found_rate"],
                     1.0,

--- a/environments/minigrid/minigrid/keycorridor/tests/test_keycorridor.py
+++ b/environments/minigrid/minigrid/keycorridor/tests/test_keycorridor.py
@@ -376,12 +376,12 @@ class KeyCorridorBenchmarkTests(unittest.TestCase):
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(
                     result.feedback.content["key_pickup_rate"],
                     1.0,

--- a/environments/minigrid/minigrid/lava_gap/tests/test_lava_gap.py
+++ b/environments/minigrid/minigrid/lava_gap/tests/test_lava_gap.py
@@ -175,12 +175,12 @@ class LavaGapTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(
                     result.feedback.content["hazard_rate"],
                     0.0,

--- a/environments/minigrid/minigrid/locked_room/tests/test_locked_room.py
+++ b/environments/minigrid/minigrid/locked_room/tests/test_locked_room.py
@@ -211,8 +211,10 @@ class LockedRoomTests(unittest.TestCase):
         self.assertEqual(final.metrics["terminal_reason"], "success")
 
         feedback = benchmark.feedback((record,))
-        self.assertEqual(feedback.content["success_rate"], 1.0)
-        self.assertEqual(feedback.score, feedback.content["mean_return"])
+        content = feedback.content
+        assert isinstance(content, dict)
+        self.assertEqual(content["success_rate"], 1.0)
+        self.assertEqual(feedback.score, content["mean_return"])
         document = json.loads(feedback.artifacts[0].read_bytes().splitlines()[0])
         self.assertEqual(document["outcome"], "success")
         self.assertEqual(document["target_color"], "grey")
@@ -248,10 +250,10 @@ class LockedRoomTests(unittest.TestCase):
                 episode_timeout_seconds=10,
             ),
         )
-        self.assertEqual(result.feedback.content["success_rate"], 1.0)
-        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
         self.assertIsInstance(result.feedback.content, dict)
         assert isinstance(result.feedback.content, dict)
+        self.assertEqual(result.feedback.content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
         for name in (
             "key_room_door_opened_rate",
             "key_picked_up_rate",

--- a/environments/minigrid/minigrid/memory/tests/test_memory.py
+++ b/environments/minigrid/minigrid/memory/tests/test_memory.py
@@ -300,18 +300,16 @@ class MemoryBenchmarkTests(unittest.TestCase):
                     result.environment_digest,
                     benchmark.spec.environment_digest,
                 )
-                self.assertEqual(result.feedback.content["success_rate"], 1.0)
+                content = result.feedback.content
+                assert isinstance(content, dict)
+                self.assertEqual(content["success_rate"], 1.0)
+                self.assertEqual(result.feedback.score, content["mean_return"])
                 self.assertEqual(
-                    result.feedback.score, result.feedback.content["mean_return"]
-                )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
-                self.assertEqual(
-                    result.feedback.content["wrong_target_rate"],
+                    content["wrong_target_rate"],
                     0.0,
                 )
                 self.assertIsNotNone(
-                    result.feedback.content["mean_decision_step"],
+                    content["mean_decision_step"],
                 )
                 trace = result.feedback.artifacts[0]
                 documents = tuple(json.loads(line) for line in trace.read_bytes().splitlines())

--- a/environments/minigrid/minigrid/multiroom/tests/test_multiroom.py
+++ b/environments/minigrid/minigrid/multiroom/tests/test_multiroom.py
@@ -267,12 +267,12 @@ class MultiRoomBenchmarkTests(unittest.TestCase):
                     "minigrid/MultiRoom-v0/mean-return-v1",
                 )
                 self.assertEqual(result.environment_digest, benchmark.spec.environment_digest)
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["goal_found_rate"], 1.0)
                 self.assertEqual(result.feedback.content["door_opened_rate"], 1.0)
                 trace = result.feedback.artifacts[0]

--- a/environments/minigrid/minigrid/obstructed_maze/tests/test_obstructed_maze.py
+++ b/environments/minigrid/minigrid/obstructed_maze/tests/test_obstructed_maze.py
@@ -294,10 +294,10 @@ class ObstructedMazeTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
-                self.assertEqual(result.feedback.content["success_rate"], 1.0)
-                self.assertEqual(
-                    result.feedback.score, result.feedback.content["mean_return"]
-                )
+                content = result.feedback.content
+                assert isinstance(content, dict)
+                self.assertEqual(content["success_rate"], 1.0)
+                self.assertEqual(result.feedback.score, content["mean_return"])
                 self.assertEqual(result.feedback.artifacts[0].name, "trace.jsonl")
                 documents = tuple(
                     json.loads(line)

--- a/environments/minigrid/minigrid/put_near/tests/test_put_near.py
+++ b/environments/minigrid/minigrid/put_near/tests/test_put_near.py
@@ -266,10 +266,8 @@ class PutNearBenchmarkTests(unittest.TestCase):
                     "minigrid/PutNear-v0/mean-return-v1",
                 )
                 self.assertEqual(result.environment_digest, benchmark.spec.environment_digest)
-                self.assertEqual(result.feedback.content["success_rate"], 1.0)
-                self.assertEqual(
-                    result.feedback.score, result.feedback.content["mean_return"]
-                )
+                self.assertEqual(content["success_rate"], 1.0)
+                self.assertEqual(result.feedback.score, content["mean_return"])
                 self.assertEqual(content["wrong_object_picked_up_rate"], 0.0)
                 self.assertEqual(content["misplaced_drop_rate"], 0.0)
                 self.assertEqual(content["blocked_terminal_drop_rate"], 0.0)

--- a/environments/minigrid/minigrid/red_blue_doors/tests/test_red_blue_doors.py
+++ b/environments/minigrid/minigrid/red_blue_doors/tests/test_red_blue_doors.py
@@ -223,12 +223,12 @@ class RedBlueDoorsBenchmarkTests(unittest.TestCase):
                         episode_timeout_seconds=10,
                     ),
                 )
+                self.assertIsInstance(result.feedback.content, dict)
+                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(result.feedback.content["success_rate"], 1.0)
                 self.assertEqual(
                     result.feedback.score, result.feedback.content["mean_return"]
                 )
-                self.assertIsInstance(result.feedback.content, dict)
-                assert isinstance(result.feedback.content, dict)
                 self.assertEqual(
                     result.feedback.content["red_door_opened_rate"],
                     1.0,

--- a/environments/minigrid/minigrid/unlock/tests/test_unlock.py
+++ b/environments/minigrid/minigrid/unlock/tests/test_unlock.py
@@ -140,8 +140,10 @@ class UnlockTests(unittest.TestCase):
         self.assertEqual(final.metrics["terminal_reason"], "success")
 
         feedback = benchmark.feedback((record,))
-        self.assertEqual(feedback.content["success_rate"], 1.0)
-        self.assertEqual(feedback.score, feedback.content["mean_return"])
+        content = feedback.content
+        assert isinstance(content, dict)
+        self.assertEqual(content["success_rate"], 1.0)
+        self.assertEqual(feedback.score, content["mean_return"])
         document = json.loads(feedback.artifacts[0].read_bytes().splitlines()[0])
         self.assertEqual(document["outcome"], "success")
         self.assertEqual(document["key_color_found"], "green")
@@ -177,10 +179,10 @@ class UnlockTests(unittest.TestCase):
                 episode_timeout_seconds=10,
             ),
         )
-        self.assertEqual(result.feedback.content["success_rate"], 1.0)
-        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
         self.assertIsInstance(result.feedback.content, dict)
         assert isinstance(result.feedback.content, dict)
+        self.assertEqual(result.feedback.content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
         self.assertEqual(
             result.feedback.content["key_picked_up_rate"],
             1.0,

--- a/environments/minigrid/minigrid/unlock_pickup/tests/test_unlock_pickup.py
+++ b/environments/minigrid/minigrid/unlock_pickup/tests/test_unlock_pickup.py
@@ -217,10 +217,10 @@ class UnlockPickupTests(unittest.TestCase):
                 episode_timeout_seconds=10,
             ),
         )
-        self.assertEqual(result.feedback.content["success_rate"], 1.0)
-        self.assertEqual(result.feedback.score, result.feedback.content["mean_return"])
-        self.assertIsInstance(result.feedback.content, dict)
-        assert isinstance(result.feedback.content, dict)
+        content = result.feedback.content
+        assert isinstance(content, dict)
+        self.assertEqual(content["success_rate"], 1.0)
+        self.assertEqual(result.feedback.score, content["mean_return"])
         for name in (
             "key_picked_up_rate",
             "key_dropped_rate",
@@ -228,14 +228,14 @@ class UnlockPickupTests(unittest.TestCase):
             "door_opened_rate",
             "target_found_rate",
         ):
-            self.assertEqual(result.feedback.content[name], 1.0)
+            self.assertEqual(content[name], 1.0)
         for name in (
             "target_destroyed_rate",
             "failed_pickup_rate",
             "failed_drop_rate",
             "failed_toggle_rate",
         ):
-            self.assertEqual(result.feedback.content[name], 0.0)
+            self.assertEqual(content[name], 0.0)
         documents = tuple(
             json.loads(line) for line in result.feedback.artifacts[0].read_bytes().splitlines()
         )

--- a/environments/minigrid/minigrid/wfc/tests/test_wfc.py
+++ b/environments/minigrid/minigrid/wfc/tests/test_wfc.py
@@ -251,10 +251,8 @@ class WFCTests(unittest.TestCase):
                 )
                 content = result.feedback.content
                 assert isinstance(content, dict)
-                self.assertEqual(result.feedback.content["success_rate"], 1.0)
-                self.assertEqual(
-                    result.feedback.score, result.feedback.content["mean_return"]
-                )
+                self.assertEqual(content["success_rate"], 1.0)
+                self.assertEqual(result.feedback.score, content["mean_return"])
                 self.assertEqual(content["goal_found_rate"], 1.0)
                 documents = tuple(
                     json.loads(line)


### PR DESCRIPTION
## Purpose
Fix the MiniGrid and BabyAI CI failures introduced by the mean-return scoring assertions.

## Changes
- narrow Feedback.content before indexing score metrics
- cover all 22 affected MiniGrid and BabyAI test packages, including Memory

## Verification
- mypy passed in all 22 affected packages
- 191 unit tests passed across all 22 packages
- uv run ruff check environments/minigrid

This changes tests only; benchmark scoring behavior is unchanged.