### PR TITLE
agents: add Qoder CLI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,8 @@ evopolicygym/
 │   ├── base.py                 Agent contract and shared command helpers
 │   ├── claude_code.py          Claude Code selection and CLI translation
 │   ├── codex.py                Codex selection and CLI translation
-│   └── kimi_code.py            Kimi Code selection and CLI translation
+│   ├── kimi_code.py            Kimi Code selection and CLI translation
+│   └── qoder.py                Qoder selection and CLI translation
 │
 ├── evaluation/                 complete direct-Evaluation use case
 │   ├── __init__.py             EvaluationConfig and evaluate()
@@ -238,7 +239,7 @@ The rules are:
 - `evaluation/_service.py` reports only sanitized Episode completion through a
   narrow callback and performs no terminal or file I/O;
 - `execution/process` owns only generic process mechanisms and never imports a
-  Codex, Claude Code, Kimi Code, or other provider integration;
+  Codex, Claude Code, Kimi Code, Qoder, or other provider integration;
 - `agents.base.CodingAgent` is the supported structural integration template:
   the Host supplies an `AgentTask`, and the provider returns a validated
   `AgentInvocation`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added a first-party Qoder CLI integration with explicit model selection,
+  optional reasoning effort, headless stream output, retained identity, and
+  caller-controlled authentication and configuration environment variables.
 - Added Crafter and Linux-targeted NLE NetHack Benchmark distributions,
   complete reversible training trajectories, and the NLE held-out experiment
   reference page.

--- a/README.md
+++ b/README.md
@@ -180,21 +180,24 @@ one.
 ## Run a coding agent
 
 First-party command-line integrations are available for Codex, Claude Code,
-and Kimi Code:
+Kimi Code, and Qoder:
 
 ```python
-from evopolicygym.agents import ClaudeCode, Codex, KimiCode
+from evopolicygym.agents import ClaudeCode, Codex, KimiCode, Qoder
 
 codex = Codex(model="gpt-5.6-luna", reasoning_effort="high")
 claude = ClaudeCode(model="sonnet", effort="high")
 kimi = KimiCode(model="kimi-code/kimi-for-coding")
+qoder = Qoder(model="performance", reasoning_effort="high")
 ```
 
 Each selection translates the same Host-owned task into a non-interactive CLI
 invocation; the Run protocol and process supervision remain provider-neutral.
-Authenticate the selected CLI before starting a Run. For Kimi Code, set
-`KIMI_CODE_HOME` to a caller-owned isolated directory when retained CLI
-configuration and session history must not share state with other Runs.
+Authenticate the selected CLI before starting a Run. Qoder automation may use
+`QODER_PERSONAL_ACCESS_TOKEN`. For Kimi Code and Qoder, respectively set
+`KIMI_CODE_HOME` or `QODER_CONFIG_DIR` to a caller-owned isolated directory
+when retained CLI configuration and session history must not share state with
+other Runs.
 
 After authenticating the Codex CLI, start a small budgeted CartPole Run:
 

--- a/skills/evopolicygym/references/providers.md
+++ b/skills/evopolicygym/references/providers.md
@@ -3,12 +3,12 @@
 Integrate another command-line Coding Agent through the public structural
 `CodingAgent` contract.
 
-The Kernel includes first-party `Codex`, `ClaudeCode`, and `KimiCode`
+The Kernel includes first-party `Codex`, `ClaudeCode`, `KimiCode`, and `Qoder`
 translations. They all retain the unchanged Host task and use the same generic
 process runner. `ClaudeCode` selects bare, non-persistent print mode. Kimi Code
-does not currently expose an equivalent no-session-persistence flag, so callers
-that require isolated CLI configuration and session history should set a
-dedicated `KIMI_CODE_HOME` before the Run.
+and Qoder do not currently expose an equivalent no-session-persistence flag,
+so callers that require isolated CLI configuration and session history should
+set a dedicated `KIMI_CODE_HOME` or `QODER_CONFIG_DIR` before the Run.
 
 Translate the Host-owned `AgentTask` into an `AgentInvocation`. Do not author
 Run instructions, duplicate Agent Session syntax, or move process supervision

--- a/src/evopolicygym/agents/__init__.py
+++ b/src/evopolicygym/agents/__init__.py
@@ -14,6 +14,7 @@ from .base import (
 from .claude_code import ClaudeCode
 from .codex import Codex
 from .kimi_code import KimiCode
+from .qoder import Qoder
 
 __all__ = [
     "AgentInvocation",
@@ -22,6 +23,7 @@ __all__ = [
     "ClaudeCode",
     "Codex",
     "KimiCode",
+    "Qoder",
     "command_invocation",
     "resolve_executable",
 ]

--- a/src/evopolicygym/agents/qoder.py
+++ b/src/evopolicygym/agents/qoder.py
@@ -1,0 +1,109 @@
+"""Public caller-owned Qoder Agent selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import AgentInvocation, AgentTask, resolve_executable
+
+_QODER_ENVIRONMENT_ALLOWLIST = (
+    "HOME",
+    "QODER_CONFIG_DIR",
+    "QODER_PERSONAL_ACCESS_TOKEN",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Qoder:
+    """Select the Qoder model, optional reasoning effort, and CLI used by a Run."""
+
+    model: str
+    reasoning_effort: str | None = None
+    executable: str = "qodercli"
+
+    def __post_init__(self) -> None:
+        _validate_identifier(self.model, name="model", max_bytes=128)
+        if self.reasoning_effort is not None:
+            _validate_identifier(
+                self.reasoning_effort,
+                name="reasoning_effort",
+                max_bytes=64,
+            )
+        _validate_executable(self.executable)
+
+    def build_invocation(self, task: AgentTask) -> AgentInvocation:
+        """Translate one Host-authored task into a Qoder CLI invocation."""
+
+        if type(task) is not AgentTask:
+            raise TypeError("task must be AgentTask")
+        resolved_executable = resolve_executable(self.executable)
+        command_prefix = (
+            resolved_executable,
+            "--print",
+            "--output-format",
+            "stream-json",
+            "--model",
+            self.model,
+            *(
+                ("--reasoning-effort", self.reasoning_effort)
+                if self.reasoning_effort is not None
+                else ()
+            ),
+            "--permission-mode",
+            "bypass_permissions",
+        )
+        identity = {
+            "provider": "qoder",
+            "model": self.model,
+            **(
+                {"reasoning_effort": self.reasoning_effort}
+                if self.reasoning_effort is not None
+                else {}
+            ),
+        }
+        return AgentInvocation(
+            command=(*command_prefix, task.instructions),
+            recorded_command=(*command_prefix, "@agent/instructions.md"),
+            identity=identity,
+            instructions=task.instructions,
+            inherited_environment=_QODER_ENVIRONMENT_ALLOWLIST,
+            stdout_media_type="application/x-ndjson",
+        )
+
+
+def _validate_identifier(value: str, *, name: str, max_bytes: int) -> None:
+    if (
+        type(value) is not str
+        or not value
+        or len(value.encode("utf-8", errors="strict")) > max_bytes
+        or any(character.isspace() for character in value)
+        or "\0" in value
+    ):
+        raise ValueError(f"{name} must be a non-empty bounded identifier")
+
+
+def _validate_executable(value: str) -> None:
+    if (
+        type(value) is not str
+        or not value
+        or len(value.encode("utf-8", errors="strict")) > 4_096
+        or "\0" in value
+        or "\r" in value
+        or "\n" in value
+    ):
+        raise ValueError("executable must be a bounded command or path")
+
+
+__all__ = ["Qoder"]

--- a/tests/test_cli_agent_integrations.py
+++ b/tests/test_cli_agent_integrations.py
@@ -9,6 +9,7 @@ from evopolicygym.agents import (
     ClaudeCode,
     CodingAgent,
     KimiCode,
+    Qoder,
 )
 from evopolicygym.authoring import BenchmarkSpec
 from evopolicygym.run import RunConfig
@@ -144,6 +145,75 @@ class KimiCodeIntegrationTests(unittest.TestCase):
                     KimiCode(model=invalid)
         with self.assertRaisesRegex(TypeError, "task must be AgentTask"):
             KimiCode(model="kimi-code/kimi-for-coding").build_invocation(
+                object()  # type: ignore[arg-type]
+            )
+
+
+class QoderIntegrationTests(unittest.TestCase):
+    def test_selection_becomes_a_headless_stream_invocation(self) -> None:
+        task = _task()
+        with tempfile.TemporaryDirectory() as temporary:
+            executable = _executable(temporary, "qodercli")
+            invocation = Qoder(
+                model="performance",
+                reasoning_effort="high",
+                executable=str(executable),
+            ).build_invocation(task)
+
+        self.assertIsInstance(Qoder(model="auto"), CodingAgent)
+        self.assertEqual(invocation.instructions, task.instructions)
+        self.assertEqual(invocation.identity["provider"], "qoder")
+        self.assertEqual(invocation.identity["model"], "performance")
+        self.assertEqual(invocation.identity["reasoning_effort"], "high")
+        self.assertEqual(invocation.stdout_media_type, "application/x-ndjson")
+        self.assertIn("--print", invocation.command)
+        self.assertEqual(
+            invocation.command[
+                invocation.command.index("--output-format") + 1
+            ],
+            "stream-json",
+        )
+        self.assertEqual(
+            invocation.command[
+                invocation.command.index("--permission-mode") + 1
+            ],
+            "bypass_permissions",
+        )
+        self.assertEqual(invocation.command[-1], task.instructions)
+        self.assertEqual(
+            invocation.recorded_command[-1],
+            "@agent/instructions.md",
+        )
+        self.assertNotIn(task.instructions, invocation.recorded_command)
+        self.assertIn(
+            "QODER_PERSONAL_ACCESS_TOKEN",
+            invocation.inherited_environment,
+        )
+        self.assertIn("QODER_CONFIG_DIR", invocation.inherited_environment)
+
+    def test_optional_reasoning_effort_is_omitted(self) -> None:
+        task = _task()
+        with tempfile.TemporaryDirectory() as temporary:
+            executable = _executable(temporary, "qodercli")
+            invocation = Qoder(
+                model="auto",
+                executable=str(executable),
+            ).build_invocation(task)
+
+        self.assertNotIn("--reasoning-effort", invocation.command)
+        self.assertNotIn("reasoning_effort", invocation.identity)
+
+    def test_rejects_invalid_selections_and_tasks(self) -> None:
+        for invalid in ("", "two models", "model\n", "x" * 129):
+            with self.subTest(model=invalid):
+                with self.assertRaisesRegex(ValueError, "model"):
+                    Qoder(model=invalid)
+        for invalid in ("", "extra high", "high\n", "x" * 65):
+            with self.subTest(reasoning_effort=invalid):
+                with self.assertRaisesRegex(ValueError, "reasoning_effort"):
+                    Qoder(model="auto", reasoning_effort=invalid)
+        with self.assertRaisesRegex(TypeError, "task must be AgentTask"):
+            Qoder(model="auto").build_invocation(
                 object()  # type: ignore[arg-type]
             )
 

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -90,6 +90,7 @@ import sys
 from evopolicygym.agents.claude_code import ClaudeCode
 from evopolicygym.agents.codex import Codex
 from evopolicygym.agents.kimi_code import KimiCode
+from evopolicygym.agents.qoder import Qoder
 from evopolicygym.evaluation import EvaluationConfig
 from evopolicygym.execution import ProcessExecution
 from evopolicygym.run import (
@@ -112,6 +113,7 @@ assert RunObserver.__module__ == "evopolicygym.run.progress"
 assert ClaudeCode.__module__ == "evopolicygym.agents.claude_code"
 assert Codex.__module__ == "evopolicygym.agents.codex"
 assert KimiCode.__module__ == "evopolicygym.agents.kimi_code"
+assert Qoder.__module__ == "evopolicygym.agents.qoder"
 assert AgentSkill.__module__ == "evopolicygym.skills"
 assert ProcessExecution.__module__ == "evopolicygym.execution"
 


### PR DESCRIPTION
## Summary

- add a first-party `Qoder` Coding Agent provider
- translate Host-owned tasks into headless `stream-json` Qoder CLI invocations
- retain model and optional reasoning effort while keeping prompts out of the recorded command
- allow only Qoder authentication/configuration and standard process environment variables
- document the provider and cover public exports, architecture, validation, and invocation behavior

## Why

Qoder CLI exposes the non-interactive, model-selection, reasoning-effort, and permission controls required by EvoPolicyGym's provider-neutral `CodingAgent` contract. This keeps process execution generic and retains provider-specific experiment identity at the provider boundary.

## Validation

- `uv run python -m unittest discover -s tests` — 130 tests passed
- `uv run ruff check src/evopolicygym/agents tests/test_cli_agent_integrations.py tests/test_package_architecture.py`
- `uv run mypy`
- `git diff --check`

## Limitation

The local machine did not have `qodercli` installed, so validation covers deterministic invocation translation rather than an authenticated live CLI smoke test.
