### PR TITLE
run: configure finish budget policy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -298,12 +298,20 @@ over-budget selections are rejected before Program capture. Reusing an index
 across Submissions is valid and consumes budget again. The mapping is fixed
 for the Run, while Evaluation still creates a fresh Environment, Policy
 process, Policy instance, and scratch directory for every selected index.
+When `finish_budget_policy` requires budget exhaustion, admission additionally
+rejects a selection that would leave more Episode units than the remaining
+Submission slots can consume. Session construction rejects a strict
+configuration whose total capacity can never exhaust its Episode budget.
 
 `finish` also uses `agent-session/v3` and accepts a non-empty
 `submission_ids` list. The Host rejects malformed, duplicate, unknown, or
 over-limit candidates before changing Session state. A successful request
 closes Agent authority; it does not select a final Program inside the Session.
-Without Validation, exactly one candidate is allowed.
+Without Validation, exactly one candidate is allowed. The default
+`allow_early` finish budget policy admits a valid request with unused Episode
+units. `require_budget_exhaustion` instead returns a retryable
+`budget_remaining` rejection until the remaining count is zero. That rejection
+does not close authority, publish a candidate set, or consume budget.
 
 Validation uses a Run-seed-derived domain-separated seed and one identical
 `EvaluationConfig` for every candidate. Selection compares primary score in
@@ -334,10 +342,10 @@ from older submissions in chronological order and updates each view's
 Artifacts, and the complete newest submission. Submission Feedback uses
 `evopolicygym/feedback/v2` and maps every public Episode summary to its
 Run-local training index. `run.json` uses
-`evopolicygym/run-record/v7`, retains the bulk capacity, pool size, derivation protocol,
-the public Environment parameters and canonical digest beside the Benchmark
-ID, selected index sets, selected Skill names, digests, and snapshot paths,
-and references the available aggregate reports.
+`evopolicygym/run-record/v8`, retains the finish budget policy, bulk capacity,
+pool size, derivation protocol, the public Environment parameters and canonical
+digest beside the Benchmark ID, selected index sets, selected Skill names,
+digests, and snapshot paths, and references the available aggregate reports.
 
 This is a logical lifecycle and publication boundary, not a security boundary:
 `ProcessExecution` remains non-isolated. A Benchmark that requires

--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ use separate private allocations after the Agent has finished.
 Episode budget makes interaction efficiency comparable within one Benchmark;
 it is not a cross-Benchmark measure of compute cost.
 
+`RunConfig.finish_budget_policy` controls whether the Agent may hand candidates
+to the Host before using every Episode unit. The default, `allow_early`, keeps
+the budget as a maximum and lets the Agent stop when further experimentation is
+not worthwhile. `require_budget_exhaustion` turns it into a required allocation:
+an early `finish` returns `budget_remaining` without closing Agent authority,
+and the Agent must continue submitting until `episodes_remaining` reaches zero.
+The strict policy also rejects submission sizes that would make full budget
+use impossible within the remaining Submission limit.
+
 ## Quickstart
 
 EvoPolicyGym requires Python 3.12 and
@@ -213,7 +222,10 @@ evopolicygym-session finish submission-000002 submission-000003
 
 `submit` requests an experiment over selected Run-local Episode indices.
 `finish` hands published candidates to the Host and permanently closes Agent
-authority before private Validation and Assessment.
+authority before private Validation and Assessment. Runs configured with
+`finish_budget_policy="require_budget_exhaustion"` reject `finish` while any
+Episode budget remains; the rejection is retryable and does not change the
+candidate set.
 
 For AI-assisted setup, SDK usage, provider integration, Benchmark authoring,
 and Run diagnostics, use the reusable

--- a/skills/evopolicygym/references/run.md
+++ b/skills/evopolicygym/references/run.md
@@ -48,6 +48,7 @@ result = run(
         episode_budget=48,
         episode_pool_size=96,
         max_episodes_per_submission=4,
+        finish_budget_policy="require_budget_exhaustion",
         validation=ValidationConfig(
             split="validation",
             episodes_per_candidate=10,
@@ -71,6 +72,10 @@ result = run(
   trace-heavy or otherwise batch-sensitive Feedback.
 - Choose `episode_pool_size` independently from `episode_budget` when the
   Agent needs more fixed matched conditions than it can spend.
+- Keep `finish_budget_policy="allow_early"` when Episode budget is a ceiling,
+  or select `"require_budget_exhaustion"` for comparable Runs that must spend
+  every Episode unit. In strict mode, make sure the configured Submission
+  count and per-Submission cap have enough total capacity.
 - Add `ConsoleProgress()` only as a non-authoritative observer. Observer
   failure must not change Run semantics.
 - State that `ProcessExecution.unsafe()` does not isolate the Agent or Policy.
@@ -101,6 +106,9 @@ submission, candidate handoff, budgets, and paths.
   Episode specification and Policy seed.
 - Treat a successful candidate handoff as the end of Agent authority. Host
   Validation and Assessment begin only after Agent cleanup.
+- In a strict finish-budget Run, treat `budget_remaining` as a retryable
+  rejection: continue legal submissions until `episodes_remaining` is zero,
+  then retry `finish` with the selected published candidates.
 
 ## Interpret Feedback and Host phases
 

--- a/src/evopolicygym/run/__init__.py
+++ b/src/evopolicygym/run/__init__.py
@@ -7,6 +7,7 @@ import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from ..agents import CodingAgent
 from ..benchmark import Benchmark
@@ -19,6 +20,11 @@ from .progress import ConsoleProgress, RunEvent, RunObserver
 _MAX_AGENT_SKILLS = 16
 _MAX_AGENT_SKILL_FILES = 2_048
 _MAX_AGENT_SKILL_BYTES = 64 * 1024 * 1024
+
+type FinishBudgetPolicy = Literal[
+    "allow_early",
+    "require_budget_exhaustion",
+]
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -61,6 +67,7 @@ class RunConfig:
     episode_budget: int = 1_000
     episode_pool_size: int | None = None
     max_episodes_per_submission: int | None = None
+    finish_budget_policy: FinishBudgetPolicy = "allow_early"
     bulk_feedback_retention_bytes: int = 1024 * 1024 * 1024
     validation: ValidationConfig | None = None
     assessment: AssessmentConfig | None = None
@@ -101,6 +108,27 @@ class RunConfig:
                     "max_episodes_per_submission cannot exceed "
                     "episode_pool_size"
                 )
+        if (
+            type(self.finish_budget_policy) is not str
+            or self.finish_budget_policy
+            not in {"allow_early", "require_budget_exhaustion"}
+        ):
+            raise ValueError(
+                "finish_budget_policy must be 'allow_early' or "
+                "'require_budget_exhaustion'"
+            )
+        configured_submission_capacity = (
+            pool_size if submission_limit is None else submission_limit
+        )
+        if (
+            self.finish_budget_policy == "require_budget_exhaustion"
+            and self.episode_budget
+            > self.max_submissions * configured_submission_capacity
+        ):
+            raise ValueError(
+                "finish_budget_policy requires an Episode budget that can be "
+                "exhausted within max_submissions"
+            )
         if (
             type(self.bulk_feedback_retention_bytes) is not int
             or self.bulk_feedback_retention_bytes <= 0
@@ -208,6 +236,7 @@ def _select_skills(
 __all__ = [
     "AssessmentConfig",
     "ConsoleProgress",
+    "FinishBudgetPolicy",
     "RunConfig",
     "RunEvent",
     "RunObserver",

--- a/src/evopolicygym/run/_records/manifest.py
+++ b/src/evopolicygym/run/_records/manifest.py
@@ -18,7 +18,7 @@ from .._episode_pool import (
 from .._json import encode_public_json_value
 from .writer import write_json_atomic
 
-_RUN_RECORD_SCHEMA = "evopolicygym/run-record/v7"
+_RUN_RECORD_SCHEMA = "evopolicygym/run-record/v8"
 
 
 def write_run_manifest(
@@ -91,6 +91,7 @@ def write_run_manifest(
                 "max_episodes_per_submission": (
                     config.max_episodes_per_submission
                 ),
+                "finish_budget_policy": config.finish_budget_policy,
                 "bulk_feedback_retention_bytes": (
                     config.bulk_feedback_retention_bytes
                 ),

--- a/src/evopolicygym/run/_session/service.py
+++ b/src/evopolicygym/run/_session/service.py
@@ -100,6 +100,24 @@ class SubmissionSession:
         self._config = config
         self._recorder = recorder
         self._episode_pool = episode_pool
+        self._submission_episode_limit = min(
+            SESSION_MAX_EPISODE_INDICES,
+            len(episode_pool),
+            (
+                SESSION_MAX_EPISODE_INDICES
+                if config.max_episodes_per_submission is None
+                else config.max_episodes_per_submission
+            ),
+        )
+        if (
+            config.finish_budget_policy == "require_budget_exhaustion"
+            and config.episode_budget
+            > config.max_submissions * self._submission_episode_limit
+        ):
+            raise ValueError(
+                "finish_budget_policy requires an Episode budget that can be "
+                "exhausted within max_submissions"
+            )
         self._episodes_remaining = config.episode_budget
         self._submissions: list[SubmissionResult] = []
         self._candidate_submission_ids: tuple[str, ...] | None = None
@@ -177,6 +195,22 @@ class SubmissionSession:
             )
         if episodes > self._episodes_remaining:
             return _error("budget_exhausted", "insufficient Episode budget")
+        if self._config.finish_budget_policy == "require_budget_exhaustion":
+            remaining_after = self._episodes_remaining - episodes
+            submission_slots_after = (
+                self._config.max_submissions - len(self._submissions) - 1
+            )
+            future_capacity = (
+                submission_slots_after * self._submission_episode_limit
+            )
+            if remaining_after > future_capacity:
+                minimum_episodes = self._episodes_remaining - future_capacity
+                return _error(
+                    "budget_allocation",
+                    "this submission is too small to exhaust the Episode "
+                    "budget within the remaining submission limit; select at "
+                    f"least {minimum_episodes} Episodes",
+                )
 
         try:
             program = self._programs.capture()
@@ -344,10 +378,33 @@ class SubmissionSession:
                 "finish candidates must be published submissions",
                 candidate_count=len(identifiers),
             )
+        if (
+            self._config.finish_budget_policy
+            == "require_budget_exhaustion"
+            and self._episodes_remaining > 0
+        ):
+            remaining_message = (
+                "1 Episode budget unit remains."
+                if self._episodes_remaining == 1
+                else (
+                    f"{self._episodes_remaining} Episode budget units remain."
+                )
+            )
+            return self._reject_finish(
+                "budget_remaining",
+                f"finish is not available: {remaining_message} "
+                "Continue evaluating or confirming candidate Programs, then "
+                "retry finish.",
+                candidate_count=len(identifiers),
+                episodes_remaining=self._episodes_remaining,
+            )
 
         self._recorder.record_event(
             "finish_requested",
-            {"candidate_count": len(identifiers)},
+            {
+                "candidate_count": len(identifiers),
+                "episodes_remaining": self._episodes_remaining,
+            },
         )
         self._candidate_submission_ids = identifiers
         return FinishReceipt(candidate_submission_ids=identifiers)
@@ -364,10 +421,13 @@ class SubmissionSession:
         message: str,
         *,
         candidate_count: int | None = None,
+        episodes_remaining: int | None = None,
     ) -> SessionError:
         fields: dict[str, object] = {"reason": code}
         if candidate_count is not None:
             fields["candidate_count"] = candidate_count
+        if episodes_remaining is not None:
+            fields["episodes_remaining"] = episodes_remaining
         self._recorder.record_event("finish_rejected", fields)
         return _error(code, message)
 

--- a/src/evopolicygym/run/_task.py
+++ b/src/evopolicygym/run/_task.py
@@ -74,6 +74,23 @@ not returned to this Agent Session. Exceeding the candidate limit, repeating a
 candidate, or naming an unpublished submission rejects the whole finish
 request, so you may correct it and retry.
 """
+    if config.finish_budget_policy == "require_budget_exhaustion":
+        finish_budget_guidance = """\
+This Run requires you to spend the entire Episode budget before finish can
+succeed. A finish request while Episode units remain is rejected with
+budget_remaining and leaves your authority open. Plan submission sizes so the
+budget can reach zero within the submission limit. The Host rejects a
+submission that is too small to preserve that possibility. After a successful
+submission reports zero episodes_remaining, call finish with your selected
+published candidate or candidates.
+
+"""
+    else:
+        finish_budget_guidance = """\
+You may call finish with unused Episode budget when you judge that further
+experimentation is not worthwhile.
+
+"""
     assessment_guidance = ""
     if config.assessment is not None:
         assessment_guidance = """\
@@ -183,6 +200,7 @@ Iterate by inspecting the Program, editing it, submitting it, and using the
 published Feedback.
 
 {finish_guidance}
+{finish_budget_guidance}\
 {assessment_guidance}\
 Unsubmitted workspace edits are never candidates or the final Program. Do not
 exit before calling finish successfully.

--- a/tests/test_codex_integration.py
+++ b/tests/test_codex_integration.py
@@ -127,6 +127,10 @@ class CodexIntegrationTests(unittest.TestCase):
         )
         self.assertIn("remaining Episode budget", invocation.instructions)
         self.assertIn(
+            "You may call finish with unused Episode budget",
+            invocation.instructions,
+        )
+        self.assertIn(
             "content field and all Artifact contents are defined by",
             invocation.instructions,
         )
@@ -136,6 +140,40 @@ class CodexIntegrationTests(unittest.TestCase):
         self.assertEqual(
             invocation.recorded_command[-1],
             "@agent/instructions.md",
+        )
+
+    def test_strict_finish_budget_policy_is_explicit_in_agent_task(self) -> None:
+        task = build_agent_task(
+            BenchmarkSpec(
+                id="example/strict-finish-v1",
+                description="Strict finish fixture.",
+                observation_space=None,
+                action_space=None,
+                metadata={},
+                max_episode_steps=1,
+                primary_metric="reward",
+                score_direction="maximize",
+            ),
+            RunConfig(
+                episode_budget=7,
+                max_submissions=2,
+                finish_budget_policy="require_budget_exhaustion",
+            ),
+        )
+
+        self.assertIn(
+            "requires you to spend the entire Episode budget",
+            task.instructions,
+        )
+        self.assertIn("budget_remaining", task.instructions)
+        self.assertIn("zero episodes_remaining", task.instructions)
+        self.assertIn(
+            "too small to preserve that possibility",
+            task.instructions,
+        )
+        self.assertNotIn(
+            "You may call finish with unused Episode budget",
+            task.instructions,
         )
 
     def test_codex_rejects_invalid_reasoning_effort_identifiers(self) -> None:

--- a/tests/test_public_contract.py
+++ b/tests/test_public_contract.py
@@ -449,6 +449,7 @@ description: Improve counter policies.
         self.assertEqual(run.episode_budget, 20)
         self.assertEqual(run.episode_pool_size, 20)
         self.assertIsNone(run.max_episodes_per_submission)
+        self.assertEqual(run.finish_budget_policy, "allow_early")
         self.assertEqual(
             run.bulk_feedback_retention_bytes,
             1024 * 1024 * 1024,
@@ -457,6 +458,7 @@ description: Improve counter policies.
             episode_budget=20,
             episode_pool_size=12,
             max_episodes_per_submission=5,
+            finish_budget_policy="require_budget_exhaustion",
             validation=ValidationConfig(
                 episodes_per_candidate=7,
                 max_candidates=2,
@@ -467,6 +469,10 @@ description: Improve counter policies.
         )
         self.assertEqual(capped.max_episodes_per_submission, 5)
         self.assertEqual(capped.episode_pool_size, 12)
+        self.assertEqual(
+            capped.finish_budget_policy,
+            "require_budget_exhaustion",
+        )
         self.assertEqual(
             capped.validation,
             ValidationConfig(
@@ -490,6 +496,18 @@ description: Improve counter policies.
             RunConfig(episode_pool_size=0)
         with self.assertRaises(ValueError):
             RunConfig(bulk_feedback_retention_bytes=0)
+        with self.assertRaises(ValueError):
+            RunConfig(finish_budget_policy="invalid")  # type: ignore[arg-type]
+        with self.assertRaisesRegex(
+            ValueError,
+            "can be exhausted within max_submissions",
+        ):
+            RunConfig(
+                max_submissions=2,
+                episode_budget=5,
+                episode_pool_size=2,
+                finish_budget_policy="require_budget_exhaustion",
+            )
         with self.assertRaises(ValueError):
             RunConfig(
                 episode_budget=10,
@@ -1081,6 +1099,24 @@ assert feedback["content"] == {{"status": "complete", "completed": 0}}
 assert not (workspace / "events.jsonl").exists()
 assert not (workspace / "agent").exists()
 
+early_finish = subprocess.run(
+    [
+        sys.executable,
+        "-m",
+        "evopolicygym.run._session.cli",
+        "finish",
+        first["result"]["submission_id"],
+    ],
+    check=False,
+    capture_output=True,
+    text=True,
+)
+assert early_finish.returncode == 1
+early_error = json.loads(early_finish.stderr)
+assert early_error["error"]["code"] == "budget_remaining"
+assert "1 Episode budget unit remains" in early_error["error"]["message"]
+assert not early_finish.stdout
+
 (workspace / "program" / "policy.py").write_text(
     {improved_source!r},
     encoding="utf-8",
@@ -1138,6 +1174,7 @@ print("fake-agent-finished")
                 config=RunConfig(
                     max_submissions=2,
                     episode_budget=2,
+                    finish_budget_policy="require_budget_exhaustion",
                     validation=ValidationConfig(
                         episodes_per_candidate=2,
                         max_candidates=2,
@@ -1226,6 +1263,10 @@ print("fake-agent-finished")
             2,
         )
         self.assertEqual(
+            [event["event"] for event in events].count("finish_rejected"),
+            1,
+        )
+        self.assertEqual(
             [event["event"] for event in events].count("episode_completed"),
             2,
         )
@@ -1239,8 +1280,12 @@ print("fake-agent-finished")
             [event.name for event in observer.events],
             [event["event"] for event in events],
         )
-        self.assertEqual(manifest["schema"], "evopolicygym/run-record/v7")
+        self.assertEqual(manifest["schema"], "evopolicygym/run-record/v8")
         self.assertEqual(manifest["config"]["episode_pool_size"], 2)
+        self.assertEqual(
+            manifest["config"]["finish_budget_policy"],
+            "require_budget_exhaustion",
+        )
         self.assertEqual(
             manifest["config"]["bulk_feedback_retention_bytes"],
             1024 * 1024 * 1024,

--- a/tests/test_submission_session.py
+++ b/tests/test_submission_session.py
@@ -22,7 +22,11 @@ from evopolicygym.results import (
     RunResult,
     SubmissionResult,
 )
-from evopolicygym.run import RunConfig, ValidationConfig
+from evopolicygym.run import (
+    FinishBudgetPolicy,
+    RunConfig,
+    ValidationConfig,
+)
 from evopolicygym.run._session.outcomes import (
     FinishReceipt,
     SessionError,
@@ -312,6 +316,102 @@ class SubmissionSessionTests(unittest.TestCase):
             ],
         )
 
+    def test_finish_can_require_the_entire_episode_budget(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            program = make_program(Path(temporary))
+            recorder = FakeRecorder()
+            session = self._session(
+                FakeProgramSource(program),
+                FakeEvaluator(),
+                FakePublisher(),
+                recorder=recorder,
+                episode_budget=3,
+                finish_budget_policy="require_budget_exhaustion",
+            )
+
+            first = session.submit([0])
+            assert isinstance(first, SubmissionReceipt)
+            rejected = session.finish([first.submission_id])
+            second = session.submit([0, 1])
+            assert isinstance(second, SubmissionReceipt)
+            accepted = session.finish([first.submission_id])
+
+        self.assertIsInstance(rejected, SessionError)
+        assert isinstance(rejected, SessionError)
+        self.assertEqual(rejected.code, "budget_remaining")
+        self.assertEqual(
+            rejected.message,
+            "finish is not available: 2 Episode budget units remain. "
+            "Continue evaluating or confirming candidate Programs, then "
+            "retry finish.",
+        )
+        self.assertEqual(second.episodes_remaining, 0)
+        self.assertIsInstance(accepted, FinishReceipt)
+        self.assertEqual(
+            session.candidate_submission_ids,
+            (first.submission_id,),
+        )
+        rejected_event = next(
+            fields
+            for name, fields in recorder.events
+            if name == "finish_rejected"
+        )
+        self.assertEqual(
+            rejected_event,
+            {
+                "reason": "budget_remaining",
+                "candidate_count": 1,
+                "episodes_remaining": 2,
+            },
+        )
+
+    def test_required_budget_rejects_an_allocation_that_would_dead_end(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            program = make_program(Path(temporary))
+            session = self._session(
+                FakeProgramSource(program),
+                FakeEvaluator(),
+                FakePublisher(),
+                episode_budget=5,
+                max_submissions=2,
+                max_episodes_per_submission=3,
+                finish_budget_policy="require_budget_exhaustion",
+            )
+
+            rejected = session.submit([0])
+            first = session.submit([0, 1])
+            second = session.submit([0, 1, 2])
+
+        self.assertIsInstance(rejected, SessionError)
+        assert isinstance(rejected, SessionError)
+        self.assertEqual(rejected.code, "budget_allocation")
+        self.assertIn("select at least 2 Episodes", rejected.message)
+        self.assertIsInstance(first, SubmissionReceipt)
+        self.assertIsInstance(second, SubmissionReceipt)
+        assert isinstance(second, SubmissionReceipt)
+        self.assertEqual(second.episodes_remaining, 0)
+
+    def test_required_budget_rejects_an_impossible_session_capacity(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            program = make_program(Path(temporary))
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "can be exhausted within max_submissions",
+            ):
+                self._session(
+                    FakeProgramSource(program),
+                    FakeEvaluator(),
+                    FakePublisher(),
+                    episode_budget=2_049,
+                    max_submissions=1,
+                    finish_budget_policy="require_budget_exhaustion",
+                )
+
     def test_mismatched_environment_identity_is_not_published(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             program = make_program(Path(temporary))
@@ -511,13 +611,17 @@ class SubmissionSessionTests(unittest.TestCase):
         *,
         recorder: FakeRecorder | None = None,
         episode_budget: int = 5,
+        max_submissions: int = 20,
         max_episodes_per_submission: int | None = None,
+        finish_budget_policy: FinishBudgetPolicy = "allow_early",
         validation: ValidationConfig | None = None,
     ) -> SubmissionSession:
         benchmark = StubBenchmark()
         config = RunConfig(
             episode_budget=episode_budget,
+            max_submissions=max_submissions,
             max_episodes_per_submission=max_episodes_per_submission,
+            finish_budget_policy=finish_budget_policy,
             validation=validation,
         )
         pool_size = config.episode_pool_size


### PR DESCRIPTION
## What changed

- add RunConfig.finish_budget_policy with allow_early and require_budget_exhaustion
- reject early finish atomically while Episode budget remains
- preserve strict-budget reachability across the remaining Submission limit
- retain the policy in run-record/v8
- update Agent instructions, README, architecture documentation, and the EvoPolicyGym Agent Skill

## Why

Formal and leaderboard Runs need an optional mode where every Coding Agent spends the same Host-managed Episode budget before handing candidates to Validation and Assessment. Development Runs retain the existing early-finish behavior by default.

## Impact

Strict Runs now reject premature finish calls with budget_remaining and reject Submission allocations that would make full budget use impossible. Rejections leave Agent authority and candidate state unchanged.

## Validation

- uv run python -m unittest discover -s tests — 126 tests passed
- uv run ruff check src tests
- uv run mypy
- uv build
